### PR TITLE
Codex/implementar agente de verificação de conflitos de merge

### DIFF
--- a/tests/test_tickets_groups.py
+++ b/tests/test_tickets_groups.py
@@ -4,6 +4,8 @@ import datetime as dt
 import pytest
 
 from src.etl import tickets_groups
+from src.glpi_dashboard.services import glpi_session
+from src.glpi_dashboard.services.worker_api import Credentials  # Adjust import as needed
 
 
 def setup_env() -> None:
@@ -64,7 +66,16 @@ async def test_collect_basic(requests_mock):
                 ]
             }
 
-    session = FakeSession()
+    credentials = Credentials(
+        app_token="dummy_app_token",
+        username="test",
+        password="test"
+    )
+
+    session = glpi_session.GLPISession(
+        base_url="http://example.com/apirest.php",
+        credentials=credentials
+    )
     df = await tickets_groups.collect_tickets_with_groups(
         "2024-01-01", "2024-01-02", client=session
     )

--- a/worker_api.py
+++ b/worker_api.py
@@ -1,11 +1,11 @@
 """Convenience wrapper for the worker API entrypoint."""
 
-from glpi_dashboard.services.worker_api import (
+from src.glpi_dashboard.services.worker_api import (
     create_app,
     main as _main,
     redis_client,
 )
-from glpi_dashboard.services.worker_api import GLPISession
+from src.glpi_dashboard.services.worker_api import GLPISession
 
 __all__ = ["create_app", "redis_client", "GLPISession", "main"]
 


### PR DESCRIPTION
## Summary by Sourcery

Switch tickets_groups tests to use a real GLPISession with Credentials and correct worker_api import paths

Tests:
- replace FakeSession with GLPISession instantiated with dummy Credentials in tickets_groups tests

Chores:
- update worker_api wrapper imports to reference src.glpi_dashboard.services.worker_api