### PR TITLE
Fix criteria initialization in tickets_client

### DIFF
--- a/src/api/tickets_client.ts
+++ b/src/api/tickets_client.ts
@@ -104,8 +104,7 @@ axiosInstance.interceptors.response.use(
     const RETRY_DELAY_MS = 1000; // Base delay for exponential back-off
 
     if (response && response.status === 429) { // [15, 16]
-      originalRequest!._retryCount = originalRequest!._retryCount |
-| 0;
+      originalRequest!._retryCount = originalRequest!._retryCount || 0;
 
       if (originalRequest!._retryCount < MAX_RETRIES) {
         originalRequest!._retryCount += 1;
@@ -210,7 +209,7 @@ export async function killGLPISession(): Promise<void> {
  * @returns An array of criterion objects for the GLPI API.
  */
 function buildCriteria(filter: TicketFilter): any {
-  const criteria: any =;
+  const criteria: any[] = [];
   let criterionIndex = 0;
 
   if (filter.status && filter.status.length > 0) {


### PR DESCRIPTION
## Summary
- clean up `_retryCount` assignment for rate limit retries
- initialize `criteria` as array in `buildCriteria`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686438387ec48320b0655bb7362c92d2

## Summary by Sourcery

Fix the initialization of retry count in the rate-limit interceptor and ensure `criteria` starts as an empty array in the tickets client.

Bug Fixes:
- Default `_retryCount` is now set using logical OR instead of bitwise OR to ensure proper initialization before rate-limit retries.
- `buildCriteria` now initializes `criteria` as an empty array to prevent undefined assignment errors.