### PR TITLE
Add React Query hook with devtools

### DIFF
--- a/src/frontend/react_app/src/App.tsx
+++ b/src/frontend/react_app/src/App.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import Header from './components/Header';
 import { ChamadosTendencia } from './components/ChamadosTendencia';
+// Devtools para monitorar queries e mutations
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 
 export default function App() {
   return (
@@ -10,6 +12,7 @@ export default function App() {
         <h1 className="text-2xl font-bold mb-4">GLPI Dashboard</h1>
         <ChamadosTendencia />
       </main>
+      <ReactQueryDevtools initialIsOpen={false} />
     </div>
   )
 }

--- a/src/frontend/react_app/src/components/ChamadosTendencia.tsx
+++ b/src/frontend/react_app/src/components/ChamadosTendencia.tsx
@@ -4,16 +4,18 @@ import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer, CartesianG
 
 
 function ChamadosTendenciaComponent() {
-  const { dados, isLoading, error } = useChamadosPorData()
+  // Exibe estado da query e mensagens de carregamento/erro
+  const { data, isLoading, isError, status } = useChamadosPorData()
 
-  if (isLoading) return <div>Carregando tendência...</div>
-  if (error) return <div>Erro ao carregar dados de tendência</div>
+  if (isLoading) return <p>Carregando chamados...</p>
+  if (isError) return <p>Erro ao carregar chamados.</p>
 
   return (
     <div className="bg-white dark:bg-gray-800 p-4 rounded shadow w-full">
+      <p>Status da query: {status}</p>
       <h2 className="text-xl font-semibold mb-2">Chamados por Dia</h2>
       <ResponsiveContainer width="100%" height={300}>
-        <LineChart data={dados} margin={{ top: 20, right: 30, left: 0, bottom: 0 }}>
+        <LineChart data={data ?? []} margin={{ top: 20, right: 30, left: 0, bottom: 0 }}>
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis dataKey="date" tick={{ fontSize: 12 }} />
           <YAxis />

--- a/src/frontend/react_app/src/hooks/useChamadosPorData.ts
+++ b/src/frontend/react_app/src/hooks/useChamadosPorData.ts
@@ -1,25 +1,16 @@
-import { useApiQuery } from '@/hooks/useApiQuery'
-import type { ChamadoPorData } from '../types/chamado'
+// Hook para buscar chamados agrupados por data usando React Query v5
+// Deve usar staleTime para evitar refetching desnecessário
+// Deve ativar refetch automático ao focar a janela
+// Pode incluir refetchInterval para polling se necessário
+
+import { useQuery } from '@tanstack/react-query'
+import { fetchChamadosPorData } from '../services/api'
 
 export function useChamadosPorData() {
-  const query = useApiQuery<ChamadoPorData[], Error>(
-    ['chamados-por-data'],
-    '/chamados/por-data',
-    {
-      select: (data: ChamadoPorData[]) =>
-        data.map((d) => ({ date: d.date, total: Number(d.total) })),
-      refetchInterval: 60000,
-    },
-  )
-
-  return {
-    dados: query.data ?? [],
-    // Se você não tiver um tipo ApiError:
-    error: query.error
-      ? (query.error as any).status === 503  // Use 'any' temporariamente
-        ? new Error('Serviço temporariamente indisponível. Tente novamente mais tarde.')
-        : (query.error as Error)
-      : null,
-    isLoading: query.isLoading,
-  }
+  return useQuery(['chamados-por-data'], fetchChamadosPorData, {
+    staleTime: 1000 * 60 * 5, // 5 minutos
+    cacheTime: 1000 * 60 * 10, // 10 minutos
+    refetchOnWindowFocus: true,
+    // refetchInterval: 30000, // descomente para polling a cada 30s
+  })
 }

--- a/src/frontend/react_app/src/services/api.ts
+++ b/src/frontend/react_app/src/services/api.ts
@@ -1,0 +1,6 @@
+import { fetcher } from '../lib/swrClient'
+import type { ChamadoPorData } from '../types/chamado'
+
+export async function fetchChamadosPorData(): Promise<ChamadoPorData[]> {
+  return fetcher<ChamadoPorData[]>('/chamados/por-data')
+}

--- a/src/frontend/react_app/tests/components/ChamadosCharts.test.tsx
+++ b/src/frontend/react_app/tests/components/ChamadosCharts.test.tsx
@@ -15,15 +15,25 @@ beforeEach(() => {
 })
 
 test('ChamadosTendencia loading', () => {
-  mockedData.useChamadosPorData.mockReturnValue({ dados: [], isLoading: true, error: null })
+  mockedData.useChamadosPorData.mockReturnValue({
+    data: [],
+    isLoading: true,
+    isError: false,
+    status: 'loading',
+  } as any)
   render(<ChamadosTendencia />)
-  expect(screen.getByText('Carregando tendência...')).toBeInTheDocument()
+  expect(screen.getByText('Carregando chamados...')).toBeInTheDocument()
 })
 
 test('ChamadosTendencia error', () => {
-  mockedData.useChamadosPorData.mockReturnValue({ dados: [], isLoading: false, error: new Error('x') })
+  mockedData.useChamadosPorData.mockReturnValue({
+    data: [],
+    isLoading: false,
+    isError: true,
+    status: 'error',
+  } as any)
   render(<ChamadosTendencia />)
-  expect(screen.getByText('Erro ao carregar dados de tendência')).toBeInTheDocument()
+  expect(screen.getByText('Erro ao carregar chamados.')).toBeInTheDocument()
 })
 
 test('ChamadosHeatmap success', () => {

--- a/src/frontend/react_app/tests/hooks/useChamados.test.tsx
+++ b/src/frontend/react_app/tests/hooks/useChamados.test.tsx
@@ -21,7 +21,7 @@ test('useChamadosPorData parses numbers', async () => {
   const { result } = renderHook(() => useChamadosPorData(), { wrapper })
   expect(result.current.isLoading).toBe(true)
   await waitFor(() => expect(result.current.isLoading).toBe(false))
-  expect(result.current.dados).toEqual([{ date: '2024-01-01', total: 2 }])
+  expect(result.current.data).toEqual([{ date: '2024-01-01', total: 2 }])
 })
 
 test('useChamadosPorData handles error', async () => {
@@ -31,7 +31,7 @@ test('useChamadosPorData handles error', async () => {
   }) as jest.Mock
 
   const { result } = renderHook(() => useChamadosPorData(), { wrapper })
-  await waitFor(() => expect(result.current.error).toBeTruthy())
+  await waitFor(() => expect(result.current.isError).toBe(true))
 })
 
 test('useChamadosPorDia handles error', async () => {

--- a/src/frontend/react_app/tests/profile.spec.tsx
+++ b/src/frontend/react_app/tests/profile.spec.tsx
@@ -15,7 +15,12 @@ jest.mock('../src/hooks/useDashboardData', () => ({
 }))
 
 jest.mock('../src/hooks/useChamadosPorData', () => ({
-  useChamadosPorData: () => ({ dados: [], isLoading: false, error: null }),
+  useChamadosPorData: () => ({
+    data: [],
+    isLoading: false,
+    isError: false,
+    status: 'success',
+  }),
 }))
 
 jest.mock('../src/hooks/useChamadosPorDia', () => ({


### PR DESCRIPTION
## Summary
- create `fetchChamadosPorData` service
- implement `useChamadosPorData` hook with caching hints
- show query status in `ChamadosTendencia`
- expose React Query Devtools in `App`
- update unit tests for new hook API

## Testing
- `pre-commit run --files src/frontend/react_app/src/App.tsx src/frontend/react_app/src/components/ChamadosTendencia.tsx src/frontend/react_app/src/hooks/useChamadosPorData.ts src/frontend/react_app/src/services/api.ts src/frontend/react_app/tests/components/ChamadosCharts.test.tsx src/frontend/react_app/tests/hooks/useChamados.test.tsx src/frontend/react_app/tests/profile.spec.tsx`
- `npm test -- -t Chamados` *(fails: Jest encountered unexpected token)*
- `pytest -k nothing` *(fails: ImportError: No module named 'aiohttp')*

------
https://chatgpt.com/codex/tasks/task_e_687b71e5f9488320bcc38c02ca1b946d