### PR TITLE
Add grouped status metrics

### DIFF
--- a/src/backend/api/worker_api.py
+++ b/src/backend/api/worker_api.py
@@ -192,6 +192,14 @@ def create_app(client: Optional[GlpiApiClient] = None, cache=None) -> FastAPI:
             raise HTTPException(status_code=503, detail="metrics not available")
         return metrics
 
+    @app.get("/metrics/levels")
+    async def metrics_levels() -> Dict[str, Dict[str, int]]:  # noqa: F401
+        """Return status counts grouped by ticket level (group)."""
+        data = await cache.get("metrics_levels")
+        if data is None:
+            raise HTTPException(status_code=503, detail="metrics not available")
+        return cast(Dict[str, Dict[str, int]], data)
+
     @app.get(
         "/chamados/por-data",
         response_model=List[ChamadoPorData],

--- a/src/backend/application/metrics_worker.py
+++ b/src/backend/application/metrics_worker.py
@@ -10,6 +10,7 @@ from arq.connections import RedisSettings
 from backend.application.aggregated_metrics import (
     cache_aggregated_metrics,
     compute_aggregated,
+    status_by_group,
     tickets_by_date,
     tickets_daily_totals,
 )
@@ -48,6 +49,7 @@ async def update_metrics(ctx: Dict[str, Any], ticket: Dict[str, Any]) -> None:
     df = process_raw(tickets)
     metrics = compute_aggregated(df)
     await cache_aggregated_metrics(cache, "metrics_aggregated", metrics)
+    await cache.set("metrics_levels", status_by_group(df))
     await cache.set(
         "chamados_por_data", tickets_by_date(df).to_dict(orient="records")
     )  # Key for /chamados/por-data

--- a/src/backend/application/ticket_loader.py
+++ b/src/backend/application/ticket_loader.py
@@ -13,6 +13,7 @@ from backend.adapters.factory import create_glpi_session
 from backend.application.aggregated_metrics import (
     cache_aggregated_metrics,
     compute_aggregated,
+    status_by_group,
     tickets_by_date,
     tickets_daily_totals,
 )
@@ -42,6 +43,7 @@ async def _process_and_cache_df(
 
     metrics = compute_aggregated(df)
     await cache_aggregated_metrics(cache, "metrics_aggregated", metrics)
+    await cache.set("metrics_levels", status_by_group(df))
     await cache.set("chamados_por_data", tickets_by_date(df).to_dict(orient="records"))
     await cache.set(
         "chamados_por_dia", tickets_daily_totals(df).to_dict(orient="records")

--- a/tests/test_aggregated_metrics.py
+++ b/tests/test_aggregated_metrics.py
@@ -7,6 +7,7 @@ from backend.application import aggregated_metrics
 from backend.application.aggregated_metrics import (
     cache_aggregated_metrics,
     get_cached_aggregated,
+    status_by_group,
     tickets_by_date,
     tickets_daily_totals,
 )
@@ -63,3 +64,20 @@ async def test_cache_helpers(monkeypatch: pytest.MonkeyPatch):
     result = await get_cached_aggregated(None, "k")
     fake.get.assert_awaited_once_with("k")
     assert result == data
+
+
+def test_status_by_group_counts():
+    df = pd.DataFrame(
+        [
+            {"group": "N1", "status": "new"},
+            {"group": "N1", "status": "pending"},
+            {"group": "N1", "status": "pending"},
+            {"group": "N2", "status": "solved"},
+        ]
+    )
+
+    result = status_by_group(df)
+    assert result == {
+        "N1": {"new": 1, "pending": 2, "solved": 0},
+        "N2": {"new": 0, "pending": 0, "solved": 1},
+    }


### PR DESCRIPTION
## Summary
- compute status counts by group
- store and expose `/metrics/levels`
- test new helper

## Testing
- `pytest tests/test_aggregated_metrics.py tests/test_worker_api.py -q` *(fails: ModuleNotFoundError: No module named 'asyncpg')*

------
https://chatgpt.com/codex/tasks/task_e_687b965f3af083208de729a6f28e8539