### PR TITLE
Refactor hook return type

### DIFF
--- a/src/frontend/react_app/jest.config.ts
+++ b/src/frontend/react_app/jest.config.ts
@@ -3,8 +3,12 @@ import type { Config } from 'jest'
 const config: Config = {
   testEnvironment: 'jsdom',
   transform: {
-    '^.+\\.(ts|tsx)$': ['ts-jest', { tsconfig: 'tsconfig.test.json' }],
+    '^.+\\.(ts|tsx)$': [
+      'ts-jest',
+      { tsconfig: 'tsconfig.test.json', useESM: true },
+    ],
   },
+  extensionsToTreatAsEsm: ['.ts', '.tsx'],
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
   testMatch: ['<rootDir>/src/**/*.test.ts?(x)'],
   moduleFileExtensions: ['ts', 'tsx', 'js'],

--- a/src/frontend/react_app/src/components/ChamadosHeatmap.tsx
+++ b/src/frontend/react_app/src/components/ChamadosHeatmap.tsx
@@ -10,14 +10,14 @@ interface HeatmapValue {
 }
 
 function ChamadosHeatmapComponent() {
-  const { dados, isLoading, error } = useChamadosPorDia()
+  const { data, isLoading, error } = useChamadosPorDia()
   const values = useMemo(
     () =>
-      dados.map((item: ChamadoPorDia) => ({
+      data.map((item: ChamadoPorDia) => ({
         date: item.date,
         count: item.total,
       })),
-    [dados],
+    [data],
   )
 
   const { startDate, endDate } = useMemo(() => {

--- a/src/frontend/react_app/src/components/TicketsDisplay.test.tsx
+++ b/src/frontend/react_app/src/components/TicketsDisplay.test.tsx
@@ -1,32 +1,35 @@
 import React from 'react'
 import { render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
-import { TicketsDisplay } from './TicketsDisplay'
+import { jest } from '@jest/globals'
 
-jest.mock('react-window', () => {
-  return {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    FixedSizeList: jest.fn((props: any) => (
-      <div data-testid="virtual-list">
-        {Array.from({ length: props.itemCount }).map((_: unknown, idx: number) =>
-          React.createElement(props.children, {
-            index: idx,
-            style: {},
-            data: props.itemData,
-          })
-        )}
-      </div>
-    )),
-  }
-}, { virtual: true })
-
-// Mock do hook useTickets para controlar os dados retornados
-jest.mock('@/hooks/useTickets', () => ({
+jest.unstable_mockModule('@/hooks/useTickets', () => ({
   useTickets: jest.fn(),
 }))
 
-import { useTickets } from '@/hooks/useTickets'
-const useTicketsMock = useTickets as jest.Mock
+let TicketsDisplay: typeof import('./TicketsDisplay').TicketsDisplay
+let useTicketsMock: jest.Mock
+
+beforeAll(async () => {
+  const mod = await import('@/hooks/useTickets')
+  useTicketsMock = mod.useTickets as jest.Mock
+  const comp = await import('./TicketsDisplay')
+  TicketsDisplay = comp.TicketsDisplay
+})
+
+jest.unstable_mockModule('react-window', () => ({
+  FixedSizeList: jest.fn((props: any) => (
+    <div data-testid="virtual-list">
+      {Array.from({ length: props.itemCount }).map((_: unknown, idx: number) =>
+        React.createElement(props.children, {
+          index: idx,
+          style: {},
+          data: props.itemData,
+        })
+      )}
+    </div>
+  )),
+}))
 
 describe('TicketsDisplay Component', () => {
   beforeEach(() => {

--- a/src/frontend/react_app/src/components/__tests__/TicketTableRender.test.tsx
+++ b/src/frontend/react_app/src/components/__tests__/TicketTableRender.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react'
 import { TicketTable } from '@/components/TicketTable'
 import type { TicketRow } from '@/components/VirtualizedTicketTable'
 import React from 'react'
+import { jest } from '@jest/globals'
 
 jest.mock('react-window', () => {
   return {

--- a/src/frontend/react_app/src/hooks/useChamadosPorDia.ts
+++ b/src/frontend/react_app/src/hooks/useChamadosPorDia.ts
@@ -13,7 +13,7 @@ export function useChamadosPorDia() {
   )
 
   return {
-    dados: query.data ?? [],
+    data: query.data ?? [],
     error: query.error as Error | null,
     isLoading: query.isLoading,
   }

--- a/src/frontend/react_app/tests/components/ChamadosCharts.test.tsx
+++ b/src/frontend/react_app/tests/components/ChamadosCharts.test.tsx
@@ -37,13 +37,13 @@ test('ChamadosTendencia error', () => {
 })
 
 test('ChamadosHeatmap success', () => {
-  mockedDia.useChamadosPorDia.mockReturnValue({ dados: [{ date: '2024-01-01', total: 2 }], isLoading: false, error: null })
+  mockedDia.useChamadosPorDia.mockReturnValue({ data: [{ date: '2024-01-01', total: 2 }], isLoading: false, error: null })
   render(<ChamadosHeatmap />)
   expect(screen.getByText('Chamados no Ano (Heatmap Diário)')).toBeInTheDocument()
 })
 
 test('ChamadosHeatmap error', () => {
-  mockedDia.useChamadosPorDia.mockReturnValue({ dados: [], isLoading: false, error: new Error('fail') })
+  mockedDia.useChamadosPorDia.mockReturnValue({ data: [], isLoading: false, error: new Error('fail') })
   render(<ChamadosHeatmap />)
   expect(screen.getByText('Erro ao carregar dados do heatmap')).toBeInTheDocument()
 })

--- a/src/frontend/react_app/tests/profile.spec.tsx
+++ b/src/frontend/react_app/tests/profile.spec.tsx
@@ -24,7 +24,7 @@ jest.mock('../src/hooks/useChamadosPorData', () => ({
 }))
 
 jest.mock('../src/hooks/useChamadosPorDia', () => ({
-  useChamadosPorDia: () => ({ dados: [], isLoading: false, error: null }),
+  useChamadosPorDia: () => ({ data: [], isLoading: false, error: null }),
 }))
 
 jest.mock('../src/hooks/useTickets', () => ({


### PR DESCRIPTION
## Summary
- refactor `useChamadosPorDia` to expose `data` field
- update heatmap component and tests for the new API
- adjust Jest config for ESM and update tests accordingly

## Testing
- `NODE_OPTIONS=--experimental-vm-modules npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687c8ad830b08320aa7bddcc652b82f7

## Resumo por Sourcery

Refatorar o hook `useChamadosPorDia` para expor um campo "data" em vez de "dados" e atualizar componentes e testes afetados para usar a nova API.

Melhorias:
- Refatorar o hook `useChamadosPorDia` para retornar "data" em vez de "dados"
- Atualizar `ChamadosHeatmap` e outros componentes para consumir o campo renomeado
- Migrar vários testes para ESM usando `jest.unstable_mockModule` e importações dinâmicas

Compilação:
- Habilitar suporte a ESM na configuração do Jest com `useESM` e `extensionsToTreatAsEsm`

Testes:
- Atualizar testes para simular (mock) e verificar (assert) a nova propriedade "data" em vários arquivos

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the useChamadosPorDia hook to expose a “data” field instead of “dados” and update affected components and tests to use the new API.

Enhancements:
- Refactor useChamadosPorDia hook to return “data” instead of “dados”
- Update ChamadosHeatmap and other components to consume the renamed field
- Migrate several tests to ESM by using jest.unstable_mockModule and dynamic imports

Build:
- Enable ESM support in Jest config with useESM and extensionsToTreatAsEsm

Tests:
- Update tests to mock and assert on the new “data” property across multiple files

</details>