### PR TITLE
Ensure optional deps skipped in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,9 @@ under `src/frontend/modules/` for Dash.
 
 **Important:** Install packages from **both** `requirements.txt` and
 `requirements-dev.txt` before running `pytest` or invoking `make test`.
+The `requirements-dev.txt` file contains extras such as `dash[testing]`,
+`playwright`, `testcontainers` and `pact-python` which are needed for the full
+suite.
 
 ```bash
 pip install -r requirements.txt -r requirements-dev.txt  # generated via pip-compile

--- a/tests/test_circuit_breaker.py
+++ b/tests/test_circuit_breaker.py
@@ -1,5 +1,7 @@
-import pybreaker
 import pytest
+
+pytest.importorskip("pybreaker")
+import pybreaker
 
 from shared.utils.resilience import breaker, call_with_breaker
 

--- a/tests/test_glpi_async_client.py
+++ b/tests/test_glpi_async_client.py
@@ -1,7 +1,9 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import aiohttp
 import pytest
+
+pytest.importorskip("aiohttp")
+import aiohttp
 
 from backend.infrastructure.glpi.glpi_session import Credentials, GLPISession
 

--- a/tests/test_glpi_client.py
+++ b/tests/test_glpi_client.py
@@ -1,7 +1,9 @@
 from unittest.mock import MagicMock
 
-import aiohttp
 import pytest
+
+pytest.importorskip("aiohttp")
+import aiohttp
 from aiohttp import BasicAuth
 
 from backend.infrastructure.glpi.glpi_session import Credentials, GLPISession

--- a/tests/test_glpi_rest_client.py
+++ b/tests/test_glpi_rest_client.py
@@ -1,8 +1,10 @@
 from typing import Any, Optional
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import aiohttp
 import pytest
+
+pytest.importorskip("aiohttp")
+import aiohttp
 
 from backend.infrastructure.glpi.glpi_session import (
     Credentials,

--- a/tests/test_glpi_session.py
+++ b/tests/test_glpi_session.py
@@ -814,6 +814,7 @@ async def test_circuit_breaker_opens_after_consecutive_failures(
     mock_response,
 ):
     """Circuit breaker opens after repeated server errors."""
+    pytest.importorskip("pybreaker")
     import pybreaker
 
     from shared.utils.resilience import breaker

--- a/tests/test_resilient_client.py
+++ b/tests/test_resilient_client.py
@@ -1,8 +1,11 @@
 from types import SimpleNamespace
 
+import pytest
+
+pytest.importorskip("httpx")
+pytest.importorskip("pybreaker")
 import httpx
 import pybreaker
-import pytest
 
 from shared.utils.resilience import ResilientClient, breaker
 


### PR DESCRIPTION
## Summary
- avoid failing tests when optional packages are missing
- document dev extras in README

## Testing
- `pre-commit`

------
https://chatgpt.com/codex/tasks/task_e_687c8f5770d483209f0fd76d6f550afe

## Resumo por Sourcery

Pular testes quando dependências opcionais estiverem ausentes e esclarecer os extras de desenvolvimento no README

Melhorias:
- Pular testes para dependências opcionais ausentes usando pytest.importorskip para evitar falhas nos testes quando os extras não estiverem instalados

Documentação:
- Documentar os extras de desenvolvimento obrigatórios (dash[testing], playwright, testcontainers, pact-python) nas instruções de teste do README

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Skip tests when optional dependencies are absent and clarify dev extras in the README

Enhancements:
- Skip tests for missing optional dependencies using pytest.importorskip to prevent test failures when extras aren’t installed

Documentation:
- Document required dev extras (dash[testing], playwright, testcontainers, pact-python) in README’s testing instructions

</details>