### PR TITLE
Add optional dependency checks in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,9 @@ Run `scripts/setup/setup_env.sh` (or `make setup`) to create the `.venv` directo
 install packages from `requirements.txt` and the development set defined in
 `pyproject.toml` (compiled into `requirements-dev.txt`) and enable `pre-commit`
 hooks automatically. Optional extras can be added later with
-`./scripts/install_dev_extras.sh`. If you prefer to install packages manually,
-remember to run `pre-commit install` afterward.
+`./scripts/install_dev_extras.sh`. These packages include browsers and
+instrumentation required for the full test suite. If you prefer to install
+packages manually, remember to run `pre-commit install` afterward.
 
 **Note:** `setup_env.sh` only supports Linux. The script checks your OS at start
 and exits with status 1 when run on macOS or Windows, directing you to the
@@ -263,7 +264,8 @@ under `src/frontend/modules/` for Dash.
 `requirements-dev.txt` before running `pytest` or invoking `make test`.
 The `requirements-dev.txt` file contains extras such as `dash[testing]`,
 `playwright`, `testcontainers` and `pact-python` which are needed for the full
-suite.
+suite. Install them with `pip install -r requirements-dev.txt` or use
+`pip install -e '.[dev]'` to ensure all development extras are available.
 
 ```bash
 pip install -r requirements.txt -r requirements-dev.txt  # generated via pip-compile

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -3,6 +3,10 @@ from contextlib import asynccontextmanager
 from typing import Optional
 from unittest.mock import AsyncMock, MagicMock
 
+import pytest
+
+pytest.importorskip("aiohttp")
+
 import aiohttp
 
 

--- a/tests/integration/test_dashboard.py
+++ b/tests/integration/test_dashboard.py
@@ -9,6 +9,9 @@ from pathlib import Path
 from types import ModuleType
 
 import pytest
+
+pytest.importorskip("aiohttp")
+
 from aiohttp import web
 
 ROOT = Path(__file__).resolve().parents[2]

--- a/tests/test_glpi_errors.py
+++ b/tests/test_glpi_errors.py
@@ -1,8 +1,11 @@
 from typing import Optional
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import aiohttp
 import pytest
+
+pytest.importorskip("aiohttp")
+
+import aiohttp
 
 from backend.domain.exceptions import (
     GLPIAPIError,

--- a/tests/test_glpi_errors.py
+++ b/tests/test_glpi_errors.py
@@ -39,7 +39,7 @@ def mock_response_obj():
             return_value=str(json_data) if json_data is not None else ""
         )
         mock_resp.request_info = MagicMock()  # Required for ClientResponseError
-        mock_resp.history = tuple()  # Required for ClientResponseError
+        mock_resp.history = ()  # Required for ClientResponseError
         return mock_resp
 
     return _mock_response_obj

--- a/tests/test_glpi_errors.py
+++ b/tests/test_glpi_errors.py
@@ -3,8 +3,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-pytest.importorskip("aiohttp")
-
 import aiohttp
 
 from backend.domain.exceptions import (

--- a/tests/test_glpi_refresh_retry.py
+++ b/tests/test_glpi_refresh_retry.py
@@ -3,6 +3,8 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+pytest.importorskip("aiohttp")
+
 from backend.infrastructure.glpi.glpi_session import Credentials, GLPISession
 from tests.helpers import make_cm
 

--- a/tests/test_glpi_session.py
+++ b/tests/test_glpi_session.py
@@ -6,8 +6,11 @@ from contextlib import asynccontextmanager
 from typing import Optional
 from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
-import aiohttp
 import pytest
+
+pytest.importorskip("aiohttp")
+
+import aiohttp
 from aiohttp import BasicAuth
 
 from backend.infrastructure.glpi import glpi_session

--- a/tests/test_validate_credentials.py
+++ b/tests/test_validate_credentials.py
@@ -1,3 +1,7 @@
+import pytest
+
+pytest.importorskip("aiohttp")
+
 from aiohttp import BasicAuth
 
 import scripts.validate_credentials as vc

--- a/tests/test_worker_api.py
+++ b/tests/test_worker_api.py
@@ -5,6 +5,8 @@ import pytest
 import pytest_asyncio
 import redis
 from fastapi.testclient import TestClient
+
+pytest.importorskip("prometheus_client")
 from prometheus_client import CONTENT_TYPE_LATEST
 
 from backend.api.worker_api import get_glpi_client


### PR DESCRIPTION
## Summary
- skip optional test dependencies with `pytest.importorskip`
- mention development extras in README

## Testing
- `pytest -p no:cov -o addopts='' tests/test_validate_credentials.py -q`
- `pytest -p no:cov -o addopts='' tests/integration/test_dashboard.py -q`
- `pytest -p no:cov -o addopts='' tests/test_glpi_refresh_retry.py -q`
- `pytest -p no:cov -o addopts='' tests/test_worker_api.py -q` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*

------
https://chatgpt.com/codex/tasks/task_e_687c9bdaec848320ac3c6dacd4c4be16

## Resumo por Sourcery

Adiciona verificações de dependências opcionais nos testes e atualiza o README para clarificar a instalação de extras de desenvolvimento.

Melhorias:
- Ignora testes que exigem `aiohttp` quando o pacote não está instalado, usando `pytest.importorskip`
- Adiciona chamadas `pytest.importorskip` a arquivos de testes de integração e de unidade para lidar com dependências opcionais

Documentação:
- Documenta os extras de desenvolvimento no README com notas sobre os requisitos de navegador e instrumentação
- Adiciona instruções `pip install` para suporte completo à suíte de testes usando `requirements-dev.txt` ou `pip install -e '.[dev]'`

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add optional dependency checks in tests and update README to clarify development extras installation.

Enhancements:
- Skip tests requiring aiohttp when the package is not installed via pytest.importorskip
- Add pytest.importorskip calls to integration and unit test files to handle optional dependencies

Documentation:
- Document development extras in README with notes on browser and instrumentation requirements
- Add pip install instructions for full test suite support using requirements-dev.txt or pip install -e '.[dev]'

</details>