### PR TITLE
Refactor GLPI client logging setup

### DIFF
--- a/dashboard_app.py
+++ b/dashboard_app.py
@@ -19,6 +19,7 @@ from backend.core.settings import (
     USE_MOCK_DATA,
 )
 from backend.domain.exceptions import GLPIAPIError
+from backend.infrastructure.glpi.glpi_client_logging import setup_logger
 from backend.infrastructure.glpi.glpi_session import Credentials, GLPISession
 from backend.utils import process_raw
 from frontend.callbacks.callbacks import register_callbacks
@@ -52,6 +53,7 @@ if cache_type != "simple":
         cache = Cache(flask_app, config={"CACHE_TYPE": "SimpleCache"})
 
 init_logging(os.getenv("LOG_LEVEL"))
+setup_logger(__name__)
 
 
 @cache.memoize(timeout=300)

--- a/dashboard_app.py
+++ b/dashboard_app.py
@@ -52,8 +52,9 @@ if cache_type != "simple":
         logging.warning("Redis unavailable, falling back to SimpleCache: %s", exc)
         cache = Cache(flask_app, config={"CACHE_TYPE": "SimpleCache"})
 
-init_logging(os.getenv("LOG_LEVEL"))
-setup_logger(__name__)
+log_level_name = os.getenv("LOG_LEVEL", "INFO")
+log_level = getattr(logging, log_level_name.upper(), logging.INFO)
+setup_logger(__name__, level=log_level)
 
 
 @cache.memoize(timeout=300)

--- a/src/backend/infrastructure/glpi/glpi_client.py
+++ b/src/backend/infrastructure/glpi/glpi_client.py
@@ -12,10 +12,8 @@ from .glpi_client_logging import (
     bind_request,
     clear_request,
     get_logger,
-    init_logging,
 )
 
-init_logging()
 logger = get_logger(__name__)
 
 

--- a/src/backend/infrastructure/glpi/glpi_client_logging.py
+++ b/src/backend/infrastructure/glpi/glpi_client_logging.py
@@ -45,10 +45,16 @@ def init_logging(level: int = logging.INFO) -> None:
 
 
 def get_logger(name: str) -> structlog.BoundLogger:
-    """Return a structured logger, configuring if necessary."""
+    """Return a structured logger without configuring logging."""
 
-    init_logging()
     return structlog.get_logger(name)
+
+
+def setup_logger(name: str, *, level: int = logging.INFO) -> structlog.BoundLogger:
+    """Initialize logging and return a logger instance."""
+
+    init_logging(level)
+    return get_logger(name)
 
 
 def bind_request(**values: Any) -> None:
@@ -63,4 +69,10 @@ def clear_request() -> None:
     clear_contextvars()
 
 
-__all__ = ["get_logger", "init_logging", "bind_request", "clear_request"]
+__all__ = [
+    "get_logger",
+    "init_logging",
+    "bind_request",
+    "clear_request",
+    "setup_logger",
+]

--- a/tests/test_glpi_client.py
+++ b/tests/test_glpi_client.py
@@ -6,6 +6,7 @@ pytest.importorskip("aiohttp")
 import aiohttp
 from aiohttp import BasicAuth
 
+from backend.infrastructure.glpi import glpi_client_logging
 from backend.infrastructure.glpi.glpi_session import Credentials, GLPISession
 
 
@@ -132,3 +133,16 @@ async def test_query_graphql_payload(mocker):
     assert args[0] == "POST" and args[1].endswith("graphql")
     assert kwargs["json"] == {"query": "query { ping }", "variables": {"x": 1}}
     assert result == {"ok": True}
+
+
+def test_setup_logger_initializes_logging():
+    import importlib
+
+    mod = importlib.reload(glpi_client_logging)
+    assert not getattr(mod, "_configured")
+
+    mod.get_logger("t").info("no config")
+    assert not getattr(mod, "_configured")
+
+    mod.setup_logger("t")
+    assert getattr(mod, "_configured")

--- a/tests/test_glpi_client.py
+++ b/tests/test_glpi_client.py
@@ -139,10 +139,10 @@ def test_setup_logger_initializes_logging():
     import importlib
 
     mod = importlib.reload(glpi_client_logging)
-    assert not getattr(mod, "_configured")
+    assert not mod.is_logging_configured()
 
     mod.get_logger("t").info("no config")
-    assert not getattr(mod, "_configured")
+    assert not mod.is_logging_configured()
 
     mod.setup_logger("t")
-    assert getattr(mod, "_configured")
+    assert mod.is_logging_configured()

--- a/worker.py
+++ b/worker.py
@@ -14,6 +14,7 @@ with contextlib.suppress(ImportError):
     # Load environment variables from .env file for local development
     load_dotenv()
 
+from backend.infrastructure.glpi.glpi_client_logging import setup_logger
 from shared.utils.logging import init_logging
 from src.backend.api.worker_api import (
     create_app,
@@ -27,6 +28,7 @@ from src.backend.infrastructure.glpi.glpi_session import GLPISession
 
 # Initialize logging as early as possible
 init_logging(level=os.getenv("LOG_LEVEL", "INFO"))
+setup_logger(__name__)
 
 __all__ = ["create_app", "redis_client", "GLPISession", "main"]
 

--- a/worker.py
+++ b/worker.py
@@ -27,8 +27,9 @@ from src.backend.core.settings import KNOWLEDGE_BASE_FILE
 from src.backend.infrastructure.glpi.glpi_session import GLPISession
 
 # Initialize logging as early as possible
-init_logging(level=os.getenv("LOG_LEVEL", "INFO"))
-setup_logger(__name__)
+log_level_name = os.getenv("LOG_LEVEL", "INFO")
+log_level = getattr(logging, log_level_name.upper(), logging.INFO)
+setup_logger(__name__, level=log_level)
 
 __all__ = ["create_app", "redis_client", "GLPISession", "main"]
 


### PR DESCRIPTION
## Summary
- configure GLPI logging only when requested
- expose `setup_logger` helper
- use new helper in worker and dashboard entrypoints
- test logger setup

## Testing
- `pytest -o addopts='' -p no:cov tests/test_glpi_client.py::test_setup_logger_initializes_logging -q`

------
https://chatgpt.com/codex/tasks/task_e_687c9bd02d2883208da86d7331c4ffbf

## Resumo por Sourcery

Refatorar o log do cliente GLPI para exigir configuração explícita através de um novo helper `setup_logger` e atualizar os pontos de entrada para usá-lo

Melhorias:
- Expor o helper `setup_logger` para inicialização explícita do logger
- Desacoplar `get_logger` da configuração automática
- Substituir chamadas implícitas de `init_logging` por `setup_logger` nos pontos de entrada `dashboard_app` e `worker`

Testes:
- Adicionar teste para verificar se `setup_logger` inicializa o estado de log

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor GLPI client logging to require explicit setup via a new setup_logger helper and update entrypoints to use it

Enhancements:
- Expose setup_logger helper for explicit logger initialization
- Decouple get_logger from automatic configuration
- Replace implicit init_logging calls with setup_logger in dashboard_app and worker entrypoints

Tests:
- Add test to verify setup_logger initializes logging state

</details>