### PR TITLE
Use structured logging in example

### DIFF
--- a/docs/langgraph_workflow.md
+++ b/docs/langgraph_workflow.md
@@ -25,7 +25,6 @@ from shared.utils.logging import get_logger, init_logging
 wf = build_workflow().compile()
 state = {"messages": ["fetch"], "next_agent": "", "iteration_count": 0}
 result = wf.invoke(state)
-init_logging()
 logger = get_logger(__name__)
 logger.info(result["messages"][-1])
 PY

--- a/docs/langgraph_workflow.md
+++ b/docs/langgraph_workflow.md
@@ -21,11 +21,14 @@ Compile the graph and invoke it with an initial state:
 ```bash
 PYTHONPATH=src python - <<'PY'
 from src.backend.application.langgraph_workflow import build_workflow
+from shared.utils.logging import get_logger, init_logging
 wf = build_workflow().compile()
 state = {"messages": ["fetch"], "next_agent": "", "iteration_count": 0}
 result = wf.invoke(state)
-print(result["messages"][-1])
+init_logging()
+logger = get_logger(__name__)
+logger.info(result["messages"][-1])
 PY
 ```
 
-The command prints `fetched tickets` when the supervisor routes execution to the fetcher and the API call succeeds.
+The command logs `fetched tickets` when the supervisor routes execution to the fetcher and the API call succeeds.

--- a/examples/patterns/sort_strategy.py
+++ b/examples/patterns/sort_strategy.py
@@ -6,6 +6,8 @@ import timeit
 from abc import ABC, abstractmethod
 from typing import List
 
+from shared.utils.logging import get_logger, init_logging
+
 
 class SortStrategy(ABC):
     @abstractmethod
@@ -31,9 +33,16 @@ class Sorter:
 
 
 if __name__ == "__main__":
+    init_logging()
+    logger = get_logger(__name__)
+
     numbers = list(range(1000, 0, -1))
     sorter = Sorter(AscendingSort())
     asc_time = timeit.timeit(lambda: sorter.execute_sort(numbers), number=100)
     sorter.strategy = DescendingSort()
     desc_time = timeit.timeit(lambda: sorter.execute_sort(numbers), number=100)
-    print(f"Ascending: {asc_time:.4f}s, Descending: {desc_time:.4f}s")
+    logger.info(
+        "Ascending: %.4fs, Descending: %.4fs",
+        asc_time,
+        desc_time,
+    )

--- a/examples/patterns/sort_strategy.py
+++ b/examples/patterns/sort_strategy.py
@@ -33,7 +33,6 @@ class Sorter:
 
 
 if __name__ == "__main__":
-    init_logging()
     logger = get_logger(__name__)
 
     numbers = list(range(1000, 0, -1))

--- a/src/shared/utils/logging.py
+++ b/src/shared/utils/logging.py
@@ -9,7 +9,7 @@ import os
 import sys
 from contextvars import ContextVar
 
-from loguru import logger
+from loguru import Logger, logger
 from opentelemetry.instrumentation.logging import LoggingInstrumentor
 
 _is_initialized: bool = False
@@ -94,6 +94,13 @@ def init_logging(
         LoggingInstrumentor().instrument(set_logging_format=True)
 
     _is_initialized = True
+
+
+def get_logger(name: str | None = None) -> Logger:
+    """Return a logger bound with the given name."""
+
+    init_logging()
+    return logger.bind(module=name) if name else logger
 
 
 def set_correlation_id(value: str | None) -> None:

--- a/src/shared/utils/logging.py
+++ b/src/shared/utils/logging.py
@@ -99,7 +99,6 @@ def init_logging(
 def get_logger(name: str | None = None) -> Logger:
     """Return a logger bound with the given name."""
 
-    init_logging()
     return logger.bind(module=name) if name else logger
 
 


### PR DESCRIPTION
## Summary
- add `get_logger` helper in `shared.utils.logging`
- update `examples/patterns/sort_strategy.py` to use `logger.info`
- show logger usage in `docs/langgraph_workflow.md`

## Testing
- `make test` *(fails: GLPI client tests)*

------
https://chatgpt.com/codex/tasks/task_e_687c9bd523d48320850e7d2d31eda574

## Sumário por Sourcery

Habilitar log estruturado introduzindo um helper `get_logger` e atualizando o código de exemplo e a documentação para usar `logger.info`

Novas Funcionalidades:
- Adicionar o helper `get_logger` em `shared.utils.logging` para log estruturado

Melhorias:
- Refatorar a configuração de log para usar `init_logging` e vinculação de log estruturado com nomes de módulos
- Substituir declarações `print` por `logger.info` no exemplo `sort_strategy`

Documentação:
- Atualizar `langgraph_workflow.md` para demonstrar o uso de `logger.info` em vez de `print`

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable structured logging by introducing a get_logger helper and updating example code and docs to use logger.info

New Features:
- Add get_logger helper in shared.utils.logging for structured logging

Enhancements:
- Refactor logging setup to use init_logging and structured log binding with module names
- Replace print statements with logger.info in sort_strategy example

Documentation:
- Update langgraph_workflow.md to demonstrate logger.info usage instead of print

</details>