### PR TITLE
Add token file documentation and fix logging import

### DIFF
--- a/README.md
+++ b/README.md
@@ -613,6 +613,10 @@ container also executes on first startup.
 - `GLPI_APP_TOKEN` – your application token
 - `GLPI_USERNAME` / `GLPI_PASSWORD` – login credentials (optional if using a user token)
 - `GLPI_USER_TOKEN` – API token for a specific user (optional)
+- You may also provide secrets via file-based variants such as
+  `GLPI_APP_TOKEN_FILE` and `GLPI_USER_TOKEN_FILE`. Set each variable with
+  the path to a Docker/Kubernetes secret file and the client will read the
+  token from that location.
 - `VERIFY_SSL` – set to `false` to ignore invalid TLS certificates
 - `CLIENT_TIMEOUT_SECONDS` – HTTP client timeout in seconds
 - `KNOWLEDGE_BASE_FILE` – caminho para o arquivo Markdown com erros

--- a/docs/glpi_tokens_guide.md
+++ b/docs/glpi_tokens_guide.md
@@ -186,4 +186,9 @@ GLPI_APP_TOKEN="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 GLPI_USER_TOKEN="yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy"
 ```
 
+Se estiver usando Docker ou Kubernetes, você pode montar os segredos como
+arquivos e definir `GLPI_APP_TOKEN_FILE` e `GLPI_USER_TOKEN_FILE` apontando para
+esses caminhos. O cliente prioriza os valores lidos desses arquivos, mantendo as
+variáveis padrão como fallback.
+
 Pronto: o dashboard agora autentica corretamente na API.

--- a/src/shared/utils/logging.py
+++ b/src/shared/utils/logging.py
@@ -8,8 +8,9 @@ import logging
 import os
 import sys
 from contextvars import ContextVar
+from typing import Any
 
-from loguru import Logger, logger
+from loguru import logger
 from opentelemetry.instrumentation.logging import LoggingInstrumentor
 
 _is_initialized: bool = False
@@ -96,7 +97,7 @@ def init_logging(
     _is_initialized = True
 
 
-def get_logger(name: str | None = None) -> Logger:
+def get_logger(name: str | None = None) -> Any:
     """Return a logger bound with the given name."""
 
     return logger.bind(module=name) if name else logger


### PR DESCRIPTION
## Summary
- document `_FILE` variants for GLPI tokens in README and setup guide
- clarify that secrets can be mounted as files
- fix `loguru` import in shared logging utilities

## Testing
- `make test` *(fails: 45 failed, 125 passed)*

------
https://chatgpt.com/codex/tasks/task_e_687c4f4719148320a8113225803ade37

## Resumo por Sourcery

Documenta variáveis de ambiente baseadas em arquivo para tokens GLPI e corrige a importação do utilitário de log

Correções de Bugs:
- Ajusta o tipo de retorno de `get_logger` para `Any` para resolver problemas de importação do `loguru`

Documentação:
- Adiciona documentação para `GLPI_APP_TOKEN_FILE` e `GLPI_USER_TOKEN_FILE` no README
- Esclarece a montagem de segredos como arquivos e atualiza o guia de configuração em glpi_tokens_guide.md

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Document file-based environment variables for GLPI tokens and fix the logging utility import

Bug Fixes:
- Adjust get_logger return type to Any to resolve loguru import issues

Documentation:
- Add documentation for GLPI_APP_TOKEN_FILE and GLPI_USER_TOKEN_FILE in README
- Clarify mounting secrets as files and update setup guide in glpi_tokens_guide.md

</details>