### PR TITLE
Remove unused React Query Devtools import

### DIFF
--- a/src/frontend/react_app/README.md
+++ b/src/frontend/react_app/README.md
@@ -23,7 +23,7 @@ npm run dev
 In development mode, React Query Devtools are automatically enabled, so you can
 inspect queries without manual configuration.
 
-The devtools component is mounted in `main.tsx` and guarded by `import.meta.env.DEV`, ensuring it is excluded from production builds.
+The devtools component is mounted in `main.tsx` and conditionally rendered using `import.meta.env.DEV`. This is Vite's standard mechanism for including code only in development, ensuring it's automatically tree-shaken from production builds.
 
 Node.js 20 is expected. Run the commands from inside `src/frontend/react_app`.
 

--- a/src/frontend/react_app/README.md
+++ b/src/frontend/react_app/README.md
@@ -23,6 +23,8 @@ npm run dev
 In development mode, React Query Devtools are automatically enabled, so you can
 inspect queries without manual configuration.
 
+The devtools component is mounted in `main.tsx` and guarded by `import.meta.env.DEV`, ensuring it is excluded from production builds.
+
 Node.js 20 is expected. Run the commands from inside `src/frontend/react_app`.
 
 See the [frontend architecture guide](../../docs/frontend_architecture.md) for advanced configuration, environment variables and available npm scripts.

--- a/src/frontend/react_app/src/App.tsx
+++ b/src/frontend/react_app/src/App.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import Header from './components/Header';
 import { ChamadosTendencia } from './components/ChamadosTendencia';
-// Devtools para monitorar queries e mutations
-import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 
 export default function App() {
   return (
@@ -12,7 +10,7 @@ export default function App() {
         <h1 className="text-2xl font-bold mb-4">GLPI Dashboard</h1>
         <ChamadosTendencia />
       </main>
-      
+
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- remove `ReactQueryDevtools` from `App.tsx`
- document that devtools are auto-enabled only in dev and mounted in `main.tsx`

## Testing
- `pre-commit run --files src/frontend/react_app/README.md src/frontend/react_app/src/App.tsx`
- `NEXT_PUBLIC_API_BASE_URL=http://localhost:8000 npm test` *(fails: SyntaxError Cannot use 'import.meta' outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_687d5b3588008320b36eaefe9162f9f9

## Resumo por Sourcery

Remove importação não utilizada de ReactQueryDevtools de App.tsx e atualiza a documentação para esclarecer que as devtools são montadas apenas em desenvolvimento.

Melhorias:
- Remove importação não utilizada de ReactQueryDevtools de App.tsx

Documentação:
- Documenta que as React Query Devtools são ativadas automaticamente em desenvolvimento e montadas em main.tsx, sendo excluídas das builds de produção.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove unused ReactQueryDevtools import from App.tsx and update documentation to clarify devtools mounting in development only.

Enhancements:
- Remove unused ReactQueryDevtools import from App.tsx

Documentation:
- Document that React Query Devtools are auto-enabled in development and mounted in main.tsx, excluded from production builds.

</details>