### PR TITLE
Fix duplicate instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,10 +73,6 @@ Run `make diagnose` to verify the Codex environment. The helper script
 
 Runtime packages come from `requirements.txt`; development and testing tools are defined in `pyproject.toml` and compiled into `requirements-dev.txt`.
 
-Run `make diagnose` to verify the Codex environment. The helper script
-`scripts/diagnostics/diagnose_codex.py` prints useful metadata for troubleshooting.
-
-Runtime packages come from `requirements.txt`; development and testing tools are listed in `requirements-dev.txt`.
 
 Create a `.env` file from the template and fill in your GLPI and database
 credentials. PostgreSQL is used by default but you can point the application to


### PR DESCRIPTION
## Summary
- remove repeated `make diagnose` paragraph

## Testing
- `pytest -k "not e2e" -q` *(fails: ModuleNotFoundError: No module named 'dash_bootstrap_components')*

------
https://chatgpt.com/codex/tasks/task_e_687d5b2db9ec8320864348de20c07550

## Resumido por Sourcery

Documentação:
- Removido parágrafo duplicado 'make diagnose' do README

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Remove duplicate 'make diagnose' paragraph from README

</details>