### PR TITLE
Fix pagination dict check

### DIFF
--- a/src/backend/utils/pagination.py
+++ b/src/backend/utils/pagination.py
@@ -51,8 +51,12 @@ async def paginate_items(
             logger.critical("Pagination aborted for %s: %s", itemtype, exc)
             break
 
-        # The API might return a single object or a list, possibly under a 'data' key.
-        page_items_raw: Any = data.get("data", data)
+        # The API might return a single object or a list. Safely access a potential
+        # 'data' key only when the payload is a dictionary.
+        if isinstance(data, dict):
+            page_items_raw: Any = data.get("data", data)
+        else:
+            page_items_raw = data
 
         # Normalize the raw page items into a list.
         items_list: List[Any]

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -1,0 +1,21 @@
+import pytest
+
+from backend.utils.pagination import paginate_items
+
+
+@pytest.mark.asyncio
+async def test_paginate_list_only_response():
+    """Pagination should handle list responses without a dict wrapper."""
+
+    pages = {
+        0: [{"id": 1}],
+        1: [{"id": 2}],
+        2: [],
+    }
+
+    async def fetch_page(offset: int, page_size: int):
+        return pages[offset], {}
+
+    items = await paginate_items("ticket", fetch_page, page_size=1)
+
+    assert items == [{"id": 1}, {"id": 2}]


### PR DESCRIPTION
## Summary
- avoid calling `.get` on non-dict pagination results
- test pagination with raw list response

## Testing
- `PYTEST_ADDOPTS='' PYTHONPATH=src:. .venv/bin/pytest tests/test_pagination.py --no-cov -q`

------
https://chatgpt.com/codex/tasks/task_e_687d5b4663848320927eadbb34d70ce5