### PR TITLE
Fix React imports and typing issues

### DIFF
--- a/src/frontend/react_app/src/App.tsx
+++ b/src/frontend/react_app/src/App.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import Header from './components/Header';
 import { ChamadosTendencia } from './components/ChamadosTendencia';
 

--- a/src/frontend/react_app/src/components/ChamadosHeatmap.tsx
+++ b/src/frontend/react_app/src/components/ChamadosHeatmap.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useMemo } from 'react'
+import { memo, useMemo } from 'react'
 import { useChamadosPorDia } from '../hooks/useChamadosPorDia'
 import type { ChamadoPorDia } from '../types/chamado'
 import ReactCalendarHeatmap from 'react-calendar-heatmap'

--- a/src/frontend/react_app/src/components/ChamadosTendencia.tsx
+++ b/src/frontend/react_app/src/components/ChamadosTendencia.tsx
@@ -1,4 +1,4 @@
-import React, { memo } from 'react'
+import { memo } from 'react'
 import { useChamadosPorData } from '../hooks/useChamadosPorData'
 import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer, CartesianGrid } from 'recharts'
 

--- a/src/frontend/react_app/src/components/ErrorMessage.tsx
+++ b/src/frontend/react_app/src/components/ErrorMessage.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 interface Props {
   readonly title?: string
   readonly message: string

--- a/src/frontend/react_app/src/components/FilterPanel.tsx
+++ b/src/frontend/react_app/src/components/FilterPanel.tsx
@@ -1,4 +1,4 @@
-import React, { type FC, useCallback } from 'react'
+import { type FC, useCallback } from 'react'
 import { useFilters } from '../hooks/useFilters'
 
 const FilterPanel: FC = () => {

--- a/src/frontend/react_app/src/components/GlpiTicketsTable.tsx
+++ b/src/frontend/react_app/src/components/GlpiTicketsTable.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { useQuery } from '@tanstack/react-query'
 import axios from 'axios'
 

--- a/src/frontend/react_app/src/components/Header.tsx
+++ b/src/frontend/react_app/src/components/Header.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { type FC, useCallback } from 'react'
 import { useThemeSwitcher } from '../hooks/useThemeSwitcher'
 import { useFilters } from '../hooks/useFilters'

--- a/src/frontend/react_app/src/components/LevelsPanel.tsx
+++ b/src/frontend/react_app/src/components/LevelsPanel.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { memo, type FC } from 'react'
 
 export interface LevelData {

--- a/src/frontend/react_app/src/components/LoadingSpinner.tsx
+++ b/src/frontend/react_app/src/components/LoadingSpinner.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 
 export function LoadingSpinner() {
   return (

--- a/src/frontend/react_app/src/components/MetricCard.tsx
+++ b/src/frontend/react_app/src/components/MetricCard.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { memo, type FC } from 'react'
 
 export interface MetricCardProps {

--- a/src/frontend/react_app/src/components/ReportOptions.tsx
+++ b/src/frontend/react_app/src/components/ReportOptions.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { type FC, useState } from 'react';
 
 // A placeholder for an icon component
 const GearIcon = () => (
@@ -21,7 +21,7 @@ const GearIcon = () => (
  * 3. `A form field element should have an id or name attribute`: All fields have `id` and `name`.
  * 4. `Certain ARIA roles must contain particular children`: A custom radio group is correctly structured.
  */
-export const ReportOptions: React.FC = () => {
+export const ReportOptions: FC = () => {
   const [format, setFormat] = useState('pdf');
 
   return (

--- a/src/frontend/react_app/src/components/Sidebar.tsx
+++ b/src/frontend/react_app/src/components/Sidebar.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { memo, type FC } from 'react'
 
 export interface PerformanceMetric {

--- a/src/frontend/react_app/src/components/SkeletonChart.tsx
+++ b/src/frontend/react_app/src/components/SkeletonChart.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import type { FC } from 'react'
 
 const SkeletonChart: FC<{ heightClass?: string }> = ({

--- a/src/frontend/react_app/src/components/SkeletonHeatmap.tsx
+++ b/src/frontend/react_app/src/components/SkeletonHeatmap.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import type { FC } from 'react'
 
 const SkeletonHeatmap: FC<{ heightClass?: string }> = ({

--- a/src/frontend/react_app/src/components/TicketTable.tsx
+++ b/src/frontend/react_app/src/components/TicketTable.tsx
@@ -1,8 +1,8 @@
-import React from 'react'
 import { VirtualizedTicketTable, type TicketRow } from './VirtualizedTicketTable'
+import type { Ticket } from '../types/ticket'
 
 interface Props {
-  readonly tickets: TicketRow[]
+  readonly tickets: Ticket[]
 }
 
 export function TicketTable({ tickets }: Props) {
@@ -20,7 +20,7 @@ export function TicketTable({ tickets }: Props) {
         </thead>
         {/* The VirtualizedTicketTable should render <tbody> rows if possible */}
       </table>
-      <VirtualizedTicketTable rows={tickets} rowHeight={40} />
+      <VirtualizedTicketTable rows={tickets as TicketRow[]} rowHeight={40} />
     </div>
   )
 }

--- a/src/frontend/react_app/src/components/TicketTable.tsx
+++ b/src/frontend/react_app/src/components/TicketTable.tsx
@@ -20,7 +20,17 @@ export function TicketTable({ tickets }: Props) {
         </thead>
         {/* The VirtualizedTicketTable should render <tbody> rows if possible */}
       </table>
-      <VirtualizedTicketTable rows={tickets as TicketRow[]} rowHeight={40} />
+      <VirtualizedTicketTable rows={tickets.map(mapTicketToTicketRow)} rowHeight={40} />
     </div>
   )
+}
+
+function mapTicketToTicketRow(ticket: Ticket): TicketRow {
+  return {
+    id: ticket.id,
+    title: ticket.title,
+    status: ticket.status,
+    priority: ticket.priority,
+    createdAt: ticket.createdAt,
+  };
 }

--- a/src/frontend/react_app/src/components/TicketsDisplay.test.tsx
+++ b/src/frontend/react_app/src/components/TicketsDisplay.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import { jest } from '@jest/globals'

--- a/src/frontend/react_app/src/components/TicketsDisplay.tsx
+++ b/src/frontend/react_app/src/components/TicketsDisplay.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { useTickets } from '../hooks/useTickets'
 import { TicketTable } from './TicketTable'
 import { LoadingSpinner } from './LoadingSpinner'

--- a/src/frontend/react_app/src/components/VirtualizedTicketTable.tsx
+++ b/src/frontend/react_app/src/components/VirtualizedTicketTable.tsx
@@ -1,5 +1,4 @@
 import {
-  React,
   memo,
   forwardRef,
   type KeyboardEvent,
@@ -8,6 +7,7 @@ import {
   useRef,
   useState,
 } from 'react'
+import type { ReactNode, HTMLAttributes } from 'react'
 import { FixedSizeList, type ListChildComponentProps } from 'react-window'
 
 const priorityClasses: Record<string, string> = {
@@ -75,13 +75,13 @@ const Row = memo(({ index, style, data }: ListChildComponentProps<RowData>) => {
       <div role="cell" className={priorityClasses[row.priority ?? '']}>
         {row.priority}
       </div>
-      <div role="cell">{formatDate(row.date_creation) as React.ReactNode}</div>
+      <div role="cell">{formatDate(row.date_creation) as ReactNode}</div>
     </div>
   )
 })
 Row.displayName = 'Row'
 
-const RowGroup = forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+const RowGroup = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
   (props, ref) => <div {...props} ref={ref} role="rowgroup" />,
 )
 RowGroup.displayName = 'RowGroup'
@@ -174,7 +174,7 @@ export function VirtualizedTicketTable({
               <div role="cell" className={priorityClasses[row.priority ?? '']}>
                 {row.priority}
               </div>
-              <div role="cell">{formatDate(row.date_creation) as React.ReactNode}</div>
+              <div role="cell">{formatDate(row.date_creation) as ReactNode}</div>
             </div>
           ))}
         </div>

--- a/src/frontend/react_app/src/components/__tests__/ChamadosTendencia.test.tsx
+++ b/src/frontend/react_app/src/components/__tests__/ChamadosTendencia.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import { jest } from '@jest/globals'
@@ -10,7 +9,7 @@ jest.mock('../../hooks/useChamadosPorData')
 
 // Mock the recharts library to avoid rendering complex SVG in tests
 jest.mock('recharts', () => {
-  const OriginalRecharts = jest.requireActual('recharts')
+  const OriginalRecharts: typeof import('recharts') = jest.requireActual('recharts')
   return {
     ...OriginalRecharts,
     ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (

--- a/src/frontend/react_app/src/components/__tests__/Header.test.tsx
+++ b/src/frontend/react_app/src/components/__tests__/Header.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { render, screen } from '@testing-library/react'
 import Header from '../Header'
 

--- a/src/frontend/react_app/src/components/__tests__/TicketTableRender.test.tsx
+++ b/src/frontend/react_app/src/components/__tests__/TicketTableRender.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { render, screen } from '@testing-library/react'
 import type { TicketRow } from '../../components/VirtualizedTicketTable'
 import { TicketTable } from '../../components/TicketTable'
@@ -20,7 +19,7 @@ describe('TicketTable formatting', () => {
     const formatted = new Intl.DateTimeFormat('pt-BR', {
       dateStyle: 'short',
       timeStyle: 'short',
-    }).format(ticket.date_creation!)
+    }).format(ticket.date_creation as Date)
     expect(screen.getByText(formatted)).toBeInTheDocument()
   })
 })

--- a/src/frontend/react_app/src/features/tickets/TicketStatsPage.tsx
+++ b/src/frontend/react_app/src/features/tickets/TicketStatsPage.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { useTicketMetrics } from './api'
 import { StatsCard } from '../../widgets/stats/StatsCard'
 

--- a/src/frontend/react_app/src/hooks/useDashboardData.ts
+++ b/src/frontend/react_app/src/hooks/useDashboardData.ts
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
-import { useApiQuery } from 'useApiQuery'
+import { useApiQuery } from './useApiQuery'
 import type { Chart as ChartType } from 'chart'
 import type { DashboardStats } from '../types/dashboard'
 

--- a/src/frontend/react_app/src/hooks/useTickets.ts
+++ b/src/frontend/react_app/src/hooks/useTickets.ts
@@ -7,7 +7,9 @@ import type { Ticket } from '../types/ticket'
 function toTicket(dto: CleanTicketDTO): Ticket {
   return {
     ...dto,
-    name: dto.name ?? "",
+    status: dto.status != null ? String(dto.status) : undefined,
+    priority: dto.priority != null ? String(dto.priority) : undefined,
+    name: dto.name ?? '',
     date_creation: dto.date_creation ? new Date(dto.date_creation) : null,
   }
 }

--- a/src/frontend/react_app/src/hooks/useTickets.ts
+++ b/src/frontend/react_app/src/hooks/useTickets.ts
@@ -9,7 +9,7 @@ function toTicket(dto: CleanTicketDTO): Ticket {
     ...dto,
     status: dto.status != null ? String(dto.status) : undefined,
     priority: dto.priority != null ? String(dto.priority) : undefined,
-    name: dto.name ?? '',
+    name: dto.name ?? "",
     date_creation: dto.date_creation ? new Date(dto.date_creation) : null,
   }
 }

--- a/src/frontend/react_app/src/main.tsx
+++ b/src/frontend/react_app/src/main.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { StrictMode } from 'react';
 import ReactDOM from 'react-dom/client';
 import { initializeFaro } from '@grafana/faro-react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -24,10 +24,10 @@ if (faroURL && faroURL.startsWith('http')) {
 }
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
-  <React.StrictMode>
+  <StrictMode>
     <QueryClientProvider client={queryClient}>
       <App />
       {import.meta.env.DEV && <ReactQueryDevtools initialIsOpen={false} />}
     </QueryClientProvider>
-  </React.StrictMode>,
+  </StrictMode>,
 );

--- a/src/frontend/react_app/src/types/chart.d.ts
+++ b/src/frontend/react_app/src/types/chart.d.ts
@@ -1,3 +1,6 @@
 declare module 'chart' {
-  export const Chart: any
+  export class Chart {
+    constructor(element: HTMLCanvasElement, options: any);
+    destroy(): void;
+  }
 }

--- a/src/frontend/react_app/src/types/chart.d.ts
+++ b/src/frontend/react_app/src/types/chart.d.ts
@@ -1,0 +1,3 @@
+declare module 'chart' {
+  export const Chart: any
+}

--- a/src/frontend/react_app/src/widgets/stats/StatsCard.tsx
+++ b/src/frontend/react_app/src/widgets/stats/StatsCard.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 
 interface Props {
   readonly label: string


### PR DESCRIPTION
## Summary
- remove unused React imports from the React app
- fix VirtualizedTicketTable imports and typing
- adjust TicketTable props for Ticket data
- fix relative path in `useDashboardData`
- map enum fields to strings in `useTickets`
- add stub `chart.d.ts`
- update tests with stricter typing
- use `StrictMode` entrypoint

## Testing
- `npm run lint` *(fails: 292 problems)*
- `npm test` *(fails: NEXT_PUBLIC_API_BASE_URL not defined)*
- `npm run build` *(fails: NEXT_PUBLIC_API_BASE_URL not defined)*

------
https://chatgpt.com/codex/tasks/task_e_687d91c61d3083209f22264d47e62cef

## Resumo por Sourcery

Limpar e corrigir importações do React, refinar definições de tipo de componentes e hooks, e aplicar tipagem estrita em todo o aplicativo React

Correções de Bugs:
- Corrigir tipagens de `VirtualizedTicketTable` importando e usando `ReactNode` e `HTMLAttributes`
- Ajustar props de `TicketTable` para aceitar e converter dados de `Ticket` corretamente
- Mapear campos de enumeração de status e prioridade para strings em `useTickets`
- Corrigir caminho de importação relativo em `useDashboardData`

Melhorias:
- Remover importações padrão não utilizadas do React e mudar para importações explícitas apenas de tipo (`FC`, `ReactNode`, `HTMLAttributes`)
- Envolver o ponto de entrada da aplicação em `StrictMode` em vez de `React.StrictMode`

Testes:
- Atualizar testes com tipagem mais rigorosa para mocks do `recharts` e conversões de formatação de data

Tarefas:
- Adicionar stub `chart.d.ts` para declarar o módulo 'chart' ausente

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clean up and fix React imports, refine component and hook type definitions, and enforce strict typing across the React app

Bug Fixes:
- Fix VirtualizedTicketTable typings by importing and using ReactNode and HTMLAttributes
- Adjust TicketTable props to accept and cast Ticket data correctly
- Map enum status and priority fields to strings in useTickets
- Correct relative import path in useDashboardData

Enhancements:
- Remove unused default React imports and switch to explicit type-only imports (FC, ReactNode, HTMLAttributes)
- Wrap the application entrypoint in StrictMode instead of React.StrictMode

Tests:
- Update tests with stricter typing for recharts mocks and date formatting casts

Chores:
- Add stub chart.d.ts to declare the missing 'chart' module

</details>