### PR TITLE
Remove unused React imports

### DIFF
--- a/src/frontend/react_app/src/App.tsx
+++ b/src/frontend/react_app/src/App.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import Header from './components/Header';
 import { ChamadosTendencia } from './components/ChamadosTendencia';
 

--- a/src/frontend/react_app/src/main.tsx
+++ b/src/frontend/react_app/src/main.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { initializeFaro } from '@grafana/faro-react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';


### PR DESCRIPTION
## Summary
- remove unused React imports from the frontend App and main entry point
- run ESLint to confirm no unused import errors remain

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687d80130170832082f5854b8154bc07