### PR TITLE
Fix datetime caching and clean docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,20 +274,6 @@ The `requirements-dev.txt` file contains extras such as `dash[testing]`,
 suite. Install them with `pip install -r requirements-dev.txt` or use
 `pip install -e '.[dev]'` to ensure all development extras are available.
 
-```bash
-pip install -r requirements.txt -r requirements-dev.txt  # generated via pip-compile
-pip install -e .
-cd src/frontend/react_app && npm ci
-```
-See [docs/testing.md](docs/testing.md) for tips on running individual tests and for common import errors.
-
-These commands mirror what the setup target does and ensure Playwright and the␊
-Dash testing extras from the dev set are available. Verify that the
-`.venv` directory exists before calling `make test`. Frontend tests expect the
-Node packages installed with `npm ci` under `src/frontend/react_app`.
-
-This command installs all requirements, builds the local package and runs `pytest` with coverage.
-Build artifacts are written to the `build/` directory. Treat this folder as temporary; it is deleted by CI and ignored in `.gitignore`.
 
 
 ## Installing Dependencies Behind a Proxy or Offline
@@ -840,30 +826,6 @@ You may also install only the optional development extras with:
 This reads the `[project.optional-dependencies].dev` list from `pyproject.toml`
 and installs each package via `pip`.
 
-```bash
-pip install -r requirements.txt -r requirements-dev.txt  # generated via pip-compile
-pip install -e .  # ensure local packages are discoverable during tests
-# tests rely on OpenTelemetry instrumentation extras
-pip install opentelemetry-instrumentation-fastapi opentelemetry-instrumentation-logging
-# install aiohttp explicitly if using a custom environment
-pip install aiohttp
-# the core suite relies on `aiohttp` and `pandas`
-# `make test` runs the same setup; running `pytest` directly requires these
-# dependencies to be installed beforehand
-# optional extras for e2e and container tests
-pip install testcontainers playwright
-# browser tests require Chrome/Chromedriver
-# install via `apt-get install chromium-driver` or `npx playwright install`
-# if the latter fails behind a proxy, download the archive manually:
-# `curl -L https://playwright.azureedge.net/builds/chromium/1181/chromium-linux.zip -o chromium.zip`
-# `unzip chromium.zip -d ~/.cache/ms-playwright`
-# and set `PLAYWRIGHT_BROWSERS_PATH=~/.cache/ms-playwright` before running tests
-# optionally configure `PLAYWRIGHT_DOWNLOAD_HOST` to use an internal mirror
-# the setup script checks for the browser in this path and aborts if not found
-# skip them with `pytest -k 'not test_dashboard_flows'` if the driver is missing
-pytest --cov=./
-pre-commit run --all-files
-```
 
 Browser-based tests such as `test_dashboard_flows` rely on Chrome and
 Chromedriver. If these are unavailable you can skip them with:

--- a/src/backend/application/ticket_loader.py
+++ b/src/backend/application/ticket_loader.py
@@ -41,7 +41,7 @@ async def _process_and_cache_df(
     df_to_cache = df.copy()
     # Convert datetime columns to ISO 8601 strings for JSON serialization
     for col in df_to_cache.select_dtypes(include=["datetime64[ns]"]).columns:
-        df_to_cache[col] = df_to_cache[col].dt.isoformat()
+        df_to_cache[col] = df_to_cache[col].dt.strftime("%Y-%m-%dT%H:%M:%S%z")
 
     metrics = compute_aggregated(df)
     await cache_aggregated_metrics(cache, "metrics_aggregated", metrics)

--- a/src/frontend/react_app/src/App.tsx
+++ b/src/frontend/react_app/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense } from 'react'
+import { Suspense } from 'react'
 import Header from './components/Header'
 import FilterPanel from './components/FilterPanel'
 import { Sidebar } from './components/Sidebar'


### PR DESCRIPTION
## Summary
- remove duplicate installation docs
- fix datetime serialization when caching DataFrames
- drop unused React import

## Testing
- `pre-commit run --files README.md src/backend/application/ticket_loader.py src/frontend/react_app/src/App.tsx`
- `pytest -q` *(fails: unrecognized arguments / missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687d3e3a78e88320bfc63df8a7730925

## Resumo por Sourcery

Limpeza da documentação e do comportamento de cache, removendo instruções redundantes, corrigindo a serialização de datetime e eliminando uma importação não utilizada

Correções de Bugs:
- Corrige a serialização de datetime ao armazenar DataFrames em cache, usando strftime para formato ISO com fuso horário

Documentação:
- Remove instruções duplicadas de instalação e teste do README.md

Tarefas de Manutenção:
- Remove importação React não utilizada de App.tsx

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clean up documentation and caching behavior by removing redundant instructions, fixing datetime serialization, and dropping an unused import

Bug Fixes:
- Fix datetime serialization when caching DataFrames by using strftime for ISO format with timezone

Documentation:
- Remove duplicate installation and testing instructions from README.md

Chores:
- Remove unused React import from App.tsx

</details>