### PR TITLE
Remove duplicate install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ invoking `pip`. The `scripts/setup/setup_env.sh` script automatically configures
 export HTTP_PROXY=http://proxy.company.com:8080␊
 export HTTPS_PROXY=$HTTP_PROXY
 ```
-Run the installation commands from the setup section to install the dependencies through the proxy.
+Run the installation commands from the [Development Setup](#development-setup) section to install the dependencies through the proxy.
 
 On a machine with internet access you can pre-download the wheels needed by the
 project:

--- a/README.md
+++ b/README.md
@@ -285,8 +285,8 @@ invoking `pip`. The `scripts/setup/setup_env.sh` script automatically configures
 ```bash
 export HTTP_PROXY=http://proxy.company.com:8080␊
 export HTTPS_PROXY=$HTTP_PROXY
-pip install -r requirements.txt -r requirements-dev.txt  # generated via pip-compile
 ```
+Run the installation commands from the setup section to install the dependencies through the proxy.
 
 On a machine with internet access you can pre-download the wheels needed by the
 project:
@@ -796,13 +796,7 @@ Execute the unit tests with coverage. The `pytest.ini` configuration applies
 that running only a subset of tests may fail because the `addopts` line in
 `pytest.ini` enforces coverage. Use `--no-cov` or clear `PYTEST_ADDOPTS` when
 invoking individual files. See [docs/testing.md](docs/testing.md) for details.
-Before running `pytest` or `make test` you **must** install all dependencies and
-the local package in editable mode:
-
-```bash
-pip install -r requirements.txt -r requirements-dev.txt  # generated via pip-compile
-pip install -e .
-```
+Before running `pytest` or `make test` you **must** install all dependencies and the local package in editable mode using the commands shown in the setup section.
 
 Running `scripts/setup/setup_env.sh` performs the same installation automatically and configures
 pre-commit hooks. If you use the Makefile run `make setup` once to prepare the


### PR DESCRIPTION
## Summary
- update proxy section to reference a single install example
- drop repeated install block from testing section

## Testing
- `pre-commit run --files README.md`
- `pytest -q` *(fails: 15 failed, 74 passed, 3 skipped, 1 deselected, 2 errors)*

------
https://chatgpt.com/codex/tasks/task_e_687dbeffb4048320997aca45e4490c41

## Resumo por Sourcery

Unificar as instruções de instalação do README removendo blocos duplicados de `pip install` e referenciando a seção de configuração para a instalação de dependências.

Documentação:
- Remover comandos de instalação repetidos da seção de testes e do exemplo de proxy
- Atualizar a seção de proxy para direcionar os usuários à seção de configuração para as etapas de instalação

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify README installation instructions by removing duplicate pip install blocks and referencing the setup section for dependency installation.

Documentation:
- Remove repeated install commands from the testing section and proxy example
- Update proxy section to direct users to the setup section for installation steps

</details>