### PR TITLE
Fix port collision by switching frontend to 5174

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ To launch the entire stack with Docker use:
 docker compose up
 ```
 
-This starts PostgreSQL, Redis, the FastAPI worker and the Dash app. Access the dashboard at `http://localhost:5173` when the build finishes.
+This starts PostgreSQL, Redis, the FastAPI worker and the Dash app. Access the dashboard at `http://localhost:5174` when the build finishes.
 
 ## Dependencies
 
@@ -752,7 +752,7 @@ need browser automation.
 
 The frontend image takes advantage of BuildKit caching to speed up subsequent `npm ci` runs. Ensure BuildKit is enabled by setting `DOCKER_BUILDKIT=1`.
 
-This exposes the worker API on port `8000` and the dashboard on port `5173`.
+This exposes the worker API on port `8000` and the dashboard on port `5174`.
 
 ## Configuration Management
 

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -24,14 +24,14 @@ services:
       - NEXT_PUBLIC_API_BASE_URL=http://localhost:8000
     ports:
       # Exposes the Vite development server port.
-      - "5173:5173"
+      - "5174:5174"
     volumes:
       # Mounts local source code for live-reloading, and uses a named volume
       # to persist node_modules, preventing it from being overwritten by the host.
       - ./src/frontend/react_app:/app:delegated
       - frontend_node_modules:/app/node_modules
     working_dir: /app
-    command: npm run dev -- --host 0.0.0.0 --port 5173
+    command: npm run dev -- --host 0.0.0.0 --port 5174
 
   db:
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,7 +49,7 @@ services:
     depends_on:
       - backend
     ports:
-      - "5173:80" # Mapeia a porta 80 do Nginx (container) para a 5173 do host
+      - "5174:80" # Mapeia a porta 80 do Nginx (container) para a 5174 do host
     healthcheck:
       test: ["CMD", "/usr/local/bin/healthcheck.sh"]
       interval: 30s

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -35,7 +35,7 @@ Launching the entire stack with Docker is recommended for a consistent environme
 docker compose up
 ```
 
-This starts PostgreSQL, Redis, the FastAPI worker and the Dash app as described in the [README](README.md). The dashboard will be available at `http://localhost:5173`.
+This starts PostgreSQL, Redis, the FastAPI worker and the Dash app as described in the [README](README.md). The dashboard will be available at `http://localhost:5174`.
 
 ## 3. React workflow
 

--- a/docs/DEV_SETUP.md
+++ b/docs/DEV_SETUP.md
@@ -1,4 +1,4 @@
 ### Frontend Hot-Reload
 - Mount local `./src/frontend/react_app` into `/app` for instant rebuild
 - Preserve `node_modules` in `frontend_node_modules` volume to avoid being overwritten
-- Expose Vite on 5173 with `--host 0.0.0.0`
+- Expose Vite on 5174 with `--host 0.0.0.0`

--- a/docs/developer_usage.md
+++ b/docs/developer_usage.md
@@ -138,7 +138,7 @@ Certifique-se de que o plugin Docker Compose esteja instalado; caso
 `docker compose` não esteja disponível, instale o pacote `docker-compose-plugin`
 ou atualize seu Docker Engine.
 
-Isso sobe PostgreSQL, Redis, o `worker` e o dashboard em portas 8000 e 5173.
+Isso sobe PostgreSQL, Redis, o `worker` e o dashboard em portas 8000 e 5174.
 
 ## Estrutura de Pastas
 

--- a/docs/glpi_tokens_guide.md
+++ b/docs/glpi_tokens_guide.md
@@ -148,7 +148,7 @@ para acompanhar oscilações em tempo real.
 |   | Definir tokens | editar `.env` |
 |   | Validar API | `python scripts/validate_credentials.py` |
 |   | `docker compose up` | iniciar stack |
-|   | Dashboard ok | abrir <http://localhost:5173> |
+|   | Dashboard ok | abrir <http://localhost:5174> |
 
 ---
 

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -41,7 +41,7 @@ The dashboard aggregates GLPI service desk metrics using a FastAPI backend and a
    docker compose up --build
    ```
 
-3. Access the frontend at <http://localhost:5173> and the API at <http://localhost:8000>.
+3. Access the frontend at <http://localhost:5174> and the API at <http://localhost:8000>.
 
 ## Folder Layout
 

--- a/scripts/healthchecks/healthcheck.sh
+++ b/scripts/healthchecks/healthcheck.sh
@@ -5,7 +5,7 @@ TARGET="${HC_TARGET:-backend}"
 
 case "$TARGET" in
   frontend)
-    curl -f http://localhost:5173/ >/dev/null
+    curl -f http://localhost:5174/ >/dev/null
     ;;
   redis)
     redis-cli ping | grep -q PONG

--- a/scripts/healthchecks/healthcheck.sh
+++ b/scripts/healthchecks/healthcheck.sh
@@ -5,7 +5,7 @@ TARGET="${HC_TARGET:-backend}"
 
 case "$TARGET" in
   frontend)
-    curl -f http://localhost:5174/ >/dev/null
+    curl -f "http://localhost:${FRONTEND_INTERNAL_PORT:-80}/" >/dev/null
     ;;
   redis)
     redis-cli ping | grep -q PONG

--- a/src/frontend/react_app/lighthouseci.config.cjs
+++ b/src/frontend/react_app/lighthouseci.config.cjs
@@ -2,7 +2,7 @@ module.exports = {
   ci: {
     collect: {
       startServerCommand: 'npm run dev',
-      url: ['http://localhost:5173'],
+      url: ['http://localhost:5174'],
       numberOfRuns: 1,
     },
     assert: {

--- a/src/frontend/react_app/playwright.config.ts
+++ b/src/frontend/react_app/playwright.config.ts
@@ -3,7 +3,7 @@ import { defineConfig, devices } from '@playwright/test'
 export default defineConfig({
   testDir: './tests',
   use: {
-    baseURL: 'http://localhost:5173',
+    baseURL: 'http://localhost:5174',
   },
   projects: [
     {

--- a/src/frontend/react_app/vite.config.js
+++ b/src/frontend/react_app/vite.config.js
@@ -4,6 +4,6 @@ export default defineConfig({
     plugins: [react()],
     server: {
         host: true,
-        port: 5173,
+        port: 5174,
     },
 });

--- a/src/frontend/react_app/vite.config.ts
+++ b/src/frontend/react_app/vite.config.ts
@@ -5,6 +5,6 @@ export default defineConfig({
   plugins: [react()],
   server: {
     host: true,
-    port: 5173,
+    port: 5174,
   },
 });

--- a/tests/e2e/test_flow.py
+++ b/tests/e2e/test_flow.py
@@ -27,7 +27,7 @@ def test_ticket_stats_page() -> None:
     with sync_playwright() as pw:
         browser = pw.chromium.launch()
         page = browser.new_page()
-        page.goto("http://localhost:5173")
+        page.goto("http://localhost:5174")
 
         expect(page.get_by_role("heading", name="Ticket Statistics")).to_be_visible()
         # Three stats cards should be rendered once data loads

--- a/tests/e2e/test_flow.py
+++ b/tests/e2e/test_flow.py
@@ -27,7 +27,7 @@ def test_ticket_stats_page() -> None:
     with sync_playwright() as pw:
         browser = pw.chromium.launch()
         page = browser.new_page()
-        page.goto("http://localhost:5174")
+        page.goto(os.environ.get("E2E_BASE_URL", "http://localhost:5174"))
 
         expect(page.get_by_role("heading", name="Ticket Statistics")).to_be_visible()
         # Three stats cards should be rendered once data loads


### PR DESCRIPTION
## Summary
- update Docker compose files to expose dashboard on 5174
- adjust Vite, Playwright and Lighthouse configs to use the new port
- update healthcheck script, docs and tests for the change

## Testing
- `pre-commit run --files README.md docker-compose.override.yml docker-compose.yml docs/CONTRIBUTING.md docs/DEV_SETUP.md docs/developer_usage.md docs/glpi_tokens_guide.md docs/onboarding.md scripts/healthchecks/healthcheck.sh src/frontend/react_app/lighthouseci.config.cjs src/frontend/react_app/playwright.config.ts src/frontend/react_app/vite.config.js src/frontend/react_app/vite.config.ts tests/e2e/test_flow.py`
- `make test` *(fails: GLPI API Error 404; 3 failed, 56 passed)*

------
https://chatgpt.com/codex/tasks/task_e_687dd1d137b48320b2e0e7a0c35ddf18

## Resumo por Sourcery

Alterar a porta de desenvolvimento e implantação do frontend de 5173 para 5174 em todo o projeto para evitar colisões de porta

Melhorias:
- Alterar a configuração da porta do servidor Vite para 5174
- Atualizar os mapeamentos do Docker Compose e os comandos de contêiner para expor a porta 5174 para o painel
- Ajustar o script de healthcheck para apontar para a porta 5174
- Revisar as configurações do Lighthouse e Playwright para usar a nova porta
- Atualizar a documentação e os testes end-to-end para fazer referência à porta 5174

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Switch the frontend development and deployment port from 5173 to 5174 across the project to prevent port collisions

Enhancements:
- Change Vite server port configuration to 5174
- Update Docker Compose mappings and container commands to expose port 5174 for the dashboard
- Adjust healthcheck script to target port 5174
- Revise Lighthouse and Playwright configs to use the new port
- Update documentation and end-to-end tests to reference port 5174

</details>