### PR TITLE
Fix ticket loader handling of missing priority and date_creation

### DIFF
--- a/src/backend/application/ticket_loader.py
+++ b/src/backend/application/ticket_loader.py
@@ -71,8 +71,9 @@ async def load_and_translate_tickets(
     validated_tickets: List[CleanTicketDTO] = []
     validation_errors = 0
     for i, r in enumerate(records):
-        r["priority"] = r.get("priority")
-        r["date_creation"] = r.get("date_creation")
+        # Ensure keys exist if required for downstream processing
+        # r["priority"] = r.get("priority")
+        # r["date_creation"] = r.get("date_creation")
         try:
             validated_tickets.append(CleanTicketDTO.model_validate(r))
         except Exception as exc:

--- a/src/backend/application/ticket_loader.py
+++ b/src/backend/application/ticket_loader.py
@@ -61,11 +61,18 @@ async def load_and_translate_tickets(
 ) -> List[CleanTicketDTO]:
     """Return tickets translated using :class:`GlpiApiClient`."""
     df = await load_tickets(client=client, cache=cache, response=response)
-    records = df.astype(object).where(pd.notna(df), None).to_dict(orient="records")
+    records = (
+        df.astype(object)
+        .where(pd.notna(df), None)
+        .replace({"": None})
+        .to_dict(orient="records")
+    )
 
     validated_tickets: List[CleanTicketDTO] = []
     validation_errors = 0
     for i, r in enumerate(records):
+        r["priority"] = r.get("priority")
+        r["date_creation"] = r.get("date_creation")
         try:
             validated_tickets.append(CleanTicketDTO.model_validate(r))
         except Exception as exc:

--- a/tests/test_ticket_loader.py
+++ b/tests/test_ticket_loader.py
@@ -32,6 +32,39 @@ async def test_load_and_translate_tickets_cache_hit(mocker):
 
 
 @pytest.mark.asyncio
+async def test_load_and_translate_tickets_missing_fields(mocker):
+    cached = {
+        "data": [
+            {
+                "id": 2,
+                "name": "Network issue",
+                "status": 1,
+                "priority": float("nan"),
+                "date_creation": "",
+            },
+            {
+                "id": 3,
+                "name": "Another issue",
+                "status": 1,
+            },
+        ]
+    }
+
+    cache = mocker.Mock()
+    cache.get = AsyncMock(return_value=cached)
+    cache.set = AsyncMock()
+
+    result = await ticket_loader.load_and_translate_tickets(cache=cache)
+
+    assert len(result) == 2
+    assert all(isinstance(t, CleanTicketDTO) for t in result)
+    assert result[0].priority is None
+    assert result[0].created_at is None
+    assert result[1].priority is None
+    assert result[1].created_at is None
+
+
+@pytest.mark.asyncio
 async def test_check_glpi_connection_mock(monkeypatch):
     """Return 200 without session when mock data is enabled."""
 


### PR DESCRIPTION
## Summary
- replace NaN and empty strings with `None` before validating tickets
- ensure optional `priority` and `date_creation` keys exist
- test missing `priority` and `date_creation` handling

## Testing
- `pre-commit run --files src/backend/application/ticket_loader.py tests/test_ticket_loader.py`
- `pytest tests/test_ticket_loader.py -q` *(fails: ModuleNotFoundError: No module named 'structlog')*

------
https://chatgpt.com/codex/tasks/task_e_687efcbddab08320a38b7a83f25101d8

## Resumo por Sourcery

Corrige o carregador de tickets para converter valores ausentes de priority e date_creation para None e adiciona testes para verificar este comportamento

Melhorias:
- Normaliza NaN e strings vazias para None ao carregar registros de tickets
- Garante que os campos opcionais priority e date_creation estejam sempre presentes antes da validação

Testes:
- Adiciona teste para lidar com tickets com campos priority e date_creation ausentes ou vazios

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix ticket loader to convert missing priority and date_creation values to None and add tests to verify this behavior

Enhancements:
- Normalize NaN and empty strings to None when loading ticket records
- Ensure optional priority and date_creation fields are always present before validation

Tests:
- Add test for handling tickets with missing or empty priority and date_creation fields

</details>