### PR TITLE
Replace axios with fetcher in ticket table

### DIFF
--- a/src/frontend/react_app/src/components/GlpiTicketsTable.tsx
+++ b/src/frontend/react_app/src/components/GlpiTicketsTable.tsx
@@ -1,23 +1,34 @@
 import { useQuery } from '@tanstack/react-query'
-import axios from 'axios'
+import { fetcher } from '@/lib/swrClient'
 
 interface Ticket {
   id: number
   name: string
   status: string
+  priority?: string | null
+  date_creation?: string | null
 }
 
 export function GlpiTicketsTable() {
   const { data: tickets, isLoading, error } = useQuery<Ticket[]>({
     queryKey: ['tickets'],
-    queryFn: async () => {
-      const { data } = await axios.get<Ticket[]>('/api/tickets')
-      return data
-    },
+    queryFn: () => fetcher<Ticket[]>('/tickets'),
   })
 
   if (isLoading) return <p>Carregando...</p>
   if (error) return <p>Erro ao buscar tickets</p>
+
+  const formatDate = (value?: string | null) => {
+    if (!value) return '-'
+    try {
+      return new Intl.DateTimeFormat('pt-BR', {
+        dateStyle: 'short',
+        timeStyle: 'short',
+      }).format(new Date(value))
+    } catch {
+      return value
+    }
+  }
 
   return (
     <table>
@@ -26,6 +37,8 @@ export function GlpiTicketsTable() {
           <th>ID</th>
           <th>Título</th>
           <th>Status</th>
+          <th>Prioridade</th>
+          <th>Criado em</th>
         </tr>
       </thead>
       <tbody>
@@ -34,6 +47,8 @@ export function GlpiTicketsTable() {
             <td>{ticket.id}</td>
             <td>{ticket.name}</td>
             <td>{ticket.status}</td>
+            <td>{ticket.priority ?? '-'}</td>
+            <td>{formatDate(ticket.date_creation)}</td>
           </tr>
         ))}
       </tbody>

--- a/src/frontend/react_app/tests/components/GlpiTicketsTable.test.tsx
+++ b/src/frontend/react_app/tests/components/GlpiTicketsTable.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { GlpiTicketsTable } from '@/components/GlpiTicketsTable'
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <QueryClientProvider client={new QueryClient()}>{children}</QueryClientProvider>
+)
+
+beforeEach(() => {
+  ;(import.meta as any).env = { NEXT_PUBLIC_API_BASE_URL: 'http://localhost' }
+})
+
+test('renders ticket rows with null fields', async () => {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    headers: { get: () => 'application/json' },
+    text: () =>
+      Promise.resolve(
+        JSON.stringify([
+          { id: 1, name: 'Teste', status: 'new', priority: null, date_creation: null },
+        ])
+      ),
+  }) as jest.Mock
+
+  render(<GlpiTicketsTable />, { wrapper })
+  await waitFor(() => expect(screen.getByText('Teste')).toBeInTheDocument())
+  expect(screen.getAllByText('-')).toHaveLength(2)
+})

--- a/src/frontend/react_app/tests/components/GlpiTicketsTable.test.tsx
+++ b/src/frontend/react_app/tests/components/GlpiTicketsTable.test.tsx
@@ -27,3 +27,25 @@ test('renders ticket rows with null fields', async () => {
   await waitFor(() => expect(screen.getByText('Teste')).toBeInTheDocument())
   expect(screen.getAllByText('-')).toHaveLength(2)
 })
+
+test('renders ticket rows with non-null priority and date_creation fields', async () => {
+  const mockPriority = 3
+  const mockDate = '2024-06-01T12:34:56Z'
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    headers: { get: () => 'application/json' },
+    text: () =>
+      Promise.resolve(
+        JSON.stringify([
+          { id: 2, name: 'Ticket 2', status: 'assigned', priority: mockPriority, date_creation: mockDate },
+        ])
+      ),
+  }) as jest.Mock
+
+  render(<GlpiTicketsTable />, { wrapper })
+  await waitFor(() => expect(screen.getByText('Ticket 2')).toBeInTheDocument())
+  // Check that the priority is rendered (as a string or label, depending on component logic)
+  expect(screen.getByText(String(mockPriority))).toBeInTheDocument()
+  // Check that the date is rendered (formatting may vary, adjust as needed)
+  expect(screen.getByText(/2024-06-01/)).toBeInTheDocument()
+})

--- a/src/frontend/react_app/tests/components/GlpiTicketsTable.test.tsx
+++ b/src/frontend/react_app/tests/components/GlpiTicketsTable.test.tsx
@@ -7,7 +7,8 @@ const wrapper = ({ children }: { children: React.ReactNode }) => (
 )
 
 beforeEach(() => {
-  ;(import.meta as any).env = { NEXT_PUBLIC_API_BASE_URL: 'http://localhost' }
+  const mockImportMetaEnv: ImportMetaEnv = { NEXT_PUBLIC_API_BASE_URL: 'http://localhost' };
+  Object.defineProperty(import.meta, 'env', { value: mockImportMetaEnv, writable: true });
 })
 
 test('renders ticket rows with null fields', async () => {


### PR DESCRIPTION
## Summary
- use SWR `fetcher` helper in `GlpiTicketsTable`
- handle `priority` and `date_creation` as nullable values
- test rendering when optional fields are null

## Testing
- `pre-commit run --files src/frontend/react_app/src/components/GlpiTicketsTable.tsx src/frontend/react_app/tests/components/GlpiTicketsTable.test.tsx`
- `npm test` *(fails: SyntaxError `Cannot use 'import.meta' outside a module`)*
- `pytest` *(fails: unrecognized arguments `--cov`)*

------
https://chatgpt.com/codex/tasks/task_e_687f003d82cc8320ad677b780d260711

## Resumo por Sourcery

Substitui `axios` por um `SWR fetcher` compartilhado em `GlpiTicketsTable`, adiciona suporte para campos de prioridade e data de criação anuláveis (`nullable`) com `placeholders` e datas formatadas, e inclui um teste para lidar com valores nulos.

Melhorias:
- Troca das requisições `axios` pelo `SWR fetcher helper` compartilhado em `GlpiTicketsTable`
- Adiciona um `helper` de formatação de data e `placeholders` padrão para campos de prioridade e data de criação anuláveis

Testes:
- Adiciona teste para verificar a renderização da tabela quando `priority` e `date_creation` são nulos

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Replace axios with shared SWR fetcher in GlpiTicketsTable, add support for nullable priority and creation date fields with placeholders and formatted dates, and include a test for handling null values.

Enhancements:
- Swap axios requests for the shared SWR fetcher helper in GlpiTicketsTable
- Add date formatting helper and default placeholders for nullable priority and creation date fields

Tests:
- Add test to verify table rendering when priority and date_creation are null

</details>