### PR TITLE
Handle undefined ticket data

### DIFF
--- a/src/frontend/react_app/src/components/TicketTable.tsx
+++ b/src/frontend/react_app/src/components/TicketTable.tsx
@@ -31,6 +31,8 @@ function mapTicketToTicketRow(ticket: Ticket): TicketRow {
     name: ticket.name,
     status: ticket.status,
     priority: ticket.priority,
-    date_creation: ticket.date_creation ? new Date(ticket.date_creation) : null,
+    // Use `undefined` when the date is missing so the formatter displays a fallback
+    date_creation:
+      ticket.date_creation != null ? new Date(ticket.date_creation) : undefined,
   };
 }

--- a/src/frontend/react_app/src/components/VirtualizedTicketTable.tsx
+++ b/src/frontend/react_app/src/components/VirtualizedTicketTable.tsx
@@ -26,8 +26,9 @@ const formatDate = (value?: string | Date | null) => {
       dateStyle: 'short',
       timeStyle: 'short',
     }).format(new Date(value))
-  } catch {
-    return String(value)
+  } catch (error) {
+    console.error('Error formatting date:', error, 'Input value:', value)
+    return '-'
   }
 }
 

--- a/src/frontend/react_app/src/components/VirtualizedTicketTable.tsx
+++ b/src/frontend/react_app/src/components/VirtualizedTicketTable.tsx
@@ -20,14 +20,14 @@ const priorityClasses: Record<string, string> = {
 }
 
 const formatDate = (value?: string | Date | null) => {
-  if (!value) return ''
+  if (!value) return '-'
   try {
     return new Intl.DateTimeFormat('pt-BR', {
       dateStyle: 'short',
       timeStyle: 'short',
     }).format(new Date(value))
   } catch {
-    return value
+    return String(value)
   }
 }
 
@@ -73,7 +73,7 @@ const Row = memo(({ index, style, data }: ListChildComponentProps<RowData>) => {
       <div role="cell" className="truncate" title={row.name}>{row.name}</div>
       <div role="cell">{row.status}</div>
       <div role="cell" className={priorityClasses[row.priority ?? '']}>
-        {row.priority}
+        {row.priority ?? '-'}
       </div>
       <div role="cell">{formatDate(row.date_creation) as ReactNode}</div>
     </div>
@@ -172,7 +172,7 @@ export function VirtualizedTicketTable({
               <div role="cell" className="truncate" title={row.name}>{row.name}</div>
               <div role="cell">{row.status}</div>
               <div role="cell" className={priorityClasses[row.priority ?? '']}>
-                {row.priority}
+                {row.priority ?? '-'}
               </div>
               <div role="cell">{formatDate(row.date_creation) as ReactNode}</div>
             </div>

--- a/src/frontend/react_app/src/components/__tests__/TicketTableRender.test.tsx
+++ b/src/frontend/react_app/src/components/__tests__/TicketTableRender.test.tsx
@@ -22,4 +22,15 @@ describe('TicketTable formatting', () => {
     }).format(ticket.date_creation as Date)
     expect(screen.getByText(formatted)).toBeInTheDocument()
   })
+
+  it('displays fallbacks when data is missing', () => {
+    const minimal: Ticket = { id: 2, name: 'Sem prioridade', status: 'New' }
+    render(<TicketTable tickets={[minimal]} />)
+    const row = screen.getAllByRole('row')[1]
+    expect(row).toHaveTextContent('Sem prioridade')
+    // priority and date columns should show "-"
+    const dashes = row.querySelectorAll('div')
+    const dashCount = Array.from(dashes).filter((d) => d.textContent === '-').length
+    expect(dashCount).toBeGreaterThanOrEqual(2)
+  })
 })

--- a/src/frontend/react_app/src/hooks/useTickets.ts
+++ b/src/frontend/react_app/src/hooks/useTickets.ts
@@ -10,7 +10,9 @@ function toTicket(dto: CleanTicketDTO): Ticket {
     status: dto.status != null ? String(dto.status) : undefined,
     priority: dto.priority != null ? String(dto.priority) : undefined,
     name: dto.name ?? "",
-    date_creation: dto.date_creation ? new Date(dto.date_creation) : null,
+    // Prefer `undefined` over `null` when the API omits the field
+    date_creation:
+      dto.date_creation != null ? new Date(dto.date_creation) : undefined,
   }
 }
 


### PR DESCRIPTION
## Summary
- convert missing fields to `undefined` in `useTickets`
- show fallback values in `VirtualizedTicketTable`
- propagate `undefined` dates in `TicketTable`
- test TicketTable fallbacks

## Testing
- `pre-commit run --files src/frontend/react_app/src/hooks/useTickets.ts src/frontend/react_app/src/components/VirtualizedTicketTable.tsx src/frontend/react_app/src/components/TicketTable.tsx src/frontend/react_app/src/components/__tests__/TicketTableRender.test.tsx`
- `NODE_OPTIONS=--experimental-vm-modules NEXT_PUBLIC_API_BASE_URL=http://localhost:8000 npx jest src/components/__tests__/TicketTableRender.test.tsx --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_687f046ccfa8832095be36ad0ee0bb92

## Resumo por Sourcery

Converter campos de ticket ausentes para `undefined` e mostrar fallbacks '-' para prioridade e data em tabelas de tickets, com testes verificando a renderização do fallback

Melhorias:
- Converter `null date_creation` para `undefined` em `useTickets` e mapeamento de `TicketTable`
- Exibir '-' para prioridade e datas ausentes em `VirtualizedTicketTable` e `TicketTable`

Testes:
- Adicionar teste para verificar a renderização do fallback '-' quando os dados do ticket estão ausentes

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Convert missing ticket fields to undefined and show '-' fallbacks for priority and date in ticket tables, with tests verifying the fallback rendering

Enhancements:
- Convert null date_creation to undefined in useTickets and TicketTable mapping
- Display '-' for missing priority and dates in VirtualizedTicketTable and TicketTable

Tests:
- Add test to verify '-' fallback rendering when ticket data is missing

</details>