### PR TITLE
Improve ticket display with null checks

### DIFF
--- a/src/frontend/react_app/src/components/VirtualizedTicketTable.tsx
+++ b/src/frontend/react_app/src/components/VirtualizedTicketTable.tsx
@@ -20,7 +20,7 @@ const priorityClasses: Record<string, string> = {
 }
 
 const formatDate = (value?: string | Date | null) => {
-  if (!value) return ''
+  if (!value) return '-'
   try {
     return new Intl.DateTimeFormat('pt-BR', {
       dateStyle: 'short',
@@ -73,7 +73,7 @@ const Row = memo(({ index, style, data }: ListChildComponentProps<RowData>) => {
       <div role="cell" className="truncate" title={row.name}>{row.name}</div>
       <div role="cell">{row.status}</div>
       <div role="cell" className={priorityClasses[row.priority ?? '']}>
-        {row.priority}
+        {row.priority ?? '-'}
       </div>
       <div role="cell">{formatDate(row.date_creation) as ReactNode}</div>
     </div>
@@ -172,7 +172,7 @@ export function VirtualizedTicketTable({
               <div role="cell" className="truncate" title={row.name}>{row.name}</div>
               <div role="cell">{row.status}</div>
               <div role="cell" className={priorityClasses[row.priority ?? '']}>
-                {row.priority}
+                {row.priority ?? '-'}
               </div>
               <div role="cell">{formatDate(row.date_creation) as ReactNode}</div>
             </div>

--- a/src/frontend/react_app/src/components/__tests__/TicketTableRender.test.tsx
+++ b/src/frontend/react_app/src/components/__tests__/TicketTableRender.test.tsx
@@ -31,8 +31,7 @@ describe('TicketTable formatting', () => {
       date_creation: null,
     }
     render(<TicketTable tickets={[missing]} />)
-    const cells = screen.getAllByRole('cell')
-    expect(cells[3]).toHaveTextContent('-')
-    expect(cells[4]).toHaveTextContent('-')
+    expect(screen.getByTestId('priority-cell-2')).toHaveTextContent('-')
+    expect(screen.getByTestId('date-cell-2')).toHaveTextContent('-')
   })
 })

--- a/src/frontend/react_app/src/components/__tests__/TicketTableRender.test.tsx
+++ b/src/frontend/react_app/src/components/__tests__/TicketTableRender.test.tsx
@@ -22,4 +22,17 @@ describe('TicketTable formatting', () => {
     }).format(ticket.date_creation as Date)
     expect(screen.getByText(formatted)).toBeInTheDocument()
   })
+
+  it('renders placeholders for missing priority and date', () => {
+    const missing: Ticket = {
+      id: 2,
+      name: 'Sem prioridade',
+      status: 'New',
+      date_creation: null,
+    }
+    render(<TicketTable tickets={[missing]} />)
+    const cells = screen.getAllByRole('cell')
+    expect(cells[3]).toHaveTextContent('-')
+    expect(cells[4]).toHaveTextContent('-')
+  })
 })


### PR DESCRIPTION
## Summary
- ensure `.env` lists `NEXT_PUBLIC_API_BASE_URL`
- handle empty priority/date in `VirtualizedTicketTable`
- add regression test for missing priority/date

## Testing
- `node --experimental-vm-modules node_modules/jest/bin/jest.js src/components/__tests__/TicketTableRender.test.tsx`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'playwright')*

------
https://chatgpt.com/codex/tasks/task_e_687f052466ac8320a42b3f99fd6306c3

## Resumo por Sourcery

Exibe marcadores de posição '-' para tickets sem prioridade ou data de criação e adiciona um teste de regressão para este comportamento

Melhorias:
- Retorna o marcador de posição '-' em vez de uma string vazia ao formatar datas ausentes
- Mostra '-' para valores de prioridade nulos ou indefinidos em VirtualizedTicketTable

Testes:
- Adiciona teste de regressão para verificar se os marcadores de posição '-' são renderizados para tickets sem prioridade e data

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Display '-' placeholders for tickets with no priority or creation date and add a regression test for this behavior

Enhancements:
- Return '-' placeholder instead of empty string when formatting missing dates
- Show '-' for null or undefined priority values in VirtualizedTicketTable

Tests:
- Add regression test to verify '-' placeholders render for tickets missing priority and date

</details>