### PR TITLE
Fix GLPISession exit cancellation

### DIFF
--- a/src/backend/infrastructure/glpi/glpi_session.py
+++ b/src/backend/infrastructure/glpi/glpi_session.py
@@ -399,11 +399,9 @@ class GLPISession:
         self._shutdown_event.set()
         if self._refresh_task:
             self._refresh_task.cancel()
-            try:
+            with contextlib.suppress(asyncio.CancelledError):
                 await self._refresh_task
-            except asyncio.CancelledError:
-                logger.info("Proactive refresh task cancelled.")
-                raise
+            logger.info("Proactive refresh task cancelled.")
 
         if self._session_token and not self._using_user_token:
             await self._kill_session()


### PR DESCRIPTION
## Summary
- prevent CancelledError from breaking GLPISession cleanup
- add regression test for graceful cancellation

## Testing
- `pre-commit run --files src/backend/infrastructure/glpi/glpi_session.py tests/test_glpi_session.py`
- `PYTEST_ADDOPTS='--no-cov' pytest tests/test_glpi_session.py::test_aexit_suppresses_cancellation -q`

------
https://chatgpt.com/codex/tasks/task_e_687f17043fd88320acf56015e2f5c982

## Resumo por Sourcery

Suprimir `asyncio.CancelledError` durante o encerramento da `GLPISession` para garantir que a limpeza da sessão sempre seja concluída e adicionar um teste de regressão para o tratamento de cancelamento

Correções de Bugs:
- Suprimir `CancelledError` ao aguardar a tarefa de atualização proativa em `GLPISession.__aexit__` para evitar que a limpeza seja interrompida

Testes:
- Adicionar `test_aexit_suppresses_cancellation` para verificar que o encerramento de `GLPISession` lida graciosamente com um loop de atualização cancelado sem vazar recursos

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Suppress asyncio.CancelledError during GLPISession shutdown to ensure the session cleanup always completes and add a regression test for cancellation handling

Bug Fixes:
- Suppress CancelledError when awaiting the proactive refresh task in GLPISession.__aexit__ to prevent cleanup from being interrupted

Tests:
- Add test_aexit_suppresses_cancellation to verify that GLPISession exit gracefully handles a canceled refresh loop without leaking resources

</details>