### PR TITLE
fix dto name validation

### DIFF
--- a/src/shared/dto.py
+++ b/src/shared/dto.py
@@ -59,9 +59,7 @@ class CleanTicketDTO(BaseModel):
     @classmethod
     def _sanitize_title(cls, v: Any) -> str:
         """Ensure title is a non-null string."""
-        if v is None:
-            return ""
-        return str(v)
+        return "" if v is None else str(v)
 
     @field_validator("status", mode="before")
     @classmethod

--- a/src/shared/dto.py
+++ b/src/shared/dto.py
@@ -47,13 +47,21 @@ class CleanTicketDTO(BaseModel):
     """Normalized ticket used internally by the application."""
 
     id: int
-    title: str = Field(..., alias="name")
+    title: str = Field("", alias="name")
     status: str
     priority: Optional[str] = Field(default=None)
     created_at: Optional[datetime] = Field(default=None, alias="date_creation")
     assigned_to: str = "Unassigned"
 
     model_config = ConfigDict(populate_by_name=True)
+
+    @field_validator("title", mode="before")
+    @classmethod
+    def _sanitize_title(cls, v: Any) -> str:
+        """Ensure title is a non-null string."""
+        if v is None:
+            return ""
+        return str(v)
 
     @field_validator("status", mode="before")
     @classmethod
@@ -67,7 +75,7 @@ class CleanTicketDTO(BaseModel):
     ) -> Optional[str]:  # pragma: no cover - simple mapping
         if v is None:
             return None
-        
+
         return PRIORITY_MAP.get(v, "Unknown")
 
 

--- a/tests/test_clean_ticket_dto.py
+++ b/tests/test_clean_ticket_dto.py
@@ -47,8 +47,9 @@ def test_clean_ticket_dto_missing_required_field():
         "date_creation": "2024-01-01T12:00:00",
     }
 
-    with pytest.raises(ValidationError):
-        CleanTicketDTO.model_validate(data)
+    ticket = CleanTicketDTO.model_validate(data)
+
+    assert ticket.title == ""
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
- handle missing `name` field when parsing CleanTicketDTO
- update tests for new default behavior

## Testing
- `pre-commit run --files src/shared/dto.py tests/test_clean_ticket_dto.py`
- `PYTEST_ADDOPTS="" pytest -o addopts='' -p no:cov tests/test_clean_ticket_dto.py -q`


------
https://chatgpt.com/codex/tasks/task_e_687f1844da2883208f0b1434474d4bfd

## Resumo por Sourcery

Permitir que CleanTicketDTO lide com campos 'name' ausentes ou nulos, definindo o título como uma string vazia por padrão e atualizando os testes relacionados.

Correções de Bugs:
- Fazer com que CleanTicketDTO.title seja uma string vazia por padrão, em vez de levantar um erro de validação quando 'name' estiver ausente ou for nulo

Melhorias:
- Adicionar um validador pré-campo para converter valores nulos de title em uma string vazia

Testes:
- Atualizar teste unitário para afirmar que title == '' para 'name' ausente, em vez de esperar um ValidationError

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Allow CleanTicketDTO to handle missing or null 'name' fields by defaulting the title to an empty string and update related tests.

Bug Fixes:
- Make CleanTicketDTO.title default to an empty string instead of raising a validation error when 'name' is missing or null

Enhancements:
- Add a before-field validator to coerce null title values into an empty string

Tests:
- Update unit test to assert title == '' for missing 'name' instead of expecting a ValidationError

</details>