### PR TITLE
Handle missing ticket names with fallback

### DIFF
--- a/tests/test_clean_ticket_dto.py
+++ b/tests/test_clean_ticket_dto.py
@@ -49,7 +49,7 @@ def test_clean_ticket_dto_missing_required_field():
 
     ticket = CleanTicketDTO.model_validate(data)
 
-    assert ticket.title == ""
+    assert ticket.title == "[Título não informado]"
 
 
 @pytest.mark.unit

--- a/tests/test_convert_ticket.py
+++ b/tests/test_convert_ticket.py
@@ -59,3 +59,13 @@ def test_convert_ticket_invalid_status_fallback(
     assert any(
         "Unknown TicketStatus value: 99" in rec.getMessage() for rec in caplog.records
     )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("raw_name", [None, ""])
+def test_convert_ticket_missing_name(raw_name: str | None) -> None:
+    raw = RawTicketDTO(id=1, name=raw_name)
+
+    ticket = convert_ticket(raw)
+
+    assert ticket.name == "[Título não informado]"


### PR DESCRIPTION
## Summary
- allow `name` in `CleanTicketDTO` to be optional
- default missing or empty names to `[Título não informado]`
- propagate the same logic to `shared.dto.CleanTicketDTO`
- update ticket conversion to keep `None` for missing names
- test default name behavior for DTO and converter

## Testing
- `pre-commit run --files src/backend/domain/ticket_models.py src/shared/dto.py tests/test_convert_ticket.py tests/test_clean_ticket_dto.py`
- `pytest -k missing_name -q -p no:cov -o addopts=""`

------
https://chatgpt.com/codex/tasks/task_e_687f2395b868832086f256923fc37887

## Resumo por Sourcery

Introduz o tratamento para nomes de ticket ausentes, tornando os campos de nome opcionais em CleanTicketDTO, aplicando uma string de fallback via pré-validação, ajustando a lógica de conversão para emitir avisos e cobrindo o comportamento com novos testes.

Novas Funcionalidades:
- Adiciona um fallback para nomes de ticket ausentes ou vazios, usando "[Título não informado]" como padrão, tanto nos DTOs de domínio quanto nos compartilhados

Melhorias:
- Permite que os campos de nome/título em CleanTicketDTO sejam opcionais e os sanitiza usando um `model_validator` antes da instanciação
- Atualiza `convert_ticket` para registrar um aviso para nomes ausentes ou vazios, enquanto preserva a lógica de fallback

Testes:
- Adiciona testes de unidade para verificar o comportamento padrão do nome para nomes ausentes ou vazios, tanto no DTO quanto no conversor

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce handling for missing ticket names by making name fields optional in CleanTicketDTO, applying a fallback string via pre-validation, adjusting conversion logic to emit warnings, and covering the behavior with new tests.

New Features:
- Add fallback for missing or empty ticket names defaulting to "[Título não informado]" in both domain and shared DTOs

Enhancements:
- Allow name/title fields in CleanTicketDTO to be optional and sanitize them using a model_validator before instantiation
- Update convert_ticket to log a warning for missing or empty names while preserving the fallback logic

Tests:
- Add unit tests to verify default name behavior for missing or empty names in both the DTO and converter

</details>