### PR TITLE
Add missing None-name unit test

### DIFF
--- a/tests/test_clean_ticket_dto.py
+++ b/tests/test_clean_ticket_dto.py
@@ -53,6 +53,21 @@ def test_clean_ticket_dto_missing_required_field():
 
 
 @pytest.mark.unit
+def test_clean_ticket_dto_none_name_becomes_empty_string():
+    """Ensure None titles are sanitized to an empty string."""
+
+    data = {
+        "id": 1,
+        "name": None,
+        "status": 1,
+    }
+
+    ticket = CleanTicketDTO.model_validate(data)
+
+    assert ticket.title == ""
+
+
+@pytest.mark.unit
 def test_clean_ticket_dto_missing_optional_fields():
     data = {
         "id": 2,


### PR DESCRIPTION
## Summary
- add unit test verifying CleanTicketDTO converts `None` titles to empty strings

## Testing
- `pytest tests/test_clean_ticket_dto.py -q --no-cov`

------
https://chatgpt.com/codex/tasks/task_e_687f2570c13c8320a460d34f9c6e7128

## Resumo por Sourcery

Testes:
- Verificar que CleanTicketDTO.model_validate sanitiza nomes `None` para strings vazias

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Tests:
- Verify that CleanTicketDTO.model_validate sanitizes None names to empty strings

</details>