### PR TITLE
Fix GLPI session request context

### DIFF
--- a/src/backend/infrastructure/glpi/glpi_session.py
+++ b/src/backend/infrastructure/glpi/glpi_session.py
@@ -1,6 +1,5 @@
 import asyncio
 import contextlib
-import inspect
 import json
 import logging
 import os
@@ -579,14 +578,11 @@ class GLPISession:
         elif self.ssl_ctx is not None:
             request_kwargs["ssl"] = self.ssl_ctx
 
-        request_ctx = self._session.request(
+        async with self._session.request(
             method,
             full_url,
             **request_kwargs,
-        )
-        if inspect.isawaitable(request_ctx):
-            request_ctx = await request_ctx
-        async with request_ctx as response:
+        ) as response:
             if response.status == 401 and retry_on_401 and attempt < max_401_retries:
                 raise GLPIUnauthorizedError(401, "401 Unauthorized")
             try:


### PR DESCRIPTION
## Summary
- remove unused `inspect` import
- simplify `_execute_request` with `async with self._session.request`

## Testing
- `pre-commit run --files src/backend/infrastructure/glpi/glpi_session.py`
- `pytest -k ''` *(fails: 36 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_687f251ccb188320a91f0dbec5b5fbe7

## Resumo por Sourcery

Simplifica o gerenciamento de contexto de requisição assíncrona na sessão GLPI e remove uma importação não utilizada

Melhorias:
- Simplifica _execute_request usando async with self._session.request diretamente

Tarefas:
- Remove a importação não utilizada de inspect de glpi_session

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Simplify the asynchronous request context management in GLPI session and remove an unused import

Enhancements:
- Simplify _execute_request by using async with self._session.request directly

Chores:
- Remove unused inspect import from glpi_session

</details>