### PR TITLE
feat(dto): map textual ticket statuses

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,2 +1,3 @@
 - **src/frontend/react_app/Dockerfile**: upgraded base image from Node 18 to Node 20.19.0-alpine to fix `EBADENGINE` and crypto.hash errors.
 - **tooling**: minimum frontend Node version is now **20.19**.
+- **shared.dto**: `_validate_status` now accepts textual status values like `"closed"`.

--- a/src/shared/dto.py
+++ b/src/shared/dto.py
@@ -76,8 +76,10 @@ class CleanTicketDTO(BaseModel):
             else:
                 return TEXT_STATUS_MAP.get(value.lower(), "Unknown")
 
-        return STATUS_MAP.get(int(v), "Unknown")
+        if not isinstance(v, int) and not str(v).isdigit():
+            return "Unknown"
 
+        return STATUS_MAP.get(int(v), "Unknown")
     @field_validator("priority", mode="before")
     @classmethod
     def _validate_priority(

--- a/src/shared/dto.py
+++ b/src/shared/dto.py
@@ -20,6 +20,9 @@ STATUS_MAP = {
     6: "Closed",
 }
 
+# Map textual statuses (e.g., "closed") to the same canonical labels
+TEXT_STATUS_MAP = {label.lower(): label for label in STATUS_MAP.values()}
+
 PRIORITY_MAP = {
     1: "Very Low",
     2: "Low",
@@ -63,8 +66,17 @@ class CleanTicketDTO(BaseModel):
 
     @field_validator("status", mode="before")
     @classmethod
-    def _validate_status(cls, v: int) -> str:  # pragma: no cover - simple mapping
-        return STATUS_MAP.get(v, "Unknown")
+    def _validate_status(cls, v: int | str) -> str:  # pragma: no cover - simple mapping
+        """Normalize integer or textual status values to labels."""
+
+        if isinstance(v, str):
+            value = v.strip()
+            if value.isdigit():
+                v = int(value)
+            else:
+                return TEXT_STATUS_MAP.get(value.lower(), "Unknown")
+
+        return STATUS_MAP.get(int(v), "Unknown")
 
     @field_validator("priority", mode="before")
     @classmethod

--- a/tests/test_clean_ticket_dto.py
+++ b/tests/test_clean_ticket_dto.py
@@ -64,3 +64,18 @@ def test_clean_ticket_dto_missing_optional_fields():
 
     assert ticket.priority is None
     assert ticket.created_at is None
+
+
+@pytest.mark.unit
+def test_clean_ticket_dto_text_status():
+    """Textual status values should be normalized."""
+
+    data = {
+        "id": 3,
+        "name": "Network issue",
+        "status": "closed",
+    }
+
+    ticket = CleanTicketDTO.model_validate(data)
+
+    assert ticket.status == "Closed"


### PR DESCRIPTION
## Summary
- normalize textual ticket statuses in CleanTicketDTO
- test CleanTicketDTO with string status
- document status normalization in CHANGELOG

## Testing
- `pre-commit run --files src/shared/dto.py tests/test_clean_ticket_dto.py docs/CHANGELOG.md`
- `PYTEST_ADDOPTS='--cov-fail-under=0' .venv/bin/pytest tests/test_clean_ticket_dto.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687f256adc948320a826cc837f936ea0

## Resumo por Sourcery

Normalizar valores de status de ticket inteiros e textuais para rótulos canônicos em CleanTicketDTO, e atualizar testes e documentação de acordo

Melhorias:
- Aceitar e normalizar status de ticket textuais em CleanTicketDTO

Documentação:
- Documentar a normalização de status para valores textuais no CHANGELOG

Testes:
- Adicionar teste unitário para normalização de status de string em CleanTicketDTO

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Normalize integer and textual ticket status values to canonical labels in CleanTicketDTO, and update tests and documentation accordingly

Enhancements:
- Accept and normalize textual ticket statuses in CleanTicketDTO

Documentation:
- Document status normalization for textual values in CHANGELOG

Tests:
- Add unit test for string status normalization in CleanTicketDTO

</details>