### PR TITLE
Refactor React hooks for unified API access

### DIFF
--- a/src/frontend/react_app/src/App.test.tsx
+++ b/src/frontend/react_app/src/App.test.tsx
@@ -51,7 +51,12 @@ describe('App Integration', () => {
   })
 
   it('renders loading state initially', () => {
-    useTicketsMock.mockReturnValue({ tickets: [], isLoading: true, error: null })
+    useTicketsMock.mockReturnValue({
+      tickets: [],
+      isLoading: true,
+      isSuccess: false,
+      error: null,
+    })
     useChamadosPorDataMock.mockReturnValue({ data: [], isLoading: true })
     useChamadosPorDiaMock.mockReturnValue({ data: [], isLoading: true })
 
@@ -66,6 +71,7 @@ describe('App Integration', () => {
     useTicketsMock.mockReturnValue({
       tickets: mockTickets,
       isLoading: false,
+      isSuccess: true,
       error: null,
     })
     useChamadosPorDataMock.mockReturnValue({
@@ -92,7 +98,12 @@ describe('App Integration', () => {
   })
 
   it('renders error messages if data fetching fails', () => {
-    useTicketsMock.mockReturnValue({ tickets: [], isLoading: false, error: { message: 'Falha ao buscar tickets' } })
+    useTicketsMock.mockReturnValue({
+      tickets: [],
+      isLoading: false,
+      isSuccess: false,
+      error: { message: 'Falha ao buscar tickets' },
+    })
     useChamadosPorDataMock.mockReturnValue({ data: [], isLoading: false, isError: true })
     useChamadosPorDiaMock.mockReturnValue({ data: [], isLoading: false, error: true })
 

--- a/src/frontend/react_app/src/components/GlpiTicketsTable.tsx
+++ b/src/frontend/react_app/src/components/GlpiTicketsTable.tsx
@@ -1,5 +1,4 @@
-import { useQuery } from '@tanstack/react-query'
-import { fetcher } from '@/lib/swrClient'
+import { useApiQuery } from '../hooks/useApiQuery'
 
 interface Ticket {
   id: number
@@ -10,13 +9,18 @@ interface Ticket {
 }
 
 export function GlpiTicketsTable() {
-  const { data: tickets, isLoading, error } = useQuery<Ticket[]>({
-    queryKey: ['tickets'],
-    queryFn: () => fetcher<Ticket[]>('/tickets'),
-  })
+  const {
+    data: tickets,
+    isLoading,
+    error,
+    isSuccess,
+  } = useApiQuery<Ticket[], Error>(['tickets'], '/tickets')
 
   if (isLoading) return <p>Carregando...</p>
   if (error) return <p>Erro ao buscar tickets</p>
+  if (isSuccess && (!tickets || tickets.length === 0)) {
+    return <p>Nenhum chamado encontrado</p>
+  }
 
   const formatDate = (value?: string | null) => {
     if (!value) return '-'

--- a/src/frontend/react_app/src/components/TicketsDisplay.test.tsx
+++ b/src/frontend/react_app/src/components/TicketsDisplay.test.tsx
@@ -26,6 +26,7 @@ describe('TicketsDisplay Component', () => {
       tickets: undefined,
       error: undefined,
       isLoading: true,
+      isSuccess: false,
       refreshTickets: jest.fn(),
     })
 
@@ -41,6 +42,7 @@ describe('TicketsDisplay Component', () => {
       tickets: undefined,
       error: new Error('Falha na API'),
       isLoading: false,
+      isSuccess: false,
       refreshTickets: refreshSpy,
     })
 
@@ -59,6 +61,7 @@ describe('TicketsDisplay Component', () => {
       tickets: [],
       error: undefined,
       isLoading: false,
+      isSuccess: true,
       refreshTickets: refreshSpy,
     })
 
@@ -79,6 +82,7 @@ describe('TicketsDisplay Component', () => {
       tickets: mockTickets,
       error: undefined,
       isLoading: false,
+      isSuccess: true,
       refreshTickets: jest.fn(),
     })
 

--- a/src/frontend/react_app/src/components/TicketsDisplay.tsx
+++ b/src/frontend/react_app/src/components/TicketsDisplay.tsx
@@ -5,7 +5,7 @@ import { ErrorMessage } from './ErrorMessage'
 import { EmptyState } from './EmptyState'
 
 function TicketsDisplay() {
-  const { tickets, error, isLoading, refreshTickets } = useTickets()
+  const { tickets, error, isLoading, isSuccess, refreshTickets } = useTickets()
 
   if (isLoading) {
     return <LoadingSpinner />
@@ -21,7 +21,7 @@ function TicketsDisplay() {
     )
   }
 
-  if (!tickets || tickets.length === 0) {
+  if (isSuccess && (!tickets || tickets.length === 0)) {
     return <EmptyState
       title="Nenhum chamado encontrado"
       message="Não há chamados para exibir no momento."

--- a/src/frontend/react_app/src/hooks/useChamadosPorData.ts
+++ b/src/frontend/react_app/src/hooks/useChamadosPorData.ts
@@ -3,28 +3,28 @@
 // Deve ativar refetch automático ao focar a janela
 // Pode incluir refetchInterval para polling se necessário
 
-import { useQuery } from '@tanstack/react-query'
-import { fetchChamadosPorData } from '../services/api'
+import { useApiQuery } from './useApiQuery'
+import type { ChamadoPorData } from '../types/chamado'
 
 /**
  * Hook to fetch "chamados" grouped by date using React Query v5.
- * 
+ *
  * This hook leverages caching to minimize unnecessary refetching and supports
  * automatic refetching when the window regains focus. It can also be configured
  * for polling by uncommenting the `refetchInterval` option.
- * 
- * @returns {import('@tanstack/react-query').UseQueryResult} - The result object from React Query, 
+ *
+ * @returns {import('@tanstack/react-query').UseQueryResult} - The result object from React Query,
  * including the fetched data, loading state, and error information.
- * 
+ *
  * @example
  * import { useChamadosPorData } from './hooks/useChamadosPorData';
- * 
+ *
  * function ChamadosComponent() {
  *   const { data, isLoading, error } = useChamadosPorData();
- * 
+ *
  *   if (isLoading) return <p>Loading...</p>;
  *   if (error) return <p>Error: {error.message}</p>;
- * 
+ *
  *   return (
  *     <ul>
  *       {data.map(chamado => (
@@ -35,12 +35,14 @@ import { fetchChamadosPorData } from '../services/api'
  * }
  */
 export function useChamadosPorData() {
-  return useQuery({
-    queryKey: ['chamados-por-data'],
-    queryFn: fetchChamadosPorData,
-    staleTime: 1000 * 60 * 5, // 5 minutos
-    gcTime: 1000 * 60 * 10, // 10 minutos
-    refetchOnWindowFocus: true,
-    // refetchInterval: 30000, // descomente para polling a cada 30s
-  })
+  return useApiQuery<ChamadoPorData[], Error>(
+    ['chamados-por-data'],
+    '/chamados/por-data',
+    {
+      staleTime: 1000 * 60 * 5, // 5 minutos
+      gcTime: 1000 * 60 * 10, // 10 minutos
+      refetchOnWindowFocus: true,
+      // refetchInterval: 30000, // descomente para polling a cada 30s
+    },
+  )
 }

--- a/src/frontend/react_app/src/hooks/useTickets.ts
+++ b/src/frontend/react_app/src/hooks/useTickets.ts
@@ -28,6 +28,7 @@ export function useTickets() {
     tickets,
     error: query.error,
     isLoading: query.isLoading,
+    isSuccess: query.isSuccess,
     refreshTickets,
   }
 }

--- a/src/frontend/react_app/src/services/api.ts
+++ b/src/frontend/react_app/src/services/api.ts
@@ -1,6 +1,1 @@
-import { fetcher } from '../lib/swrClient'
-import type { ChamadoPorData } from '../types/chamado'
-
-export async function fetchChamadosPorData(): Promise<ChamadoPorData[]> {
-  return fetcher<ChamadoPorData[]>('/chamados/por-data')
-}
+// Deprecated: direct data fetching helpers have been replaced by `useApiQuery`.

--- a/src/frontend/react_app/tests/hooks/useTickets.test.tsx
+++ b/src/frontend/react_app/tests/hooks/useTickets.test.tsx
@@ -16,6 +16,7 @@ test('fetches tickets from API', async () => {
   const { result } = renderHook(() => useTickets(), { wrapper })
   expect(result.current.isLoading).toBe(true)
   await waitFor(() => expect(result.current.isLoading).toBe(false))
+  expect(result.current.isSuccess).toBe(true)
   expect(result.current.tickets).toHaveLength(1)
   expect(result.current.tickets?.[0].name).toBe('t1')
 })
@@ -28,4 +29,5 @@ test('handles API error', async () => {
 
   const { result } = renderHook(() => useTickets(), { wrapper })
   await waitFor(() => expect(result.current.error).toBeTruthy())
+  expect(result.current.isSuccess).toBe(false)
 })

--- a/src/frontend/react_app/tests/profile.spec.tsx
+++ b/src/frontend/react_app/tests/profile.spec.tsx
@@ -28,7 +28,12 @@ jest.mock('../src/hooks/useChamadosPorDia', () => ({
 }))
 
 jest.mock('../src/hooks/useTickets', () => ({
-  useTickets: () => ({ tickets: [], isLoading: false, error: null }),
+  useTickets: () => ({
+    tickets: [],
+    isLoading: false,
+    isSuccess: true,
+    error: null,
+  }),
 }))
 
 // JSDOM lacks ResizeObserver used by Recharts


### PR DESCRIPTION
## Summary
- update `useTickets` to expose `isSuccess`
- show empty state only after query success
- migrate `GlpiTicketsTable` and `useChamadosPorData` to `useApiQuery`
- adjust related tests and mocks
- deprecate direct fetching helper

## Testing
- `make test` *(fails: GLPI session tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_687fad02bf9c83209af106262300decd

## Resumo por Sourcery

Refatorar componentes e hooks React para aproveitar um hook `useApiQuery` unificado para busca de dados, introduzir flags `isSuccess` para controlar estados de carregamento e vazios, depreciar antigos helpers de busca direta e atualizar todos os testes e mocks afetados de acordo.

Melhorias:
- Substituir chamadas individuais de `useQuery` em `useChamadosPorData`, `GlpiTicketsTable` e módulos relacionados pelo hook `useApiQuery` padronizado
- Estender o hook `useTickets` para expor uma flag `isSuccess` e ajustar os componentes para exibir estados vazios apenas após buscas bem-sucedidas
- Depreciar o helper standalone `fetchChamadosPorData` em favor de `useApiQuery`

Testes:
- Atualizar testes unitários e de integração para verificar o novo campo `isSuccess` e ajustar mocks em `TicketsDisplay`, `useTickets` e testes de integração do App

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor React components and hooks to leverage a unified useApiQuery hook for data fetching, introduce isSuccess flags to control loading and empty states, deprecate old direct fetching helpers, and update all affected tests and mocks accordingly.

Enhancements:
- Replace individual useQuery calls in useChamadosPorData, GlpiTicketsTable, and related modules with the standardized useApiQuery hook
- Extend the useTickets hook to expose an isSuccess flag and adjust components to only display empty states after successful fetches
- Deprecate the standalone fetchChamadosPorData helper in favor of useApiQuery

Tests:
- Update unit and integration tests to assert the new isSuccess field and adjust mocks across TicketsDisplay, useTickets, and App integration tests

</details>