### PR TITLE
docs: update node instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,8 +133,17 @@ This starts PostgreSQL, Redis, the FastAPI worker and the Dash app. Access the d
 
 - Python 3.10\u20133.12
 - PostgreSQL and Redis instances running locally (or update the `.env` file)
-- Node.js >=20.19.0 is required to run the React frontend locally.
-  Install it with [nvm](https://github.com/nvm-sh/nvm):
+- Node.js >=20.19.0 is required to run the React frontend locally. The required
+  version is stored in the `.nvmrc` file at the repository root. If you use
+  [mise](https://github.com/jdx/mise) for tool management run the following once
+  to silence the deprecation warning about `.nvmrc`:
+
+  ```bash
+  mise settings add idiomatic_version_file_enable_tools node
+  ```
+
+  Install the same version with [nvm](https://github.com/nvm-sh/nvm) if you
+  prefer:
 
   ```bash
   nvm install 20.19.0

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ This starts PostgreSQL, Redis, the FastAPI worker and the Dash app. Access the d
   prefer:
 
   ```bash
-  nvm install 20.19.0
+  nvm install
   nvm use 20.19.0
   ```
 

--- a/docs/install_quickstart.md
+++ b/docs/install_quickstart.md
@@ -74,12 +74,15 @@ Copy the React environment file, install Node packages and run Vite:
 ```bash
 cp src/frontend/react_app/.env.example src/frontend/react_app/.env
 cd src/frontend/react_app
-nvm install 20.19.0
+# optional but recommended with mise to avoid the .nvmrc warning
+mise settings add idiomatic_version_file_enable_tools node
+nvm install 20.19.0  # version pinned in the repository's .nvmrc
 nvm use 20.19.0
 npm install         # installs dotenv, @eslint/js and other dev dependencies
 # npm ci can be used for reproducible installs
 npm run dev
 ```
+The exact Node version is pinned in `.nvmrc` at the repository root.
 Docker Compose automatically loads `.env` when present.
 Docker can be used if you cannot install the required Node version.
 

--- a/docs/install_quickstart.md
+++ b/docs/install_quickstart.md
@@ -76,8 +76,8 @@ cp src/frontend/react_app/.env.example src/frontend/react_app/.env
 cd src/frontend/react_app
 # optional but recommended with mise to avoid the .nvmrc warning
 mise settings add idiomatic_version_file_enable_tools node
-nvm install 20.19.0  # version pinned in the repository's .nvmrc
-nvm use 20.19.0
+nvm install  # installs the version pinned in the repository's .nvmrc
+nvm use
 npm install         # installs dotenv, @eslint/js and other dev dependencies
 # npm ci can be used for reproducible installs
 npm run dev


### PR DESCRIPTION
## Summary
- mention `.nvmrc` and `mise` in dependency setup
- add optional `mise` command in quickstart guide

## Testing
- `pre-commit run --files README.md docs/install_quickstart.md`
- `pytest -p no:cov --override-ini addopts=''` *(fails: ModuleNotFoundError: No module named 'playwright')*

------
https://chatgpt.com/codex/tasks/task_e_6880480d42cc8320b0f694a0e3cf3f6f

## Resumo por Sourcery

Atualiza a documentação de configuração do Node.js para referenciar o arquivo `.nvmrc` do repositório para o travamento de versão e adiciona um comando opcional do `mise` para suprimir avisos de depreciação do `.nvmrc`

Documentação:
- Esclarece que a versão exata do Node está travada no `.nvmrc` na raiz do repositório, tanto no README quanto no guia de início rápido
- Apresenta um comando opcional `mise settings add idiomatic_version_file_enable_tools node` para silenciar os avisos do `.nvmrc`

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update Node.js setup documentation to reference the repository’s .nvmrc for version pinning and add an optional mise command to suppress .nvmrc deprecation warnings

Documentation:
- Clarify that the exact Node version is pinned in .nvmrc at the repository root in both README and quickstart guide
- Introduce an optional `mise settings add idiomatic_version_file_enable_tools node` command to silence .nvmrc warnings

</details>