### PR TITLE
Add React hook tests

### DIFF
--- a/src/frontend/react_app/src/hooks/__tests__/useApiQuery.test.tsx
+++ b/src/frontend/react_app/src/hooks/__tests__/useApiQuery.test.tsx
@@ -5,8 +5,13 @@ import { useApiQuery } from '../useApiQuery'
 jest.mock('axios')
 const mockedAxios = axios as jest.Mocked<typeof axios>
 
-process.env.NEXT_PUBLIC_API_BASE_URL = 'http://test-api.com'
+beforeAll(() => {
+  process.env.NEXT_PUBLIC_API_BASE_URL = 'http://test-api.com';
+});
 
+afterAll(() => {
+  delete process.env.NEXT_PUBLIC_API_BASE_URL;
+});
 // Helper to make fetch use axios under the hood
 beforeEach(() => {
   mockedAxios.mockReset()

--- a/src/frontend/react_app/src/hooks/__tests__/useApiQuery.test.tsx
+++ b/src/frontend/react_app/src/hooks/__tests__/useApiQuery.test.tsx
@@ -1,0 +1,46 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import axios from 'axios'
+import { useApiQuery } from '../useApiQuery'
+
+jest.mock('axios')
+const mockedAxios = axios as jest.Mocked<typeof axios>
+
+process.env.NEXT_PUBLIC_API_BASE_URL = 'http://test-api.com'
+
+// Helper to make fetch use axios under the hood
+beforeEach(() => {
+  mockedAxios.mockReset()
+  global.fetch = jest.fn((url: RequestInfo, options?: RequestInit) =>
+    mockedAxios.get(url.toString(), { signal: options?.signal }).then(res => ({
+      ok: true,
+      status: 200,
+      json: async () => res.data,
+    }))
+  ) as unknown as typeof fetch
+})
+
+describe('useApiQuery', () => {
+  it('updates state on success', async () => {
+    mockedAxios.get.mockResolvedValue({ data: { foo: 'bar' } })
+    const { result } = renderHook(() => useApiQuery('/test'))
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.data).toEqual({ foo: 'bar' })
+    expect(result.current.error).toBeNull()
+  })
+
+  it('updates state on error', async () => {
+    mockedAxios.get.mockRejectedValue(new Error('fail'))
+    const { result } = renderHook(() => useApiQuery('/test'))
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.data).toBeNull()
+    expect(result.current.error).toBe('fail')
+  })
+
+  it('ignores abort errors', async () => {
+    mockedAxios.get.mockRejectedValue({ name: 'AbortError', message: 'aborted' })
+    const { result } = renderHook(() => useApiQuery('/test'))
+    await waitFor(() => expect(mockedAxios.get).toHaveBeenCalled())
+    expect(result.current.isLoading).toBe(true)
+    expect(result.current.error).toBeNull()
+  })
+})

--- a/src/frontend/react_app/src/hooks/__tests__/useDashboardData.test.tsx
+++ b/src/frontend/react_app/src/hooks/__tests__/useDashboardData.test.tsx
@@ -1,0 +1,33 @@
+import { renderHook } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { useDashboardData } from '../useDashboardData'
+import { useApiQuery } from '../useApiQuery'
+
+jest.mock('../useApiQuery')
+
+describe('useDashboardData refresh interval', () => {
+  beforeEach(() => {
+    (useApiQuery as jest.Mock).mockReturnValue({
+      data: { status: {} },
+      isLoading: false,
+      error: null,
+    })
+    process.env.NEXT_PUBLIC_API_BASE_URL = 'http://test'
+  })
+
+  it('clears refresh interval on unmount', () => {
+    const clearSpy = jest.spyOn(global, 'clearInterval')
+    const setSpy = jest
+      .spyOn(global, 'setInterval')
+      .mockReturnValue(123 as unknown as NodeJS.Timer)
+
+    const queryClient = new QueryClient()
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+    const { unmount } = renderHook(() => useDashboardData(), { wrapper })
+    unmount()
+    expect(clearSpy).toHaveBeenCalledWith(123)
+    setSpy.mockRestore()
+  })
+})

--- a/src/frontend/react_app/src/hooks/__tests__/useDashboardData.test.tsx
+++ b/src/frontend/react_app/src/hooks/__tests__/useDashboardData.test.tsx
@@ -6,15 +6,21 @@ import { useApiQuery } from '../useApiQuery'
 jest.mock('../useApiQuery')
 
 describe('useDashboardData refresh interval', () => {
+  beforeAll(() => {
+    process.env.NEXT_PUBLIC_API_BASE_URL = 'http://test'
+  })
+
   beforeEach(() => {
     (useApiQuery as jest.Mock).mockReturnValue({
       data: { status: {} },
       isLoading: false,
       error: null,
     })
-    process.env.NEXT_PUBLIC_API_BASE_URL = 'http://test'
   })
 
+  afterAll(() => {
+    delete process.env.NEXT_PUBLIC_API_BASE_URL
+  })
   it('clears refresh interval on unmount', () => {
     const clearSpy = jest.spyOn(global, 'clearInterval')
     const setSpy = jest


### PR DESCRIPTION
## Summary
- add unit tests for useApiQuery covering success, error, and abort scenarios
- add useDashboardData test verifying the refresh interval cleanup

## Testing
- `npx jest src/hooks/__tests__/useDashboardData.test.tsx --config jest.config.ts --runInBand --no-cache`
- `npx jest src/hooks/__tests__/useApiQuery.test.tsx --config jest.config.ts --runInBand --no-cache`
- `npm test -- -w 1 --silent` *(fails: Unable to find an element with the text)*

------
https://chatgpt.com/codex/tasks/task_e_68804822fbb08320b4294e1e3eaae208

## Resumo por Sourcery

Adiciona testes unitários abrangentes para os hooks React `useApiQuery` e `useDashboardData`

Testes:
- Adiciona testes unitários para `useApiQuery` cobrindo cenários de sucesso, erro e aborto
- Adiciona teste unitário para `useDashboardData` para verificar a limpeza do intervalo de atualização

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add comprehensive unit tests for the useApiQuery and useDashboardData React hooks

Tests:
- Add unit tests for useApiQuery covering success, error, and abort scenarios
- Add unit test for useDashboardData to verify refresh interval cleanup

</details>