### PR TITLE
Add React hook tests

### DIFF
--- a/src/frontend/react_app/src/hooks/__tests__/useApiQuery.test.tsx
+++ b/src/frontend/react_app/src/hooks/__tests__/useApiQuery.test.tsx
@@ -1,0 +1,59 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import axios from 'axios'
+import { useApiQuery } from '../useApiQuery'
+
+jest.mock('axios')
+const mockedAxios = axios as jest.Mocked<typeof axios>
+
+process.env.NEXT_PUBLIC_API_BASE_URL = 'http://test-api.com'
+
+// Helper to make fetch use axios under the hood
+beforeEach(() => {
+  mockedAxios.mockReset()
+  global.fetch = jest.fn((url: RequestInfo, options?: RequestInit) =>
+    mockedAxios.get(url.toString(), { signal: options?.signal }).then(res => ({
+      ok: res.status ? res.status >= 200 && res.status < 300 : true,
+      status: res.status || 200,
+      statusText: res.statusText || 'OK',
+      json: async () => res.data,
+    }))
+  ) as unknown as typeof fetch
+})
+
+describe('useApiQuery', () => {
+  it('updates state on success', async () => {
+    mockedAxios.get.mockResolvedValue({ data: { foo: 'bar' } })
+    const { result } = renderHook(() => useApiQuery('/test'))
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.data).toEqual({ foo: 'bar' })
+    expect(result.current.error).toBeNull()
+  })
+
+  it('updates state on error', async () => {
+    mockedAxios.get.mockRejectedValue(new Error('fail'))
+    const { result } = renderHook(() => useApiQuery('/test'))
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.data).toBeNull()
+    expect(result.current.error).toBe('fail')
+  })
+
+  it('updates state on non-ok response', async () => {
+    mockedAxios.get.mockResolvedValue({
+      data: { message: 'Not Found' },
+      status: 404,
+      statusText: 'Not Found',
+    })
+    const { result } = renderHook(() => useApiQuery('/test'))
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.data).toBeNull()
+    expect(result.current.error).toContain('Erro na requisição: Not Found')
+  })
+
+  it('ignores abort errors', async () => {
+    mockedAxios.get.mockRejectedValue({ name: 'AbortError', message: 'aborted' })
+    const { result } = renderHook(() => useApiQuery('/test'))
+    await waitFor(() => expect(mockedAxios.get).toHaveBeenCalled())
+    expect(result.current.isLoading).toBe(true)
+    expect(result.current.error).toBeNull()
+  })
+})

--- a/src/frontend/react_app/src/hooks/__tests__/useDashboardData.test.tsx
+++ b/src/frontend/react_app/src/hooks/__tests__/useDashboardData.test.tsx
@@ -1,0 +1,33 @@
+import { renderHook } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { useDashboardData } from '../useDashboardData'
+import { useApiQuery } from '../useApiQuery'
+
+jest.mock('../useApiQuery')
+
+describe('useDashboardData refresh interval', () => {
+  beforeEach(() => {
+    (useApiQuery as jest.Mock).mockReturnValue({
+      data: { status: {} },
+      isLoading: false,
+      error: null,
+    })
+    process.env.NEXT_PUBLIC_API_BASE_URL = 'http://test'
+  })
+
+  it('clears refresh interval on unmount', () => {
+    const clearSpy = jest.spyOn(global, 'clearInterval')
+    const setSpy = jest
+      .spyOn(global, 'setInterval')
+      .mockReturnValue(123 as unknown as NodeJS.Timer)
+
+    const queryClient = new QueryClient()
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+    const { unmount } = renderHook(() => useDashboardData(), { wrapper })
+    unmount()
+    expect(clearSpy).toHaveBeenCalledWith(123)
+    setSpy.mockRestore()
+  })
+})


### PR DESCRIPTION
## Summary
- improve axios mocking in `useApiQuery.test` and add non-ok response case
- ensure dashboard refresh interval cleanup works

## Testing
- `NEXT_PUBLIC_API_BASE_URL=http://test npx jest src/hooks/__tests__/useApiQuery.test.tsx --runInBand --no-cache`
- `NEXT_PUBLIC_API_BASE_URL=http://test npx jest src/hooks/__tests__/useDashboardData.test.tsx --runInBand --no-cache`
- `NEXT_PUBLIC_API_BASE_URL=http://test make test-frontend` *(fails: 7 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_68804822fbb08320b4294e1e3eaae208