### PR TITLE
refactor: simplify useApiQuery calls

### DIFF
--- a/docs/developer_usage.md
+++ b/docs/developer_usage.md
@@ -190,11 +190,11 @@ Altere as opções padrão do `queryClient` nesse arquivo para ajustar
 
 ### Padrão de uso do `useApiQuery`
 
-O helper `useApiQuery` padroniza chamadas ao worker API. Ele recebe um
-`queryKey`, o `endpoint` e quaisquer opções do React Query:
+O helper `useApiQuery` padroniza chamadas ao worker API. Ele recebe o
+`endpoint` e, opcionalmente, um objeto de opções:
 
 ```ts
-const { data, isLoading } = useApiQuery(['tickets'], '/tickets')
+const { data, isLoading } = useApiQuery('/tickets')
 ```
 
 Internamente a função utiliza o `fetcher` definido em `src/lib/swrClient.ts`.
@@ -206,7 +206,7 @@ de lógica adicional:
 
 ```ts
 export function useUsuarios() {
-  return useApiQuery(['usuarios'], '/usuarios')
+  return useApiQuery('/usuarios')
 }
 ```
 

--- a/src/frontend/react_app/src/components/GlpiTicketsTable.tsx
+++ b/src/frontend/react_app/src/components/GlpiTicketsTable.tsx
@@ -14,7 +14,7 @@ export function GlpiTicketsTable() {
     isLoading,
     error,
     isSuccess,
-  } = useApiQuery<Ticket[], Error>(['tickets'], '/tickets')
+  } = useApiQuery<Ticket[], Error>('/tickets')
 
   if (isLoading) return <p>Carregando...</p>
   if (error) return <p>Erro ao buscar tickets</p>

--- a/src/frontend/react_app/src/features/tickets/api.ts
+++ b/src/frontend/react_app/src/features/tickets/api.ts
@@ -2,5 +2,5 @@ import { useApiQuery } from '../../hooks/useApiQuery'
 import type { TicketMetrics } from '../../types/dashboard'
 
 export function useTicketMetrics() {
-  return useApiQuery<TicketMetrics, Error>(['metrics'], '/metrics')
+  return useApiQuery<TicketMetrics, Error>('/metrics')
 }

--- a/src/frontend/react_app/src/hooks/useChamadosPorData.ts
+++ b/src/frontend/react_app/src/hooks/useChamadosPorData.ts
@@ -35,14 +35,10 @@ import type { ChamadoPorData } from '../types/chamado'
  * }
  */
 export function useChamadosPorData() {
-  return useApiQuery<ChamadoPorData[], Error>(
-    ['chamados-por-data'],
-    '/chamados/por-data',
-    {
-      staleTime: 1000 * 60 * 5, // 5 minutos
-      gcTime: 1000 * 60 * 10, // 10 minutos
-      refetchOnWindowFocus: true,
-      // refetchInterval: 30000, // descomente para polling a cada 30s
-    },
-  )
+  return useApiQuery<ChamadoPorData[], Error>('/chamados/por-data', {
+    staleTime: 1000 * 60 * 5, // 5 minutos
+    gcTime: 1000 * 60 * 10, // 10 minutos
+    refetchOnWindowFocus: true,
+    // refetchInterval: 30000, // descomente para polling a cada 30s
+  })
 }

--- a/src/frontend/react_app/src/hooks/useChamadosPorDia.ts
+++ b/src/frontend/react_app/src/hooks/useChamadosPorDia.ts
@@ -2,15 +2,11 @@ import { useApiQuery } from './useApiQuery'
 import type { ChamadoPorDia } from '../types/chamado'
 
 export function useChamadosPorDia() {
-  const query = useApiQuery<ChamadoPorDia[], Error>(
-    ['chamados-por-dia'],
-    '/chamados/por-dia',
-    {
-      select: (data: ChamadoPorDia[]) =>
-        data.map((d) => ({ date: d.date, total: Number(d.total) })),
-      refetchInterval: 60000,
-    },
-  )
+  const query = useApiQuery<ChamadoPorDia[], Error>('/chamados/por-dia', {
+    select: (data: ChamadoPorDia[]) =>
+      data.map((d) => ({ date: d.date, total: Number(d.total) })),
+    refetchInterval: 60000,
+  })
 
   return {
     data: query.data ?? [],

--- a/src/frontend/react_app/src/hooks/useDashboardData.ts
+++ b/src/frontend/react_app/src/hooks/useDashboardData.ts
@@ -14,10 +14,7 @@ interface Aggregated {
 
 export function useDashboardData() {
   const queryClient = useQueryClient()
-  const query = useApiQuery<Aggregated, Error>(
-    ['metrics-aggregated'],
-    '/metrics/aggregated',
-  )
+  const query = useApiQuery<Aggregated, Error>('/metrics/aggregated')
 
   const metrics: Metrics = {
     new: query.data?.status?.new ?? 0,

--- a/src/frontend/react_app/src/hooks/useTickets.ts
+++ b/src/frontend/react_app/src/hooks/useTickets.ts
@@ -18,7 +18,7 @@ function toTicket(dto: CleanTicketDTO): Ticket {
 
 export function useTickets() {
   const queryClient = useQueryClient()
-  const query = useApiQuery<CleanTicketDTO[], Error>(['tickets'], '/tickets')
+  const query = useApiQuery<CleanTicketDTO[], Error>('/tickets')
   const tickets = useMemo(() => query.data?.map(toTicket), [query.data])
 
   const refreshTickets = () =>


### PR DESCRIPTION
## Summary
- update hooks to call `useApiQuery` with endpoint only
- adjust `useChamadosPorData` and `useChamadosPorDia` option arguments
- simplify ticket metrics and tickets table hooks
- update docs with new `useApiQuery` usage

## Testing
- `npm test --silent` *(fails: Element type is invalid)*
- `pytest -q` *(fails: unrecognized arguments)*

------
https://chatgpt.com/codex/tasks/task_e_6880531ab94483208e7b819ae362d3b8

## Resumo por Sourcery

Simplificar o uso de `useApiQuery` removendo o parâmetro explícito `query key` e atualizando os hooks e a documentação afetados

Melhorias:
- Refatorar os hooks `useChamadosPorData`, `useChamadosPorDia`, `useDashboardData`, `useTicketMetrics`, `useTickets` e `GlpiTicketsTable` para chamar `useApiQuery` apenas com `endpoint` e `options`

Documentação:
- Atualizar `developer_usage.md` para refletir a nova assinatura e exemplos de uso de `useApiQuery`

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Simplify useApiQuery usage by removing the explicit query key parameter and updating affected hooks and documentation

Enhancements:
- Refactor useChamadosPorData, useChamadosPorDia, useDashboardData, useTicketMetrics, useTickets and GlpiTicketsTable hooks to call useApiQuery with endpoint and options only

Documentation:
- Update developer_usage.md to reflect the new useApiQuery signature and usage examples

</details>