### PR TITLE
Fix query options passed as params

### DIFF
--- a/src/frontend/react_app/src/hooks/useChamadosPorData.ts
+++ b/src/frontend/react_app/src/hooks/useChamadosPorData.ts
@@ -35,10 +35,14 @@ import type { ChamadoPorData } from '../types/chamado'
  * }
  */
 export function useChamadosPorData() {
-  return useApiQuery<ChamadoPorData[], Error>('/chamados/por-data', {
-    staleTime: 1000 * 60 * 5, // 5 minutos
-    gcTime: 1000 * 60 * 10, // 10 minutos
-    refetchOnWindowFocus: true,
-    // refetchInterval: 30000, // descomente para polling a cada 30s
-  })
+  return useApiQuery<ChamadoPorData[], Error>(
+    '/chamados/por-data',
+    undefined,
+    {
+      staleTime: 1000 * 60 * 5, // 5 minutos
+      gcTime: 1000 * 60 * 10, // 10 minutos
+      refetchOnWindowFocus: true,
+      // refetchInterval: 30000, // descomente para polling a cada 30s
+    },
+  )
 }

--- a/src/frontend/react_app/src/hooks/useChamadosPorDia.ts
+++ b/src/frontend/react_app/src/hooks/useChamadosPorDia.ts
@@ -2,11 +2,15 @@ import { useApiQuery } from './useApiQuery'
 import type { ChamadoPorDia } from '../types/chamado'
 
 export function useChamadosPorDia() {
-  const query = useApiQuery<ChamadoPorDia[], Error>('/chamados/por-dia', {
-    select: (data: ChamadoPorDia[]) =>
-      data.map((d) => ({ date: d.date, total: Number(d.total) })),
-    refetchInterval: 60000,
-  })
+  const query = useApiQuery<ChamadoPorDia[], Error>(
+    '/chamados/por-dia',
+    undefined,
+    {
+      select: (data: ChamadoPorDia[]) =>
+        data.map((d) => ({ date: d.date, total: Number(d.total) })),
+      refetchInterval: 60000,
+    },
+  )
 
   return {
     data: query.data ?? [],


### PR DESCRIPTION
## Summary
- separate React Query options from URL params in hooks

## Testing
- `pytest -q` *(fails: 37 errors during collection)*
- `npm test` *(fails to run tests due to Jest ESM issues)*

------
https://chatgpt.com/codex/tasks/task_e_6880687df6ec832090dbbd6479427be2