### PR TITLE
Restrict CORS configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,3 +51,11 @@ USE_MOCK_DATA=false
 
 # Log level for the backend application.
 LOG_LEVEL=INFO
+
+# Allowed CORS origins when APP_ENV=production
+# Example: API_CORS_ALLOW_ORIGINS=https://dashboard.example.com
+API_CORS_ALLOW_ORIGINS=
+
+# Allowed HTTP methods in production
+# Example: API_CORS_ALLOW_METHODS=GET,POST
+API_CORS_ALLOW_METHODS=GET,HEAD,OPTIONS

--- a/README.md
+++ b/README.md
@@ -620,6 +620,8 @@ container also executes on first startup.
 - `CACHE_TYPE` – choose `redis` (default) or `simple` for in-memory caching
 - `LOG_LEVEL` – logging verbosity for backend and worker services (default `INFO`)
 - `APP_ENV` – set to `production` for JSON logs without backtraces
+- `API_CORS_ALLOW_ORIGINS` – comma-separated list of trusted origins when `APP_ENV=production`
+- `API_CORS_ALLOW_METHODS` – comma-separated HTTP methods allowed in production (default `GET,HEAD,OPTIONS`)
 - `LANGCHAIN_TRACING_V2` – set to `true` to enable LangSmith tracing
 - `LANGCHAIN_API_KEY` – API key used by LangSmith when tracing
 - `LANGCHAIN_PROJECT` – optional project name for tracing sessions


### PR DESCRIPTION
## Summary
- limit allowed origins and HTTP methods in worker API when `APP_ENV=production`
- document `API_CORS_ALLOW_ORIGINS` and `API_CORS_ALLOW_METHODS`
- show example values in `.env.example`

## Testing
- `pre-commit run --files src/backend/api/worker_api.py README.md .env.example`
- `pytest -p no:cov -o addopts=''` *(fails: PytestUnknownMarkWarning and other collection errors)*

------
https://chatgpt.com/codex/tasks/task_e_688071fe06348320be8e5725f35198e8

## Resumo por Sourcery

Restringir CORS na API do worker para ambientes de produção, carregando origens e métodos permitidos de `API_CORS_ALLOW_ORIGINS` e `API_CORS_ALLOW_METHODS`, enquanto preserva a configuração CORS irrestrita em desenvolvimento.

Novos Recursos:
- Restringir a configuração CORS em produção, lendo origens e métodos permitidos de variáveis de ambiente

Melhorias:
- Manter as configurações CORS abertas em desenvolvimento para compatibilidade com versões anteriores

Documentação:
- Documentar `API_CORS_ALLOW_ORIGINS` e `API_CORS_ALLOW_METHODS` no README
- Adicionar valores de exemplo para as novas variáveis de ambiente CORS em `.env.example`

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restrict CORS in the worker API for production environments by loading allowed origins and methods from API_CORS_ALLOW_ORIGINS and API_CORS_ALLOW_METHODS, while preserving the unrestricted CORS setup in development

New Features:
- Restrict CORS configuration in production by reading allowed origins and methods from environment variables

Enhancements:
- Keep open CORS settings in development for backward compatibility

Documentation:
- Document API_CORS_ALLOW_ORIGINS and API_CORS_ALLOW_METHODS in the README
- Add example values for the new CORS environment variables in .env.example

</details>