### PR TITLE
Implement useApiQuery hook

### DIFF
--- a/src/frontend/react_app/src/hooks/useApiQuery.ts
+++ b/src/frontend/react_app/src/hooks/useApiQuery.ts
@@ -1,0 +1,67 @@
+import { useMemo } from 'react'
+import {
+  useQuery,
+  type UseQueryResult,
+  type UseQueryOptions,
+  type QueryKey,
+} from '@tanstack/react-query'
+import { fetcher } from '../lib/swrClient'
+import { stableStringify } from '../lib/stableStringify'
+
+function getBaseUrl(): string | undefined {
+  return process.env.NEXT_PUBLIC_API_BASE_URL
+}
+
+export function useApiQuery<TData = unknown, TError = unknown>(
+  queryKey: QueryKey,
+  endpoint: string,
+  options: Omit<UseQueryOptions<TData, TError>, 'queryKey' | 'queryFn'> = {},
+): UseQueryResult<TData, TError> {
+  const baseUrl = getBaseUrl()
+
+  const key = useMemo(
+    () =>
+      Array.isArray(queryKey)
+        ? queryKey.map((k) =>
+            typeof k === 'object'
+              ? stableStringify(k as Record<string, unknown>)
+              : k,
+          )
+        : [queryKey],
+    [queryKey],
+  )
+
+  return useQuery<TData, TError>({
+    queryKey: key,
+    ...options,
+    enabled: options.enabled ?? true,
+    queryFn: async ({ signal }) => {
+      if (!endpoint) {
+        throw new Error('Endpoint não fornecido.')
+      }
+      if (!baseUrl) {
+        throw new Error(
+          'URL base da API não configurada. Verifique NEXT_PUBLIC_API_BASE_URL.',
+        )
+      }
+
+      const controller = new AbortController()
+      const abort = () => controller.abort()
+
+      if (signal) {
+        if (signal.aborted) abort()
+        else signal.addEventListener('abort', abort)
+      }
+
+      try {
+        return await fetcher<TData>(
+          endpoint,
+          { signal: controller.signal },
+          { baseUrl },
+        )
+      } finally {
+        if (signal) signal.removeEventListener('abort', abort)
+      }
+    },
+  })
+}

--- a/src/frontend/react_app/src/lib/swrClient.ts
+++ b/src/frontend/react_app/src/lib/swrClient.ts
@@ -3,13 +3,8 @@ export async function fetcher<T>(
   init: RequestInit = {},
   opts: { timeoutMs?: number; baseUrl?: string } = {}
 ): Promise<T> {
-  const metaEnv: Record<string, string | undefined> | undefined =
-    typeof import.meta !== 'undefined' && import.meta.env
-      ? import.meta.env
-      : undefined;
   const base =
     opts.baseUrl ??
-    metaEnv?.NEXT_PUBLIC_API_BASE_URL ??
     process.env.NEXT_PUBLIC_API_BASE_URL ??
     'http://localhost:8000'
 


### PR DESCRIPTION
## Summary
- implement `useApiQuery` using React Query
- use `process.env` in fetcher and the new hook

## Testing
- `npm test` *(fails: various tests errors)*

------
https://chatgpt.com/codex/tasks/task_e_6880763205f48320bbe9d01ea0429bc4