### PR TITLE
Update useApiQuery tests

### DIFF
--- a/src/frontend/react_app/tsconfig.test.json
+++ b/src/frontend/react_app/tsconfig.test.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "jsx": "react-jsx",
     "module": "CommonJS",
+    "moduleResolution": "Node",
     "esModuleInterop": true,
     "verbatimModuleSyntax": false,
     "types": ["jest", "@testing-library/jest-dom", "node"]


### PR DESCRIPTION
## Summary
- adjust `useApiQuery` tests to match final hook
- configure TypeScript test compiler for Node

## Testing
- `make test-backend` *(fails: dash_bootstrap_components missing)*
- `npm test --silent` in `src/frontend/react_app` *(fails: SyntaxError: Cannot use 'import.meta' outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68807c0d36d88320b441003731c1e28c

## Resumo por Sourcery

Atualiza os testes de `useApiQuery` para se alinhar com a assinatura final da API do hook e configura o TypeScript para Node no ambiente de teste

Build:
- Atualiza `tsconfig.test.json` para configurar o compilador TypeScript para Node nos testes

Testes:
- Envolve as chamadas de `renderHook` com `QueryClientProvider` e inicializa `QueryClient` em `beforeEach`
- Ajusta os testes para usar `query keys` e opções explícitas, atualizando as expectativas de dados/erro para corresponder às mudanças do hook
- Adiciona testes para o tratamento de erro para URL base de API ausente e para a geração de `query key` baseada em opções

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update useApiQuery tests to align with the hook’s final API signature and configure TypeScript for Node in the test environment

Build:
- Update tsconfig.test.json to configure the TypeScript compiler for Node in tests

Tests:
- Wrap renderHook calls with QueryClientProvider and initialize QueryClient in beforeEach
- Adjust tests to use explicit query keys and options, updating data/error expectations to match the hook changes
- Add tests for missing API base URL error handling and for option-based query key generation

</details>