### PR TITLE
Fix dev server port

### DIFF
--- a/README.md
+++ b/README.md
@@ -769,6 +769,7 @@ need browser automation.
 The frontend image takes advantage of BuildKit caching to speed up subsequent `npm ci` runs. Ensure BuildKit is enabled by setting `DOCKER_BUILDKIT=1`.
 
 This exposes the worker API on port `8000` and the dashboard on port `5174`.
+Open `http://localhost:5174` in your browser once the containers are ready.
 
 ## Configuration Management
 

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -18,7 +18,7 @@ services:
       dockerfile: src/frontend/react_app/Dockerfile
       target: dev  # Usa o estágio de desenvolvimento
     ports:
-      - "5173:5173"  # Porta padrão do Vite
+      - "5174:5174"  # Porta padrão do Vite
     environment:
       NEXT_PUBLIC_API_BASE_URL: http://localhost:8000/api
     volumes:

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -18,7 +18,7 @@ services:
       dockerfile: src/frontend/react_app/Dockerfile
       target: dev  # Usa o estágio de desenvolvimento
     ports:
-      - "5174:5174"  # Porta padrão do Vite
+      - "5174:5174"  # Porta customizada do Vite
     environment:
       NEXT_PUBLIC_API_BASE_URL: http://localhost:8000/api
     volumes:


### PR DESCRIPTION
## Summary
- correct frontend port in docker-compose override
- note `http://localhost:5174` in README

## Testing
- `pre-commit run --files README.md docker-compose.override.yml`
- `pytest -p no:cov -c /tmp/pytest_custom.ini` *(fails: ModuleNotFoundError: 'playwright', 'libcst', 'pandas', 'redis', 'pydantic', 'loguru', 'sqlalchemy', ...)*

------
https://chatgpt.com/codex/tasks/task_e_688080b40a648320a5da09b2a16ac762

## Resumo por Sourcery

Corrige o mapeamento da porta do servidor de desenvolvimento frontend e atualiza o README com o URL correto.

Correções de Bug:
- Altera o mapeamento da porta do servidor de desenvolvimento Vite de 5173 para 5174 em docker-compose.override.yml

Documentação:
- Adiciona uma nota no README para abrir http://localhost:5174 assim que os contêineres estiverem prontos

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix the frontend development server port mapping and update the README with the correct URL.

Bug Fixes:
- Change the Vite dev server port mapping from 5173 to 5174 in docker-compose.override.yml

Documentation:
- Add a note in the README to open http://localhost:5174 once the containers are ready

</details>