### PR TITLE
Rename API env var

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,1 +1,1 @@
-VITE_API_BASE_URL=http://localhost:8000
+NEXT_PUBLIC_API_BASE_URL=http://localhost:8000

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -89,7 +89,7 @@ responsible for API calls verifies that `NEXT_PUBLIC_API_BASE_URL` is defined
 
 The React code can read this value using `import.meta.env.NEXT_PUBLIC_API_BASE_URL` to send requests to the worker.
 
-> **Note**: previous revisions referenced `VITE_API_URL`. The variable name was updated to `NEXT_PUBLIC_API_BASE_URL` to match Next.js conventions.
+> **Note**: this variable was renamed to `NEXT_PUBLIC_API_BASE_URL` to match Next.js conventions.
 
 Vite only exposes variables prefixed with `VITE_` by default. The project configures `envPrefix` in `vite.config.ts` so that `NEXT_PUBLIC_*` variables are also loaded.
 

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -89,7 +89,7 @@ responsible for API calls verifies that `NEXT_PUBLIC_API_BASE_URL` is defined
 
 The React code can read this value using `import.meta.env.NEXT_PUBLIC_API_BASE_URL` to send requests to the worker.
 
-> **Note**: this variable was renamed to `NEXT_PUBLIC_API_BASE_URL` to match Next.js conventions.
+> **Note**: this variable was renamed from `VITE_API_URL` to `NEXT_PUBLIC_API_BASE_URL` to match Next.js conventions. This change ensures compatibility with Next.js, which uses the `NEXT_PUBLIC_` prefix for environment variables exposed to the browser.
 
 Vite only exposes variables prefixed with `VITE_` by default. The project configures `envPrefix` in `vite.config.ts` so that `NEXT_PUBLIC_*` variables are also loaded.
 


### PR DESCRIPTION
## Summary
- use `NEXT_PUBLIC_API_BASE_URL` variable in `.env.local`
- clarify the variable rename in frontend docs

## Testing
- `pre-commit run --files .env.local docs/frontend_architecture.md`
- `pytest -q -c /dev/null tests/test_backend_config.py`
- `npm test` *(fails: SyntaxError: Cannot use 'import.meta' outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_688080b2b058832085870b9c4cb2c5c5

## Resumo por Sourcery

Renomeia a variável de ambiente da URL base da API para NEXT_PUBLIC_API_BASE_URL e atualiza a documentação relacionada

Melhorias:
- Atualiza .env.local para usar NEXT_PUBLIC_API_BASE_URL em vez da variável antiga

Documentação:
- Esclarece na documentação da arquitetura de frontend que a variável de ambiente da API foi renomeada para NEXT_PUBLIC_API_BASE_URL para corresponder às convenções do Next.js

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Rename the API base URL environment variable to NEXT_PUBLIC_API_BASE_URL and update related documentation

Enhancements:
- Update .env.local to use NEXT_PUBLIC_API_BASE_URL instead of the old variable

Documentation:
- Clarify in frontend architecture docs that the API env var was renamed to NEXT_PUBLIC_API_BASE_URL to match Next.js conventions

</details>