### PR TITLE
Unify API base URL variable

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,1 +1,1 @@
-VITE_API_BASE_URL=http://localhost:8000
+NEXT_PUBLIC_API_BASE_URL=http://localhost:8000

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -1,2 +1,3 @@
-- `NEXT_PUBLIC_API_BASE_URL`: must point to `http://localhost:8000` when running under Docker Compose network.
+- `NEXT_PUBLIC_API_BASE_URL`: must point to `http://localhost:8000` when running under Docker Compose.
+  You can also create `.env.local` with this setting for local scripts outside Docker.
 - `DISALLOWED_PROXIES`: comma-separated list of proxy hosts ignored by `scripts/validate_credentials.py`.


### PR DESCRIPTION
## Summary
- keep a single API base URL variable
- mention `.env.local` in docs

## Testing
- `pre-commit run --files .env.local`
- `npm test --silent` *(fails: Cannot use 'import.meta' outside a module)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'playwright')*

------
https://chatgpt.com/codex/tasks/task_e_68807df2885c8320aa98f02d99021609

## Resumo por Sourcery

Consolidar a URL base da API em uma única variável de ambiente e atualizar a documentação para referenciar .env.local para scripts locais.

Aprimoramentos:
- Unificar o uso da URL base da API sob NEXT_PUBLIC_API_BASE_URL
- Permitir que .env.local defina NEXT_PUBLIC_API_BASE_URL para scripts locais fora do Docker

Documentação:
- Esclarecer as instruções do Docker Compose e mencionar .env.local em docs/ENVIRONMENT.md

Tarefas:
- Adicionar arquivo .env.local para configurações de variáveis de ambiente locais

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Consolidate the API base URL into a single environment variable and update documentation to reference .env.local for local scripts.

Enhancements:
- Unify API base URL usage under NEXT_PUBLIC_API_BASE_URL
- Allow .env.local to define NEXT_PUBLIC_API_BASE_URL for local scripts outside Docker

Documentation:
- Clarify Docker Compose instructions and mention .env.local in docs/ENVIRONMENT.md

Chores:
- Add .env.local file for local environment variable settings

</details>