### PR TITLE
Update Jest testMatch

### DIFF
--- a/src/frontend/react_app/jest.config.ts
+++ b/src/frontend/react_app/jest.config.ts
@@ -10,7 +10,10 @@ const config: Config = {
     ],
   },
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
-  testMatch: ['<rootDir>/src/**/*.test.ts?(x)'],
+  testMatch: [
+    '<rootDir>/src/**/*.test.ts?(x)',
+    '<rootDir>/tests/**/*.test.ts?(x)',
+  ],
   moduleFileExtensions: ['ts', 'tsx', 'js'],
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',


### PR DESCRIPTION
## Summary
- include tests directory in `testMatch` pattern for the React app

## Testing
- `npm test` *(fails: Cannot use 'import.meta' outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_688083a88ea48320b5b26dd2fb53ea27

## Resumo por Sourcery

Melhorias:
- Adicionar '<rootDir>/tests/**/*.test.ts?(x)' aos padrões de testMatch do Jest

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Add '<rootDir>/tests/**/*.test.ts?(x)' to Jest testMatch patterns

</details>