### PR TITLE
Fix docker dev URL

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -20,7 +20,7 @@ services:
     ports:
       - "5174:5174"  # Porta customizada do Vite
     environment:
-      NEXT_PUBLIC_API_BASE_URL: http://localhost:8000/api
+      NEXT_PUBLIC_API_BASE_URL: http://localhost:8000
     volumes:
       # Mounts local source code for live-reloading, and uses a named volume
       # to persist node_modules, preventing it from being overwritten by the host.


### PR DESCRIPTION
## Summary
- set NEXT_PUBLIC_API_BASE_URL without `/api` in docker-compose.override.yml

## Testing
- `make test-backend` *(fails: GLPI session tests)*

------
https://chatgpt.com/codex/tasks/task_e_6880fb2912788320880971d30bd9481b