### PR TITLE
Add pagination to TicketsDisplay

### DIFF
--- a/src/frontend/react_app/src/components/TicketTable.tsx
+++ b/src/frontend/react_app/src/components/TicketTable.tsx
@@ -1,28 +1,11 @@
-import { useApiQuery } from '../hooks/useApiQuery'
-import { VirtualizedTicketTable, type TicketRow } from './VirtualizedTicketTable';
-import type { Ticket } from '../types/ticket';
+import { VirtualizedTicketTable, type TicketRow } from './VirtualizedTicketTable'
+import type { Ticket } from '../types/ticket'
 
-// A interface para a resposta esperada da API.
-// A API pode retornar um objeto com uma chave 'tickets'.
-interface TicketsApiResponse {
-  tickets: Ticket[];
+export interface TicketTableProps {
+  tickets: Ticket[]
 }
 
-export function TicketTable() {
-  const { data, isLoading, error } = useApiQuery<TicketsApiResponse>(
-    ['tickets'],
-    '/tickets',
-  );
-
-  if (isLoading) {
-    return <div className="p-4 text-center">Carregando chamados...</div>;
-  }
-
-  if (error) {
-    return <div className="p-4 text-center text-red-600">Erro ao carregar dados: {error}</div>;
-  }
-
-  const tickets = data?.tickets ?? [];
+export function TicketTable({ tickets }: TicketTableProps) {
 
   if (tickets.length === 0) {
     return <div className="p-4 text-center">Nenhum chamado encontrado.</div>;

--- a/src/frontend/react_app/src/components/TicketsDisplay.test.tsx
+++ b/src/frontend/react_app/src/components/TicketsDisplay.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import { jest } from '@jest/globals'
 
@@ -67,11 +67,11 @@ describe('TicketsDisplay Component', () => {
     expect(refreshSpy).toHaveBeenCalled()
   })
 
-  it('deve renderizar a tabela de tickets quando os dados são recebidos com sucesso', () => {
-    const mockTickets = [
-      { id: 1, name: 'Problema na impressora', status: 'New', priority: 'High' },
-      { id: 2, name: 'Rede lenta', status: 'Open', priority: 'Low' },
-    ]
+  it('deve paginar os tickets corretamente', () => {
+    const mockTickets = Array.from({ length: 20 }, (_, i) => ({
+      id: i + 1,
+      name: `Ticket ${i + 1}`,
+    }))
 
     useTicketsMock.mockReturnValue({
       tickets: mockTickets,
@@ -83,9 +83,12 @@ describe('TicketsDisplay Component', () => {
 
     render(<TicketsDisplay />)
 
-    expect(screen.getByText(/dashboard de chamados glpi/i)).toBeInTheDocument()
-    expect(screen.getByText(/problema na impressora/i)).toBeInTheDocument()
-    expect(screen.getByText(/rede lenta/i)).toBeInTheDocument()
-    expect(screen.getByRole('table')).toBeInTheDocument()
+    expect(screen.getByText('Ticket 1')).toBeInTheDocument()
+    expect(screen.queryByText('Ticket 16')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByLabelText('Próxima página'))
+
+    expect(screen.getByText('Ticket 16')).toBeInTheDocument()
+    expect(screen.queryByText('Ticket 1')).not.toBeInTheDocument()
   })
 })

--- a/src/frontend/react_app/src/components/TicketsDisplay.tsx
+++ b/src/frontend/react_app/src/components/TicketsDisplay.tsx
@@ -1,11 +1,25 @@
+import { useState, useMemo, useEffect } from 'react'
 import { useTickets } from '../hooks/useTickets'
 import { TicketTable } from './TicketTable'
 import { LoadingSpinner } from './LoadingSpinner'
 import { ErrorMessage } from './ErrorMessage'
 import { EmptyState } from './EmptyState'
+import Pagination from './Pagination'
 
 function TicketsDisplay() {
   const { tickets, error, isLoading, isSuccess, refreshTickets } = useTickets()
+  const [currentPage, setCurrentPage] = useState(1)
+  const ITEMS_PER_PAGE = 15
+
+  useEffect(() => {
+    setCurrentPage(1)
+  }, [tickets])
+
+  const paginatedTickets = useMemo(
+    () => tickets?.slice((currentPage - 1) * ITEMS_PER_PAGE, currentPage * ITEMS_PER_PAGE) ?? [],
+    [tickets, currentPage]
+  )
+  const totalPages = tickets ? Math.ceil(tickets.length / ITEMS_PER_PAGE) : 1
 
   if (isLoading) {
     return <LoadingSpinner />
@@ -33,7 +47,15 @@ function TicketsDisplay() {
   return (
     <div>
       <h1 className="text-2xl font-bold mb-4">Dashboard de Chamados GLPI</h1>
-      <TicketTable tickets={tickets} />
+      <TicketTable tickets={paginatedTickets} />
+      {totalPages > 1 && (
+        <Pagination
+          className="mt-4"
+          currentPage={currentPage}
+          totalPages={totalPages}
+          onPageChange={setCurrentPage}
+        />
+      )}
     </div>
   )
 }

--- a/src/frontend/react_app/src/components/TicketsDisplay.tsx
+++ b/src/frontend/react_app/src/components/TicketsDisplay.tsx
@@ -6,10 +6,11 @@ import { ErrorMessage } from './ErrorMessage'
 import { EmptyState } from './EmptyState'
 import Pagination from './Pagination'
 
+const ITEMS_PER_PAGE = 15;
+
 function TicketsDisplay() {
   const { tickets, error, isLoading, isSuccess, refreshTickets } = useTickets()
   const [currentPage, setCurrentPage] = useState(1)
-  const ITEMS_PER_PAGE = 15
 
   useEffect(() => {
     setCurrentPage(1)

--- a/src/frontend/react_app/src/components/__tests__/TicketTable.test.tsx
+++ b/src/frontend/react_app/src/components/__tests__/TicketTable.test.tsx
@@ -1,10 +1,5 @@
 import { render, screen } from '@testing-library/react';
 import { TicketTable } from '../TicketTable';
-import { useApiQuery } from '../../hooks/useApiQuery';
-
-// Mock do hook useApiQuery
-jest.mock('../../hooks/useApiQuery');
-const mockedUseApiQuery = useApiQuery as jest.Mock;
 
 // Mock do componente de virtualização para simplificar o teste
 jest.mock('../VirtualizedTicketTable', () => ({
@@ -18,64 +13,21 @@ jest.mock('../VirtualizedTicketTable', () => ({
 }));
 
 describe('TicketTable', () => {
-  beforeEach(() => {
-    // Limpa os mocks antes de cada teste
-    mockedUseApiQuery.mockClear();
-  });
-
-  it('deve exibir a mensagem de carregamento enquanto os dados são buscados', () => {
-    mockedUseApiQuery.mockReturnValue({
-      data: null,
-      isLoading: true,
-      error: null,
-    });
-
-    render(<TicketTable />);
-
-    expect(screen.getByText('Carregando chamados...')).toBeInTheDocument();
-  });
-
-  it('deve exibir uma mensagem de erro se a busca falhar', () => {
-    const errorMessage = 'Falha na rede';
-    mockedUseApiQuery.mockReturnValue({
-      data: null,
-      isLoading: false,
-      error: errorMessage,
-    });
-
-    render(<TicketTable />);
-
-    expect(screen.getByText(`Erro ao carregar dados: ${errorMessage}`)).toBeInTheDocument();
-  });
-
   it('deve exibir uma mensagem quando nenhum chamado for encontrado', () => {
-    mockedUseApiQuery.mockReturnValue({
-      data: { tickets: [] },
-      isLoading: false,
-      error: null,
-    });
-
-    render(<TicketTable />);
+    render(<TicketTable tickets={[]} />);
 
     expect(screen.getByText('Nenhum chamado encontrado.')).toBeInTheDocument();
   });
 
-  it('deve renderizar a tabela com os dados dos chamados quando a busca for bem-sucedida', async () => {
+  it('deve renderizar a tabela com os dados dos chamados', async () => {
     const mockTickets = [
-      { id: 1, name: 'Problema na impressora', status: 'new', priority: 3, date_creation: new Date().toISOString() },
-      { id: 2, name: 'PC não liga', status: 'assigned', priority: 5, date_creation: new Date().toISOString() },
+      { id: 1, name: 'Problema na impressora', status: 'new', priority: 3 },
+      { id: 2, name: 'PC não liga', status: 'assigned', priority: 5 },
     ];
-    mockedUseApiQuery.mockReturnValue({
-      data: { tickets: mockTickets },
-      isLoading: false,
-      error: null,
-    });
 
-    render(<TicketTable />);
+    render(<TicketTable tickets={mockTickets as any} />);
 
-    // Verifica se a tabela virtualizada está presente
     expect(screen.getByTestId('virtualized-table')).toBeInTheDocument();
-    // Verifica se os nomes dos tickets estão no documento (simulando a renderização da tabela)
     expect(screen.getByText('Problema na impressora')).toBeInTheDocument();
     expect(screen.getByText('PC não liga')).toBeInTheDocument();
   });

--- a/src/frontend/react_app/src/components/__tests__/TicketTableRender.test.tsx
+++ b/src/frontend/react_app/src/components/__tests__/TicketTableRender.test.tsx
@@ -1,10 +1,6 @@
 import { render, screen } from '@testing-library/react'
 import type { Ticket } from '../../types/ticket'
 import { TicketTable } from '../../components/TicketTable'
-import { useApiQuery } from '../../hooks/useApiQuery'
-
-jest.mock('../../hooks/useApiQuery')
-const useApiQueryMock = useApiQuery as jest.Mock
 
 const ticket: Ticket = {
   id: 1,
@@ -15,13 +11,8 @@ const ticket: Ticket = {
 }
 
 describe('TicketTable formatting', () => {
-  beforeEach(() => {
-    useApiQueryMock.mockReset()
-  })
-
   it('formats date and applies styles', () => {
-    useApiQueryMock.mockReturnValue({ data: { tickets: [ticket] }, isLoading: false, error: null })
-    render(<TicketTable />)
+    render(<TicketTable tickets={[ticket]} />)
     const titleCell = screen.getByText(ticket.name)
     expect(titleCell).toHaveAttribute('title', ticket.name)
     expect(screen.getByText('High')).toHaveClass('text-red-600')
@@ -33,8 +24,7 @@ describe('TicketTable formatting', () => {
   })
 
   it('displays fallbacks when data is missing', () => {
-    useApiQueryMock.mockReturnValue({ data: { tickets: [{ id: 99 } as Ticket] }, isLoading: false, error: null })
-    render(<TicketTable />)
+    render(<TicketTable tickets={[{ id: 99 } as Ticket]} />)
     const row = screen.getAllByRole('row')[1]
     expect(row).toHaveTextContent('Sem prioridade')
     // priority and date columns should show "-"


### PR DESCRIPTION
## Summary
- paginate tickets in TicketsDisplay
- accept `tickets` prop in TicketTable
- render pagination component
- update related tests

## Testing
- `npm test src/components/TicketsDisplay.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68814119d24083208de3ec95eb040713

## Resumo por Sourcery

Adicionar suporte à paginação ao componente `TicketsDisplay` e refatorar `TicketTable` para ser controlado por `props`, atualizando os testes de acordo.

Novas Funcionalidades:
- Implementar paginação em `TicketsDisplay` com fatiamento de página, redefinição da página na mudança de dados e um componente `Pagination`.

Melhorias:
- Refatorar `TicketTable` para aceitar uma `prop` `tickets` em vez de buscar dados internamente via `useApiQuery`.

Testes:
- Atualizar testes de `TicketTable` para usar a `prop` `tickets` e remover mocks de `useApiQuery`.
- Adicionar um teste para `TicketsDisplay` para verificar o comportamento da paginação entre as páginas.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add pagination support to the TicketsDisplay component and refactor TicketTable to be prop-driven, updating tests accordingly

New Features:
- Implement pagination in TicketsDisplay with page slicing, page reset on data change, and a Pagination component

Enhancements:
- Refactor TicketTable to accept a tickets prop instead of fetching data internally via useApiQuery

Tests:
- Update TicketTable tests to use the tickets prop and remove useApiQuery mocks
- Add a TicketsDisplay test to verify pagination behavior across pages

</details>