### PR TITLE
Add normalization dataframe tests

### DIFF
--- a/tests/test_normalization.py
+++ b/tests/test_normalization.py
@@ -1,0 +1,53 @@
+import pytest
+
+from backend.adapters.normalization import (
+    aggregate_by_user,
+    filter_by_status,
+    sanitize_status_column,
+    to_dataframe,
+)
+
+pytest.importorskip("pandas")
+
+
+@pytest.fixture()
+def ticket_list():
+    return [
+        {"id": "1", "status": "New", "assigned_to": "alice", "group": "N1"},
+        {"id": None, "status": None, "group": "N2"},
+        {"status": "PENDING", "assigned_to": None, "group": None},
+    ]
+
+
+@pytest.fixture()
+def ticket_df(ticket_list):
+    return to_dataframe(ticket_list)
+
+
+def test_to_dataframe_converts_and_sets_defaults(ticket_df):
+    assert ticket_df.dtypes["id"] == "int32"
+    assert str(ticket_df.dtypes["status"]) == "category"
+    assert str(ticket_df.dtypes["assigned_to"]) == "category"
+    assert str(ticket_df.dtypes["group"]) == "category"
+
+    assert ticket_df["id"].tolist() == [1, 0, 0]
+    assert ticket_df["assigned_to"].tolist() == ["alice", "", ""]
+    assert ticket_df["group"].tolist() == ["N1", "N2", ""]
+    assert ticket_df["status"].tolist() == ["New", "", "PENDING"]
+
+
+def test_filter_by_status(ticket_df):
+    closed = filter_by_status(ticket_df, "New")
+    assert closed["id"].tolist() == [1]
+
+
+def test_aggregate_by_user(ticket_df):
+    result = aggregate_by_user(ticket_df)
+    counts = dict(zip(result["assigned_to"], result["count"]))
+    assert counts == {"alice": 1, "": 2}
+
+
+def test_sanitize_status_column(ticket_df):
+    sanitized = sanitize_status_column(ticket_df)
+    assert sanitized["status"].tolist() == ["new", "", "pending"]
+    assert sanitized["status"].dtype == object

--- a/tests/test_normalization.py
+++ b/tests/test_normalization.py
@@ -43,7 +43,7 @@ def test_filter_by_status(ticket_df):
 
 def test_aggregate_by_user(ticket_df):
     result = aggregate_by_user(ticket_df)
-    counts = dict(zip(result["assigned_to"], result["count"]))
+    counts = result.set_index("assigned_to")["count"].to_dict()
     assert counts == {"alice": 1, "": 2}
 
 


### PR DESCRIPTION
## Summary
- add unit tests for backend normalization helpers

## Testing
- `pytest -q -p no:cov -o addopts='' tests/test_normalization.py`


------
https://chatgpt.com/codex/tasks/task_e_68814462dee48320b2c859e226fa8f14

## Resumo pelo Sourcery

Adicionar testes unitários abrangentes para auxiliares de dataframe de normalização para validar a conversão de dados, filtragem, agregação e sanitização de status

Testes:
- Adicionar testes para a conversão `to_dataframe` e atribuições de valores padrão
- Adicionar testes para a funcionalidade `filter_by_status`
- Adicionar testes para as contagens por usuário de `aggregate_by_user`
- Adicionar testes para a normalização de maiúsculas/minúsculas e o `dtype` da coluna `sanitize_status_column`

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add comprehensive unit tests for normalization dataframe helpers to validate data conversion, filtering, aggregation, and status sanitization

Tests:
- Add tests for to_dataframe conversion and default value assignments
- Add tests for filter_by_status functionality
- Add tests for aggregate_by_user counts per user
- Add tests for sanitize_status_column case normalization and dtype

</details>