### PR TITLE
Fix isort order in glpi error tests

### DIFF
--- a/tests/test_glpi_errors.py
+++ b/tests/test_glpi_errors.py
@@ -1,9 +1,8 @@
 from typing import Optional
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import pytest
-
 import aiohttp
+import pytest
 
 from backend.domain.exceptions import (
     GLPIAPIError,


### PR DESCRIPTION
## Summary
- reorder imports in `tests/test_glpi_errors.py`

## Testing
- `pre-commit run --files tests/test_glpi_errors.py`
- `isort --check-only tests/test_glpi_errors.py`

------
https://chatgpt.com/codex/tasks/task_e_6881493bb404832088975072e8febdb2

## Resumo por Sourcery

Melhorias:
- Reordenar imports em tests/test_glpi_errors.py para conformidade com isort.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Reorder imports in tests/test_glpi_errors.py for isort compliance.

</details>