### PR TITLE
Fix invalid noqa rule for GLPI session

### DIFF
--- a/src/backend/infrastructure/glpi/glpi_session.py
+++ b/src/backend/infrastructure/glpi/glpi_session.py
@@ -401,7 +401,7 @@ class GLPISession:
             if self._session_token and not self._using_user_token:
                 try:
                     await self._kill_session()
-                except Exception as e:  # noqa: B902
+                except Exception as e:  # noqa: BLE001
                     logger.error("Failed to kill session: %s", e)
             else:
                 # Ensure token is cleared when killSession is skipped
@@ -531,7 +531,7 @@ class GLPISession:
                 raise
             except aiohttp.ClientError as e:
                 self._raise_client_error(e)
-            except Exception as e:  # noqa: B902
+            except Exception as e:  # noqa: BLE001
                 if isinstance(e, GLPIAPIError):
                     raise
                 raise GLPIAPIError(0, f"An unexpected error occurred: {e}") from e


### PR DESCRIPTION
## Summary
- use BLE001 for broad `except Exception` in GLPISession
- run ruff and pre-commit hooks

## Testing
- `pre-commit run --files src/backend/infrastructure/glpi/glpi_session.py`
- `ruff check src`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'playwright')*

------
https://chatgpt.com/codex/tasks/task_e_68814b25f8188320bfa1942874088bd7

## Resumo por Sourcery

Correções de Bugs:
- Corrigir o código de supressão noqa inválido de B902 para BLE001 nos blocos de exceção genéricos de GLPISession

Tarefas:
- Aplicar correções do ruff e do pre-commit hook à formatação do código

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix lint rule suppression in GLPISession and apply ruff/pre-commit formatting

Bug Fixes:
- Correct the invalid noqa suppression code from B902 to BLE001 in GLPISession broad except blocks

Chores:
- Apply ruff and pre-commit hook fixes to code formatting

</details>