### PR TITLE
Add Storybook guidelines and update agent flow

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -173,6 +173,10 @@ Após o pipeline A1-A9, pegue cada **Prompt Final** de A8 (um para cada artefato
     - `tests/test_helpers.py` (512 bytes) - Movido para acompanhar mudanças em `src/utils/helpers.py`.
     ```
 
+Front-end components seguem um fluxo próprio descrito em
+`src/frontend/react_app/AGENTS.md`. Esse arquivo define agentes adicionais,
+incluindo o passo **A16** para geração de histórias do Storybook.
+
 ---
 
 ### B1 — Agente Validador de Código

--- a/docs/developer_usage.md
+++ b/docs/developer_usage.md
@@ -234,7 +234,7 @@ cd src/frontend/react_app
 npm run storybook
 ```
 
-Este comando abre a interface em <http://localhost:6006>. Utilize as histórias
+Este comando abre a interface em <http://localhost:6006> (porta padrão, configurável). Utilize as histórias
 para validar diferentes estados (carregando, erro, sucesso) antes de integrar
 ao fluxo principal.
 

--- a/docs/developer_usage.md
+++ b/docs/developer_usage.md
@@ -225,6 +225,19 @@ Defina `staleTime` para controlar quando os dados tornam-se obsoletos e use
 `invalidateQueries` após operações de gravação. Também é possível definir
 `refetchInterval` em hooks específicos para manter métricas em tempo real.
 
+### Storybook
+
+Para visualizar os componentes React de forma isolada, execute:
+
+```bash
+cd src/frontend/react_app
+npm run storybook
+```
+
+Este comando abre a interface em <http://localhost:6006>. Utilize as histórias
+para validar diferentes estados (carregando, erro, sucesso) antes de integrar
+ao fluxo principal.
+
 ### Executando o Rope codemod
 
 Refatorações estruturais podem ser automatizadas com `scripts/run_py_codemod.sh`. O script usa o `refactor_move.py` da biblioteca Rope para mover módulos e atualizar os imports automaticamente.

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -154,8 +154,8 @@ the configuration and dashboard.
 
 ### Storybook
 
-Run Storybook to preview components in isolation. Inside
-`src/frontend/react_app` execute:
+Execute o Storybook para visualizar componentes isoladamente. Dentro de
+`src/frontend/react_app`, execute:
 
 ```bash
 npm run storybook      # inicia em http://localhost:6006

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -152,6 +152,19 @@ wraps `App` inside `React.Profiler` to push render timings via
 Refer to [docs/observability.md](observability.md) for a complete example of
 the configuration and dashboard.
 
+### Storybook
+
+Run Storybook to preview components in isolation. Inside
+`src/frontend/react_app` execute:
+
+```bash
+npm run storybook      # inicia em http://localhost:6006
+npm run build-storybook  # gera a versão estática em storybook-static/
+```
+
+Use these stories to validate different loading states and to document props
+automatically via the `autodocs` tag.
+
 ## 7. Code generation with Plop
 
 Reusable boilerplate for new React components and Dash modules is created with

--- a/docs/install_quickstart.md
+++ b/docs/install_quickstart.md
@@ -83,6 +83,7 @@ npm install         # installs dotenv, @eslint/js and other dev dependencies
 # dotenv is required for environment variables loaded during tests
 # npm ci can be used for reproducible installs
 npm run dev
+npm run storybook   # optional: preview UI components locally
 ```
 The exact Node version is pinned in `.nvmrc` at the repository root.
 Docker Compose automatically loads `.env` when present.

--- a/src/frontend/react_app/AGENTS.md
+++ b/src/frontend/react_app/AGENTS.md
@@ -144,6 +144,25 @@ Gere o código de testes completo.
 
 ---
 
+## A16 — Gerador de Histórias (Storybook)
+
+```text
+# Identidade
+Especialista em documentação de componentes React.
+
+# Instruções
+* Crie `<component>.stories.tsx` com exemplos de estados.
+* Utilize `tags: ['autodocs']` para habilitar documentação automática.
+
+# Contexto
+Componente React já implementado e hooks correspondentes.
+
+# Pergunta
+Gere a história completa incluindo variações de sucesso, carregamento e erro.
+```
+
+---
+
 ### Sequência Frontend
 
 ```text
@@ -157,4 +176,6 @@ A10 → A11 → A12
    (se aprovado)
         ↓
       A15
+        ↓
+      A16
 ```

--- a/src/frontend/react_app/AGENTS.md
+++ b/src/frontend/react_app/AGENTS.md
@@ -151,7 +151,7 @@ Gere o código de testes completo.
 Especialista em documentação de componentes React.
 
 # Instruções
-* Crie `<component>.stories.tsx` com exemplos de estados.
+* Crie `Component.stories.tsx` com exemplos de estados.
 * Utilize `tags: ['autodocs']` para habilitar documentação automática.
 
 # Contexto


### PR DESCRIPTION
## Summary
- document Storybook commands for the React app
- include Storybook usage in quickstart and developer guides
- extend frontend agent pipeline with A16 for Storybook stories
- reference the new step from the root AGENTS file

## Testing
- `pre-commit run --files docs/frontend_architecture.md docs/install_quickstart.md docs/developer_usage.md src/frontend/react_app/AGENTS.md docs/AGENTS.md`
- `make test` *(fails: ModuleNotFoundError: dash_bootstrap_components)*

------
https://chatgpt.com/codex/tasks/task_e_68818e2d486c8320ae7d4f70bae805be

## Resumo por Sourcery

Adicionar diretrizes do Storybook em várias documentações e estender o fluxo de trabalho dos AGENTS de frontend com uma nova etapa A16 para gerar histórias de componentes do Storybook

Melhorias:
- Adicionar agente A16 para gerar histórias do Storybook ao pipeline de frontend
- Referenciar a nova etapa A16 no arquivo raiz AGENTS.md

Documentação:
- Incluir instruções de configuração e uso do Storybook na documentação de início rápido, do desenvolvedor e de arquitetura

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add Storybook guidelines across multiple docs and extend the frontend AGENTS workflow with a new A16 step to generate Storybook component stories

Enhancements:
- Add A16 agent for generating Storybook stories to the frontend pipeline
- Reference the new A16 step in the root AGENTS.md file

Documentation:
- Include Storybook setup and usage instructions in quickstart, developer, and architecture documentation

</details>