### PR TITLE
Implement get_full_session in GLPI session client

### DIFF
--- a/src/backend/infrastructure/glpi/glpi_session.py
+++ b/src/backend/infrastructure/glpi/glpi_session.py
@@ -10,8 +10,6 @@ from urllib.parse import urlsplit, urlunsplit
 
 import aiohttp
 from aiohttp import BasicAuth, ClientResponse, ClientSession, TCPConnector
-from pydantic import BaseModel, ConfigDict, Field, model_validator
-
 from backend.core.settings import (
     GLPI_APP_TOKEN,
     GLPI_BASE_URL,
@@ -32,6 +30,7 @@ from backend.domain.exceptions import (
     GLPIUnauthorizedError,
 )
 from backend.domain.tool_error import ToolError
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 from shared.utils.resilience import call_with_breaker, retry_api_call
 
 logger = logging.getLogger(__name__)
@@ -290,7 +289,6 @@ class GLPISession:
     async def _handle_init_error(
         self, e: aiohttp.ClientResponseError, response: aiohttp.ClientResponse
     ) -> None:
-
         response_data = {}
         response_text = ""
         try:
@@ -784,7 +782,8 @@ class GLPISession:
         base_params: Dict[str, Any] = {**params, "expand_dropdowns": 1}
         endpoint = itemtype if itemtype.startswith("search/") else f"search/{itemtype}"
         return await self._paginate_search(endpoint, base_params, page_size)
-        # Note: Pagination logic, including offset increment, is handled within _paginate_search.
+        # Note: Pagination logic, including offset increment,
+        # is handled within _paginate_search.
 
     async def query_graphql(
         self, query: str, variables: Optional[Dict[str, Any]] = None
@@ -797,6 +796,15 @@ class GLPISession:
             msg = data["errors"][0].get("message", "GraphQL query failed")
             raise GLPIAPIError(0, msg, data)
         return data.get("data", data) or {}
+
+    async def get_full_session(self) -> Dict[str, Any]:
+        """Retrieve detailed information about the current session."""
+
+        headers = {
+            "Session-Token": self._session_token or "",
+            "App-Token": self.credentials.app_token,
+        }
+        return await self.get("getFullSession", headers=headers)
 
 
 async def open_session_tool(params: SessionParams) -> str:
@@ -831,6 +839,10 @@ async def index_all_paginated(
         return await session.get_all_paginated(itemtype, page_size=page_size, **params)
 
 
+# Expose the ``get_full_session`` method at module level for convenience.
+get_full_session = GLPISession.get_full_session
+
+
 __all__ = [
     "GLPISession",
     "Credentials",
@@ -842,5 +854,6 @@ __all__ = [
     "GLPINotFoundError",
     "GLPITooManyRequestsError",
     "GLPIInternalServerError",
+    "get_full_session",
     "index_all_paginated",
 ]


### PR DESCRIPTION
## Summary
- add `get_full_session` method to `GLPISession`
- expose the new method via module `__all__`
- provide tests for successful retrieval and error cases

## Testing
- `pre-commit run --files src/backend/infrastructure/glpi/glpi_session.py tests/test_glpi_session.py`
- `pytest` *(fails: unrecognized arguments)*
- `pytest` with minimal config *(fails: 38 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68818f5864a08320a28f70f3b026ad9e

## Resumo por Sourcery

Adiciona um novo método `get_full_session` ao cliente `GLPISession`, expõe-o como uma função de nível de módulo e cobre seu comportamento com testes de sucesso e erro.

Novas Funcionalidades:
- Implementa `get_full_session` em `GLPISession` para recuperar informações detalhadas da sessão.
- Expõe `get_full_session` como uma função de nível superior e inclui-o em `__all__`

Testes:
- Adiciona `test_get_full_session_success` para verificar a recuperação bem-sucedida dos detalhes da sessão.
- Adiciona `test_get_full_session_error` para garantir o mapeamento adequado de erros em caso de falhas.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a new get_full_session method to the GLPISession client, expose it as a module-level function, and cover its behavior with success and error tests.

New Features:
- Implement get_full_session in GLPISession to retrieve detailed session information.
- Expose get_full_session as a top-level function and include it in __all__

Tests:
- Add test_get_full_session_success to verify successful session detail retrieval.
- Add test_get_full_session_error to ensure proper error mapping on failures

</details>