### PR TITLE
Refine mapping cache logic

### DIFF
--- a/tests/test_mapping_service.py
+++ b/tests/test_mapping_service.py
@@ -1,3 +1,4 @@
+import aiohttp
 import pytest
 from backend.adapters.mapping_service import MappingService
 from backend.infrastructure.glpi.glpi_session import GLPISession
@@ -102,4 +103,44 @@ async def test_get_search_options_cache_miss(mocker):
         "search_options:Ticket",
         {"1": {"name": "ID"}},
         ttl_seconds=svc.cache_ttl_seconds,
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_search_options_invalid_cache(mocker):
+    session = mocker.Mock(spec=GLPISession)
+    session.list_search_options = mocker.AsyncMock(return_value={"1": {"name": "ID"}})
+    search_cache = mocker.Mock(spec=RedisClient)
+    search_cache.get = mocker.AsyncMock(return_value="oops")
+    search_cache.set = mocker.AsyncMock()
+
+    svc = MappingService(session, search_cache=search_cache)
+
+    result = await svc.get_search_options("Ticket")
+
+    assert result == {"1": {"name": "ID"}}
+    session.list_search_options.assert_awaited_once_with("Ticket")
+    search_cache.set.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_get_search_options_network_error(mocker):
+    session = mocker.Mock(spec=GLPISession)
+    session.list_search_options = mocker.AsyncMock(
+        side_effect=aiohttp.ClientError("fail")
+    )
+    search_cache = mocker.Mock(spec=RedisClient)
+    search_cache.get = mocker.AsyncMock(return_value=None)
+    search_cache.set = mocker.AsyncMock()
+
+    svc = MappingService(session, search_cache=search_cache)
+
+    result = await svc.get_search_options("Ticket")
+
+    assert result == {}
+    session.list_search_options.assert_awaited_once_with("Ticket")
+    search_cache.set.assert_awaited_once_with(
+        "search_options:Ticket",
+        {},
+        ttl_seconds=300,
     )


### PR DESCRIPTION
## Summary
- use a dedicated `RedisClient` instance in `MappingService`
- validate cached search options and handle invalid data
- catch `aiohttp.ClientError` and `GLPIAPIError` separately
- test network errors and invalid cache scenarios

## Testing
- `make test-backend` *(fails: 18 failed, 2 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6881a2832d608320adaa306e3e99b037