### PR TITLE
Implement GLPI document service

### DIFF
--- a/src/backend/application/document_service.py
+++ b/src/backend/application/document_service.py
@@ -1,0 +1,76 @@
+"""Helpers for creating and linking GLPI documents."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from aiohttp import FormData
+from backend.infrastructure.glpi.glpi_session import GLPISession
+
+
+async def _post_form(session: GLPISession, endpoint: str, form: FormData) -> dict:
+    """Send a multipart/form-data POST request using the underlying session."""
+    session._init_aiohttp_session()  # type: ignore[attr-defined]
+    assert session._session is not None  # type: ignore[attr-defined]
+
+    headers = session._build_request_headers(None)  # type: ignore[attr-defined]
+    headers.pop("Content-Type", None)
+    request_kwargs = {
+        "headers": headers,
+        "data": form,
+        "proxy": session.proxy,
+        "timeout": session._resolve_timeout(),  # type: ignore[attr-defined]
+    }
+    if not session.verify_ssl:
+        request_kwargs["ssl"] = False
+    elif session.ssl_ctx is not None:
+        request_kwargs["ssl"] = session.ssl_ctx
+
+    async with session._session.post(  # type: ignore[attr-defined]
+        f"{session.base_url}/{endpoint}",
+        **request_kwargs,
+    ) as resp:
+        resp.raise_for_status()
+        return await resp.json()
+
+
+async def create_document(
+    session: GLPISession,
+    name: str,
+    file_path: Path,
+    linked_item: tuple[str, int] | None = None,
+) -> int:
+    """Upload a document to GLPI and return its ID."""
+    manifest: dict[str, dict[str, object]] = {"input": {"name": name}}
+    if linked_item is not None:
+        itemtype, items_id = linked_item
+        manifest["input"].update({"itemtype": itemtype, "items_id": items_id})
+
+    form = FormData()
+    form.add_field(
+        "uploadManifest", json.dumps(manifest), content_type="application/json"
+    )
+    form.add_field(
+        "filename",
+        file_path.read_bytes(),
+        filename=file_path.name,
+        content_type="application/octet-stream",
+    )
+
+    data = await _post_form(session, "Document", form)
+    return int(data.get("id", 0))
+
+
+async def link_document(
+    session: GLPISession, document_id: int, itemtype: str, items_id: int
+) -> None:
+    """Link an existing document to another GLPI item."""
+    payload = {
+        "input": {
+            "documents_id": document_id,
+            "itemtype": itemtype,
+            "items_id": items_id,
+        }
+    }
+    await session.post("Document_Item", json_data=payload)

--- a/src/backend/application/document_service.py
+++ b/src/backend/application/document_service.py
@@ -51,14 +51,14 @@ async def create_document(
     form.add_field(
         "uploadManifest", json.dumps(manifest), content_type="application/json"
     )
-    form.add_field(
-        "filename",
-        file_path.read_bytes(),
-        filename=file_path.name,
-        content_type="application/octet-stream",
-    )
-
-    data = await _post_form(session, "Document", form)
+    com file_path.open("rb") como f:
+        formulário.add_field(
+            "nome do arquivo",
+            f,
+            nome do arquivo=file_path.nome,
+            content_type="aplicativo/fluxo de octeto",
+        )
+        dados = aguardar _post_form(sessão, "Documento", formulário)
     if "id" not in data:
         raise ValueError(f"API response does not contain 'id': {data}")
     return int(data["id"])

--- a/src/backend/application/document_service.py
+++ b/src/backend/application/document_service.py
@@ -59,7 +59,9 @@ async def create_document(
     )
 
     data = await _post_form(session, "Document", form)
-    return int(data.get("id", 0))
+    if "id" not in data:
+        raise ValueError(f"API response does not contain 'id': {data}")
+    return int(data["id"])
 
 
 async def link_document(

--- a/tests/test_document_service.py
+++ b/tests/test_document_service.py
@@ -48,7 +48,7 @@ async def test_create_document_posts_multipart(tmp_path):
     session._session.post.assert_called_once()
     args, kwargs = session._session.post.call_args
     assert args[0].endswith("/Document")
-    assert isinstance(kwargs["data"], object)
+    assert type(kwargs["data"]).__name__ == "FormData"
     assert doc_id == 5
 
 

--- a/tests/test_document_service.py
+++ b/tests/test_document_service.py
@@ -1,0 +1,64 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from backend.application.document_service import create_document, link_document
+from backend.infrastructure.glpi.glpi_session import GLPISession
+
+from tests.helpers import make_cm
+
+
+class DummySession(GLPISession):
+    """GLPISession stub exposing an aiohttp-like client."""
+
+    def __init__(self):
+        # Avoid parent initialization logic
+        self.base_url = "http://example.com/apirest.php"
+        self.proxy = None
+        self.verify_ssl = True
+        self.ssl_ctx = None
+        self._session = MagicMock()
+        self._session.post = MagicMock(
+            side_effect=lambda *a, **k: make_cm(201, {"id": 5})
+        )
+
+    def _init_aiohttp_session(self) -> None:
+        pass
+
+    def _build_request_headers(self, headers=None):
+        hdrs = {"App-Token": "app", "Content-Type": "application/json"}
+        if headers:
+            hdrs.update(headers)
+        return hdrs
+
+    def _resolve_timeout(self):
+        class T:  # simple stand-in for aiohttp.ClientTimeout
+            pass
+
+        return T()
+
+
+@pytest.mark.asyncio
+async def test_create_document_posts_multipart(tmp_path):
+    file_path = tmp_path / "doc.txt"
+    file_path.write_text("data")
+    session = DummySession()
+
+    doc_id = await create_document(session, "doc", file_path, None)
+
+    session._session.post.assert_called_once()
+    args, kwargs = session._session.post.call_args
+    assert args[0].endswith("/Document")
+    assert isinstance(kwargs["data"], object)
+    assert doc_id == 5
+
+
+@pytest.mark.asyncio
+async def test_link_document_calls_post():
+    session = AsyncMock(spec=GLPISession)
+
+    await link_document(session, 2, "Ticket", 99)
+
+    session.post.assert_awaited_once_with(
+        "Document_Item",
+        json_data={"input": {"documents_id": 2, "itemtype": "Ticket", "items_id": 99}},
+    )


### PR DESCRIPTION
## Summary
- add a document service with helpers to create and link documents
- include tests mocking GLPI session behaviour

## Testing
- `pytest tests/test_document_service.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6881a845be0c8320a23b08f32b760ac5

## Resumo por Sourcery

Implementa serviço de documentos para GLPI adicionando funções auxiliares para fazer upload e vincular documentos e cobrindo-as com testes unitários que simulam o comportamento da sessão

Novas Funcionalidades:
- Introduz o módulo `document_service` com as funções `create_document` e `link_document` para fazer upload e vincular documentos ao GLPI

Testes:
- Adiciona testes que simulam `GLPISession` para verificar o upload multipart em `create_document` e o comportamento de vinculação em `link_document`

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement document service for GLPI by adding helpers to upload and link documents and cover them with unit tests mocking session behavior

New Features:
- Introduce document_service module with create_document and link_document functions to upload and link documents to GLPI

Tests:
- Add tests mocking GLPISession to verify multipart upload in create_document and linking behavior in link_document

</details>