### PR TITLE
Implement multi-item fetch

### DIFF
--- a/src/backend/infrastructure/glpi/glpi_session.py
+++ b/src/backend/infrastructure/glpi/glpi_session.py
@@ -785,6 +785,20 @@ class GLPISession:
         # Note: Pagination logic, including offset increment,
         # is handled within _paginate_search.
 
+    async def get_multiple_items(
+        self, pairs: list[tuple[str, int]]
+    ) -> list[dict[str, Any]]:
+        """Return several items in a single request."""
+
+        payload = {
+            "items": [{"itemtype": itype, "items_id": iid} for itype, iid in pairs]
+        }
+        data = await self.post("getMultipleItems", json_data=payload)
+        items: Any = data.get("data", data) if isinstance(data, dict) else data
+        if isinstance(items, dict):
+            items = [items]
+        return list(items)
+
     async def query_graphql(
         self, query: str, variables: Optional[Dict[str, Any]] = None
     ) -> Dict[str, Any]:
@@ -841,6 +855,7 @@ async def index_all_paginated(
 
 # Expose the ``get_full_session`` method at module level for convenience.
 get_full_session = GLPISession.get_full_session
+get_multiple_items = GLPISession.get_multiple_items
 
 
 __all__ = [
@@ -856,4 +871,5 @@ __all__ = [
     "GLPIInternalServerError",
     "get_full_session",
     "index_all_paginated",
+    "get_multiple_items",
 ]

--- a/tests/test_batch_fetch.py
+++ b/tests/test_batch_fetch.py
@@ -1,15 +1,34 @@
+# ruff: noqa: E402
 import asyncio
 import json
+import sys
 import time
+from types import ModuleType, SimpleNamespace
 
 import pytest
 
+structlog = ModuleType("structlog")
+setattr(structlog, "get_logger", lambda *a, **k: SimpleNamespace())
+contextvars = ModuleType("contextvars")
+setattr(contextvars, "bind_contextvars", lambda *a, **k: None)
+setattr(contextvars, "clear_contextvars", lambda: None)
+setattr(contextvars, "merge_contextvars", lambda *a, **k: None)
+setattr(structlog, "contextvars", contextvars)
+sys.modules.setdefault("structlog", structlog)
+sys.modules.setdefault("structlog.contextvars", contextvars)
+httpx_mod = ModuleType("httpx")
+setattr(httpx_mod, "AsyncClient", object)
+sys.modules.setdefault("httpx", httpx_mod)
+sys.modules.setdefault("redis.asyncio", ModuleType("redis.asyncio"))
+
 from backend.application import batch_fetch
+from shared.dto import CleanTicketDTO
 
 
-class DummySession:
+class DummyClient:
     def __init__(self, delay: float = 0.01) -> None:
         self.delay = delay
+        self.calls: list[list[int]] = []
 
     async def __aenter__(self):
         return self
@@ -17,36 +36,44 @@ class DummySession:
     async def __aexit__(self, exc_type, exc, tb):
         pass
 
-    async def get(self, endpoint: str, params=None, headers=None):
+    async def fetch_tickets_by_ids(self, ids: list[int]):
+        self.calls.append(ids)
         await asyncio.sleep(self.delay)
-        ticket_id = int(endpoint.split("/")[-1])
-        return {"data": {"id": ticket_id}}
+        return [CleanTicketDTO(id=i, status="New") for i in ids]
 
 
 @pytest.mark.asyncio
 async def test_fetch_all_tickets(monkeypatch):
-    monkeypatch.setattr(batch_fetch, "GLPISession", lambda *a, **k: DummySession())
+    client = DummyClient()
+    monkeypatch.setattr(batch_fetch, "GLPISession", lambda *a, **k: object())
+    monkeypatch.setattr(batch_fetch, "GlpiApiClient", lambda *a, **k: client)
+
     ids = [1, 2, 3]
     data = await batch_fetch.fetch_all_tickets(ids)
+
+    assert client.calls == [ids]
     assert [d["id"] for d in data] == ids
 
 
 @pytest.mark.asyncio
 async def test_async_vs_sync_benchmark(monkeypatch):
-    monkeypatch.setattr(batch_fetch, "GLPISession", lambda *a, **k: DummySession())
+    client = DummyClient()
+    monkeypatch.setattr(batch_fetch, "GLPISession", lambda *a, **k: object())
+    monkeypatch.setattr(batch_fetch, "GlpiApiClient", lambda *a, **k: client)
     ids = list(range(20))
 
     start = time.perf_counter()
     async_result = await batch_fetch.fetch_all_tickets(ids)
     async_duration = time.perf_counter() - start
 
+    seq_client = DummyClient()
+
     async def sequential() -> list[dict]:
-        async with DummySession() as sess:
-            out = []
-            for tid in ids:
-                resp = await sess.get(f"Ticket/{tid}")
-                out.append(resp["data"])
-            return out
+        out = []
+        for tid in ids:
+            res = await seq_client.fetch_tickets_by_ids([tid])
+            out.extend(res)
+        return [t.model_dump() for t in out]
 
     start = time.perf_counter()
     sync_result = await sequential()


### PR DESCRIPTION
## Summary
- support batch lookup endpoint in `GLPISession`
- add `fetch_tickets_by_ids` to `GlpiApiClient`
- refactor `batch_fetch.fetch_all_tickets` to use the high-level client
- update tests for new helper

## Testing
- `pytest tests/test_batch_fetch.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6881acc998c88320b2426142d6834bb3

## Resumo por Sourcery

Implementa a busca de múltiplos itens estendendo a sessão para suportar a recuperação de itens em lote, adicionando um método de cliente de alto nível para buscar tickets por IDs, refatorando a função de busca em lote para aproveitar o novo cliente e atualizando os testes correspondentes.

Novas Funcionalidades:
- Adiciona endpoint de busca multi-item em GLPISession para requisições em lote
- Introduz o método fetch_tickets_by_ids em GlpiApiClient para recuperação de tickets em lote

Melhorias:
- Refatora fetch_all_tickets para usar GlpiApiClient e simplificar a lógica de concorrência personalizada

Testes:
- Atualiza os testes de batch_fetch para simular GlpiApiClient, usar DummyClient e usar shims para os módulos structlog/httpx/redis

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement multi-item fetch by extending the session to support batch item retrieval, adding a high-level client method to fetch tickets by IDs, refactoring the batch fetch function to leverage the new client, and updating corresponding tests.

New Features:
- Add multi-item fetch endpoint in GLPISession for batch requests
- Introduce fetch_tickets_by_ids method in GlpiApiClient for batch ticket retrieval

Enhancements:
- Refactor fetch_all_tickets to use GlpiApiClient and simplify away custom concurrency logic

Tests:
- Update batch_fetch tests to mock GlpiApiClient, use DummyClient, and shim structlog/httpx/redis modules

</details>