### PR TITLE
Implement GLPI document service

### DIFF
--- a/src/backend/application/document_service.py
+++ b/src/backend/application/document_service.py
@@ -1,0 +1,59 @@
+"""Helpers for creating and linking GLPI documents."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from aiohttp import FormData
+from backend.domain.exceptions import GLPIAPIError
+from backend.infrastructure.glpi.glpi_session import GLPISession
+
+
+async def create_document(
+    session: GLPISession,
+    name: str,
+    file_path: Path,
+    linked_item: tuple[str, int] | None = None,
+) -> int:
+    """Upload a document to GLPI and return its ID."""
+    manifest: dict[str, dict[str, object]] = {"input": {"name": name}}
+    if linked_item is not None:
+        itemtype, items_id = linked_item
+        manifest["input"].update({"itemtype": itemtype, "items_id": items_id})
+
+    form = FormData()
+    form.add_field(
+        "uploadManifest", json.dumps(manifest), content_type="application/json"
+    )
+    file_handle = file_path.open("rb")
+    form.add_field(
+        "filename",
+        file_handle,
+        filename=file_path.name,
+        content_type="application/octet-stream",
+    )
+
+    try:
+        data = await session.post_form("Document", form)
+    finally:
+        file_handle.close()
+
+    doc_id = data.get("id")
+    if doc_id is None:
+        raise GLPIAPIError(0, "Document creation response missing 'id'", data)
+    return int(doc_id)
+
+
+async def link_document(
+    session: GLPISession, document_id: int, itemtype: str, items_id: int
+) -> None:
+    """Link an existing document to another GLPI item."""
+    payload = {
+        "input": {
+            "documents_id": document_id,
+            "itemtype": itemtype,
+            "items_id": items_id,
+        }
+    }
+    await session.post("Document_Item", json_data=payload)

--- a/tests/test_document_service.py
+++ b/tests/test_document_service.py
@@ -1,0 +1,60 @@
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+from backend.application.document_service import create_document, link_document
+from backend.domain.exceptions import GLPIAPIError
+from backend.infrastructure.glpi.glpi_session import GLPISession
+
+
+class DummySession(GLPISession):
+    """GLPISession stub exposing an aiohttp-like client."""
+
+    def __init__(self):
+        self.base_url = "http://example.com/apirest.php"
+        self.post_form = AsyncMock(return_value={"id": 5})
+        self.post = AsyncMock()
+
+
+@pytest.mark.asyncio
+async def test_create_document_posts_multipart(tmp_path):
+    file_path = tmp_path / "doc.txt"
+    file_path.write_text("data")
+    session = DummySession()
+
+    doc_id = await create_document(session, "doc", file_path, None)
+
+    session.post_form.assert_awaited_once()
+    call = session.post_form.await_args
+    assert call is not None
+    args, kwargs = call
+    assert args[0] == "Document"
+    form = args[1]
+    fields = {f[0]["name"]: f[2] for f in getattr(form, "_fields", [])}
+    assert fields["uploadManifest"] == json.dumps({"input": {"name": "doc"}})
+    assert Path(fields["filename"].name) == file_path
+    assert doc_id == 5
+
+
+@pytest.mark.asyncio
+async def test_create_document_missing_id(tmp_path):
+    file_path = tmp_path / "doc.txt"
+    file_path.write_text("data")
+    session = DummySession()
+    session.post_form.return_value = {}
+
+    with pytest.raises(GLPIAPIError):
+        await create_document(session, "doc", file_path, None)
+
+
+@pytest.mark.asyncio
+async def test_link_document_calls_post():
+    session = AsyncMock(spec=GLPISession)
+
+    await link_document(session, 2, "Ticket", 99)
+
+    session.post.assert_awaited_once_with(
+        "Document_Item",
+        json_data={"input": {"documents_id": 2, "itemtype": "Ticket", "items_id": 99}},
+    )


### PR DESCRIPTION
## Summary
- add multipart upload helper in `GLPISession`
- rewrite document service to use the helper and stream files
- raise error when document creation response lacks an id
- expand tests for document uploads

## Testing
- `pre-commit run --files src/backend/application/document_service.py src/backend/infrastructure/glpi/glpi_session.py tests/test_document_service.py`
- `pytest tests/test_document_service.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6881a845be0c8320a23b08f32b760ac5

## Resumo por Sourcery

Introduz um novo serviço de documentos para GLPI que suporta uploads multipart via um helper `post_form`, faz streaming de uploads de arquivos em `create_document`, impõe tratamento de erros para IDs ausentes e fornece `link_document` para anexar documentos a itens, apoiado por testes unitários dedicados.

Novos Recursos:
- Adiciona o método `post_form` a `GLPISession` para requisições multipart/form-data
- Implementa o helper `create_document` para fazer upload de arquivos e retornar IDs de documentos
- Implementa o helper `link_document` para anexar documentos a itens do GLPI

Melhorias:
- Faz streaming de arquivos durante o upload de documentos e levanta um erro quando a resposta não possui um ID

Testes:
- Adiciona testes para criação bem-sucedida de documentos, erro de ID ausente e vinculação de documentos

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a new document service for GLPI that supports multipart uploads via a post_form helper, streams file uploads in create_document, enforces error handling for missing IDs, and provides link_document for attaching documents to items, backed by dedicated unit tests.

New Features:
- Add post_form method to GLPISession for multipart/form-data requests
- Implement create_document helper to upload files and return document IDs
- Implement link_document helper to attach documents to GLPI items

Enhancements:
- Stream files during document upload and raise an error when response lacks an ID

Tests:
- Add tests for successful document creation, missing ID error, and document linking

</details>