### PR TITLE
Handle non-JSON responses

### DIFF
--- a/src/backend/infrastructure/glpi/glpi_session.py
+++ b/src/backend/infrastructure/glpi/glpi_session.py
@@ -585,6 +585,14 @@ class GLPISession:
                 raise GLPIUnauthorizedError(401, "401 Unauthorized")
             try:
                 response.raise_for_status()
+                content_type = response.headers.get("Content-Type", "")
+                if not content_type.startswith("application/json"):
+                    html_snippet = await response.text()
+                    raise GLPIAPIError(
+                        response.status,
+                        f"Unexpected content type: {content_type}",
+                        {"text": html_snippet},
+                    )
                 data = await response.json()
                 return (data, dict(response.headers)) if return_headers else data
             except aiohttp.ClientResponseError as e:


### PR DESCRIPTION
## Summary
- detect non-JSON content in `_execute_request`
- raise `GLPIAPIError` with HTML when server returns HTML
- add unit test for HTML response handling

## Testing
- `pre-commit run --files src/backend/infrastructure/glpi/glpi_session.py tests/test_glpi_session.py`
- `pytest tests/test_glpi_session.py -k test_non_json_response_raises_error -vv`

------
https://chatgpt.com/codex/tasks/task_e_6881b322610c8320bf14388940f1c359

## Resumo por Sourcery

Adiciona tratamento para respostas do servidor que não são JSON, levantando um `GLPIAPIError` com conteúdo HTML e inclui um teste unitário para este cenário

Novas Funcionalidades:
- Detecta conteúdo de resposta não-JSON em requisições de API e levanta `GLPIAPIError` com o trecho HTML

Testes:
- Adiciona teste unitário para verificar se respostas não-JSON (HTML) disparam `GLPIAPIError` com o código de status e os dados de resposta corretos

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add handling for non-JSON server responses by raising a GLPIAPIError with HTML content and include a unit test for this scenario

New Features:
- Detect non-JSON response content in API requests and raise GLPIAPIError with the HTML snippet

Tests:
- Add unit test to verify non-JSON (HTML) responses trigger GLPIAPIError with correct status code and response data

</details>