### PR TITLE
Implement GLPIAuthClient with caching

### DIFF
--- a/src/backend/infrastructure/glpi/glpi_auth.py
+++ b/src/backend/infrastructure/glpi/glpi_auth.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Optional
+
+import redis
+import requests
+from backend.core.settings import (
+    GLPI_APP_TOKEN,
+    GLPI_BASE_URL,
+    GLPI_PASSWORD,
+    GLPI_USER_TOKEN,
+    GLPI_USERNAME,
+    REDIS_DB,
+    REDIS_HOST,
+    REDIS_PORT,
+    REDIS_TTL_SECONDS,
+)
+from requests.auth import HTTPBasicAuth
+from shared.utils.logging import get_logger
+from tenacity import (
+    before_sleep_log,
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+    wait_fixed,
+)
+
+logger = get_logger(__name__)
+
+
+class GLPIAuthError(Exception):
+    """Raised when authentication fails permanently."""
+
+
+class TemporaryAuthError(Exception):
+    """Raised for transient errors that should trigger a retry."""
+
+
+def _wait_strategy():
+    if os.getenv("DISABLE_RETRY_BACKOFF"):
+        return wait_fixed(0)
+    return wait_exponential(multiplier=1, min=1, max=10)
+
+
+class GLPIAuthClient:
+    """Simple authentication manager for the GLPI REST API."""
+
+    _instance: Optional["GLPIAuthClient"] = None
+
+    def __new__(cls, *args, **kwargs):
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __init__(
+        self,
+        base_url: str = GLPI_BASE_URL,
+        app_token: str = GLPI_APP_TOKEN,
+        *,
+        user_token: Optional[str] = GLPI_USER_TOKEN,
+        username: Optional[str] = GLPI_USERNAME,
+        password: Optional[str] = GLPI_PASSWORD,
+        redis_conn: Optional[redis.Redis] = None,
+        session: Optional[requests.Session] = None,
+        redis_key: str = "glpi:session_token",
+        ttl_seconds: int = REDIS_TTL_SECONDS,
+    ) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.app_token = app_token
+        self.user_token = user_token
+        self.username = username
+        self.password = password
+        self.redis_key = redis_key
+        self.ttl_seconds = ttl_seconds
+        self.session = session or requests.Session()
+        self.redis = redis_conn or redis.Redis(
+            host=REDIS_HOST,
+            port=REDIS_PORT,
+            db=REDIS_DB,
+            decode_responses=True,
+        )
+
+    @retry(
+        stop=stop_after_attempt(5),
+        wait=_wait_strategy(),
+        before_sleep=before_sleep_log(logger, logging.WARNING),
+        retry=retry_if_exception_type(TemporaryAuthError),
+        reraise=True,
+    )
+    def init_session(self) -> str:
+        """Authenticate with GLPI and return a new ``session_token``."""
+
+        headers = {"App-Token": self.app_token, "Content-Type": "application/json"}
+        auth = None
+        if self.user_token:
+            headers["Authorization"] = f"user_token {self.user_token}"
+            logger.info(json.dumps({"event": "init_session", "method": "user_token"}))
+        elif self.username and self.password:
+            auth = HTTPBasicAuth(self.username, self.password)
+            logger.info(json.dumps({"event": "init_session", "method": "basic_auth"}))
+        else:
+            raise GLPIAuthError("missing credentials")
+
+        url = f"{self.base_url}/initSession"
+        try:
+            resp = self.session.get(url, headers=headers, auth=auth, timeout=30)
+        except requests.RequestException as exc:
+            logger.warning(
+                json.dumps({"event": "init_session_error", "error": str(exc)})
+            )
+            raise TemporaryAuthError from exc
+
+        if resp.status_code == 401:
+            logger.error(json.dumps({"event": "unauthorized"}))
+            raise GLPIAuthError("unauthorized")
+        if resp.status_code >= 500:
+            logger.warning(
+                json.dumps({"event": "server_error", "status": resp.status_code})
+            )
+            raise TemporaryAuthError(f"status {resp.status_code}")
+        resp.raise_for_status()
+        token = resp.json().get("session_token")
+        if not token:
+            raise GLPIAuthError("session_token missing")
+        logger.info(json.dumps({"event": "init_session_success"}))
+        return token
+
+    def get_session_token(self, force_refresh: bool = False) -> str:
+        """Return a cached ``session_token`` or authenticate if needed."""
+
+        if not force_refresh:
+            try:
+                token = self.redis.get(self.redis_key)
+            except redis.RedisError as exc:  # pragma: no cover - defensive
+                logger.warning(json.dumps({"event": "cache_error", "error": str(exc)}))
+                token = None
+            if token:
+                logger.info(json.dumps({"event": "cache_hit"}))
+                return token
+            logger.info(json.dumps({"event": "cache_miss"}))
+
+        token = self.init_session()
+        try:
+            self.redis.setex(self.redis_key, self.ttl_seconds, token)
+            logger.info(json.dumps({"event": "cache_store", "ttl": self.ttl_seconds}))
+        except redis.RedisError as exc:  # pragma: no cover - defensive
+            logger.warning(
+                json.dumps({"event": "cache_store_error", "error": str(exc)})
+            )
+        return token

--- a/tests/test_glpi_auth.py
+++ b/tests/test_glpi_auth.py
@@ -1,0 +1,105 @@
+import json
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+import requests
+from backend.infrastructure.glpi.glpi_auth import (
+    GLPIAuthClient,
+    GLPIAuthError,
+)
+
+
+class DummyResponse(requests.Response):
+    def __init__(self, status: int, data: Any) -> None:
+        super().__init__()
+        self.status_code = status
+        self._content = json.dumps(data).encode()
+        self.headers = requests.structures.CaseInsensitiveDict(
+            {"Content-Type": "application/json"}
+        )
+
+
+def make_session(responses):
+    def side(lst):
+        calls = list(lst)
+
+        def _inner(*args, **kwargs):
+            result = calls.pop(0)
+            if isinstance(result, Exception):
+                raise result
+            return result
+
+        return _inner
+
+    session = SimpleNamespace()
+    session.get = MagicMock(side_effect=side(responses))
+    return session
+
+
+class FakeRedis:
+    def __init__(self) -> None:
+        self.store: dict[str, str] = {}
+
+    def get(self, key: str):
+        return self.store.get(key)
+
+    def setex(self, key: str, ttl: int, value: str):
+        self.store[key] = value
+
+
+def test_get_session_token_success(monkeypatch):
+    monkeypatch.setenv("DISABLE_RETRY_BACKOFF", "1")
+    redis = FakeRedis()
+    session = make_session([DummyResponse(200, {"session_token": "tok"})])
+    client = GLPIAuthClient(
+        base_url="http://example.com/apirest.php",
+        app_token="APP",
+        user_token="USER",
+        redis_conn=redis,
+        session=session,
+    )
+    token = client.get_session_token()
+    assert token == "tok"
+    assert redis.get("glpi:session_token") == "tok"
+    session.get.assert_called_once()
+    session.get.reset_mock()
+    assert client.get_session_token() == "tok"
+    session.get.assert_not_called()
+
+
+def test_init_session_unauthorized(monkeypatch):
+    monkeypatch.setenv("DISABLE_RETRY_BACKOFF", "1")
+    redis = FakeRedis()
+    session = make_session([DummyResponse(401, {})])
+    client = GLPIAuthClient(
+        base_url="http://example.com/apirest.php",
+        app_token="APP",
+        user_token="USER",
+        redis_conn=redis,
+        session=session,
+    )
+    with pytest.raises(GLPIAuthError):
+        client.get_session_token(force_refresh=True)
+
+
+def test_retry_on_temporary_error(monkeypatch):
+    monkeypatch.setenv("DISABLE_RETRY_BACKOFF", "1")
+    redis = FakeRedis()
+    session = make_session(
+        [
+            requests.exceptions.ConnectionError("fail"),
+            DummyResponse(200, {"session_token": "tok"}),
+        ]
+    )
+    client = GLPIAuthClient(
+        base_url="http://example.com/apirest.php",
+        app_token="APP",
+        user_token="USER",
+        redis_conn=redis,
+        session=session,
+    )
+    token = client.get_session_token(force_refresh=True)
+    assert token == "tok"
+    assert session.get.call_count == 2


### PR DESCRIPTION
## Summary
- add `GLPIAuthClient` for authenticating against GLPI and caching the session token in Redis
- log authentication and cache events in structured JSON format
- implement retries for transient errors
- create unit tests covering successful login, unauthorized failure and retry logic

## Testing
- `pytest -q tests/test_glpi_auth.py`
- `pre-commit run --files src/backend/infrastructure/glpi/glpi_auth.py tests/test_glpi_auth.py`
- `pytest -q` *(fails: ModuleNotFoundError: playwright)*

------
https://chatgpt.com/codex/tasks/task_e_6881b87c86fc8320b416b1936796e6d2