### PR TITLE
Implement GLPITicketClient

### DIFF
--- a/glpi_ticket_client.py
+++ b/glpi_ticket_client.py
@@ -1,0 +1,94 @@
+import json
+import time
+from typing import Any, Dict, List, Optional
+
+import requests
+from backend.core.settings import GLPI_APP_TOKEN, GLPI_BASE_URL
+from backend.infrastructure.glpi.glpi_auth import GLPIAuthClient
+from backend.infrastructure.glpi.glpi_client import SearchCriteriaBuilder
+from shared.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+class GLPITicketClient:
+    """Simple client to fetch GLPI tickets using REST search."""
+
+    def __init__(
+        self,
+        base_url: str = GLPI_BASE_URL,
+        app_token: str = GLPI_APP_TOKEN,
+        auth_client: Optional[GLPIAuthClient] = None,
+        session: Optional[requests.Session] = None,
+    ) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.app_token = app_token
+        self.auth_client = auth_client or GLPIAuthClient(base_url, app_token)
+        self.session = session or requests.Session()
+
+    def _build_params(
+        self, filters: Optional[Dict[str, str]], page: int, page_size: int
+    ) -> Dict[str, Any]:
+        params: Dict[str, Any] = {"range": f"{(page-1)*page_size}-{page*page_size-1}"}
+        if filters:
+            builder = SearchCriteriaBuilder()
+            for field, value in filters.items():
+                builder.add(field, value)
+            params.update(builder.build())
+        return params
+
+    def list_tickets(
+        self,
+        filters: Optional[Dict[str, str]] = None,
+        page: int = 1,
+        page_size: int = 50,
+    ) -> List[Dict[str, Any]]:
+        """Return tickets matching ``filters`` using GLPI search."""
+
+        token = self.auth_client.get_session_token()
+        params = self._build_params(filters, page, page_size)
+        headers = {
+            "App-Token": self.app_token,
+            "Session-Token": token,
+            "Content-Type": "application/json",
+        }
+        url = f"{self.base_url}/search/Ticket"
+        log_data = {"page": page, "page_size": page_size, "filters": filters}
+        start = time.perf_counter()
+        try:
+            resp = self.session.get(url, headers=headers, params=params, timeout=30)
+        except requests.RequestException as exc:
+            logger.error(
+                json.dumps({"event": "request_error", **log_data, "error": str(exc)})
+            )
+            raise
+        if resp.status_code == 401:
+            logger.info(json.dumps({"event": "token_refresh", **log_data}))
+            token = self.auth_client.get_session_token(force_refresh=True)
+            headers["Session-Token"] = token
+            resp = self.session.get(url, headers=headers, params=params, timeout=30)
+        if resp.status_code >= 400:
+            logger.error(
+                json.dumps(
+                    {
+                        "event": "http_error",
+                        "status": resp.status_code,
+                        "body": resp.text,
+                    }
+                )
+            )
+            resp.raise_for_status()
+        data = resp.json()
+        tickets: List[Dict[str, Any]] = data.get("data", data)
+        duration = time.perf_counter() - start
+        logger.info(
+            json.dumps(
+                {
+                    "event": "list_tickets",
+                    **log_data,
+                    "count": len(tickets),
+                    "duration": duration,
+                }
+            )
+        )
+        return tickets

--- a/tests/test_glpi_ticket_client.py
+++ b/tests/test_glpi_ticket_client.py
@@ -1,0 +1,99 @@
+import json
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+import requests
+
+from glpi_ticket_client import GLPITicketClient
+
+
+class DummyResponse(requests.Response):
+    def __init__(self, status: int, data: Any) -> None:
+        super().__init__()
+        self.status_code = status
+        self._content = json.dumps(data).encode()
+        self.headers = requests.structures.CaseInsensitiveDict(
+            {"Content-Type": "application/json"}
+        )
+
+
+def make_session(responses):
+    def side(lst):
+        calls = list(lst)
+
+        def _inner(*args, **kwargs):
+            result = calls.pop(0)
+            if isinstance(result, Exception):
+                raise result
+            return result
+
+        return _inner
+
+    session = SimpleNamespace()
+    session.get = MagicMock(side_effect=side(responses))
+    return session
+
+
+class FakeAuth:
+    def __init__(self, tokens):
+        self.tokens = list(tokens)
+        self.calls = 0
+
+    def get_session_token(self, force_refresh: bool = False):
+        self.calls += 1
+        return self.tokens.pop(0)
+
+
+def test_list_tickets_basic(monkeypatch):
+    resp = DummyResponse(200, {"data": [{"id": 1}]})
+    session = make_session([resp])
+    client = GLPITicketClient(
+        base_url="http://example.com/apirest.php",
+        auth_client=FakeAuth(["tok"]),
+        session=session,
+    )
+
+    tickets = client.list_tickets(filters={"status": "new"}, page=1, page_size=50)
+
+    assert tickets == [{"id": 1}]
+    args, kwargs = session.get.call_args
+    assert args[0] == "http://example.com/apirest.php/search/Ticket"
+    assert kwargs["headers"]["Session-Token"] == "tok"
+    assert kwargs["params"]["criteria[0][field]"] == "status"
+    assert kwargs["params"]["range"] == "0-49"
+
+
+def test_pagination(monkeypatch):
+    session = make_session([DummyResponse(200, {"data": []})])
+    client = GLPITicketClient(
+        base_url="http://ex.com/api", auth_client=FakeAuth(["a"]), session=session
+    )
+    client.list_tickets(page=2, page_size=10)
+    params = session.get.call_args.kwargs["params"]
+    assert params["range"] == "10-19"
+
+
+def test_retry_on_401(monkeypatch):
+    responses = [DummyResponse(401, {}), DummyResponse(200, {"data": [{"id": 2}]})]
+    session = make_session(responses)
+    auth = FakeAuth(["old", "new"])
+    client = GLPITicketClient(
+        base_url="http://ex.com/api", auth_client=auth, session=session
+    )
+
+    tickets = client.list_tickets()
+
+    assert tickets == [{"id": 2}]
+    assert auth.calls == 2
+    assert session.get.call_count == 2
+
+
+def test_http_error(monkeypatch):
+    session = make_session([DummyResponse(403, {"error": "forbidden"})])
+    client = GLPITicketClient(
+        base_url="http://ex.com/api", auth_client=FakeAuth(["tok"]), session=session
+    )
+    with pytest.raises(requests.HTTPError):
+        client.list_tickets()


### PR DESCRIPTION
## Summary
- add `GLPITicketClient` for paginated ticket fetching via GLPI REST API
- log request info and handle token renewal
- include unit tests for happy path, pagination and auth retries

## Testing
- `pytest tests/test_glpi_ticket_client.py tests/test_glpi_auth.py tests/test_glpi_client_sync.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6881bdd33dc48320a28a5bf405893413

## Resumo por Sourcery

Implementar GLPITicketClient para buscar e paginar tickets da API REST do GLPI com renovação automática de token e registro detalhado de logs.

Novas Funcionalidades:
- Introdução do GLPITicketClient para recuperação de tickets com paginação e filtros personalizáveis
- Atualização e nova tentativa automáticas em caso de expiração do token de sessão (erros 401)
- Registro de metadados da requisição, incluindo paginação, contagens de resposta, erros e durações

Testes:
- Adição de testes unitários para listagem bem-sucedida, lógica de paginação, nova tentativa de token em caso de 401 e tratamento de erros HTTP

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement GLPITicketClient to fetch and paginate tickets from the GLPI REST API with automatic token renewal and detailed logging

New Features:
- Introduce GLPITicketClient for ticket retrieval with pagination and customizable filters
- Automatically refresh and retry on session token expiration (401 errors)
- Log request metadata including pagination, response counts, errors, and durations

Tests:
- Add unit tests for successful listing, pagination logic, token retry on 401, and HTTP error handling

</details>