### PR TITLE
Fix criteria builder logging and tests

### DIFF
--- a/glpi_criteria_builder.py
+++ b/glpi_criteria_builder.py
@@ -72,7 +72,7 @@ class CriteriaBuilder:
         if field_id is None:
             raise KeyError(f"Unknown field: {field_name}")
         logger.debug(
-            "Filtro adicionado: field '%s' (id %s) = '%s', link=%s",
+            "Filter added: field '%s' (id %s) = '%s', link=%s",
             field_name,
             field_id,
             value,
@@ -92,9 +92,10 @@ class CriteriaBuilder:
     def build(self) -> Dict[str, str]:
         """Return parameters suitable for ``requests`` ``params`` argument."""
         params: Dict[str, str] = {}
+        last_idx = len(self._criteria) - 1
         for idx, crit in enumerate(self._criteria):
             params[f"criteria[{idx}][field]"] = str(crit.field)
             params[f"criteria[{idx}][search]"] = str(crit.search)
-            if idx < len(self._criteria) - 1:
+            if idx < last_idx:
                 params[f"criteria[{idx}][link]"] = crit.link
         return params

--- a/tests/test_glpi_criteria_builder.py
+++ b/tests/test_glpi_criteria_builder.py
@@ -24,6 +24,25 @@ def test_unknown_field():
         builder.add("foo", "bar")
 
 
+def test_multiple_fields_mixed_links():
+    builder = CriteriaBuilder(field_map={"status": 1, "priority": 2, "type": 3})
+    (
+        builder.where_status("Closed", link="OR")
+        .add("priority", "High", link="AND")
+        .add("type", "Incident")
+    )
+    params = builder.build()
+    assert params["criteria[0][field]"] == "1"
+    assert params["criteria[0][search]"] == "Closed"
+    assert params["criteria[0][link]"] == "OR"
+    assert params["criteria[1][field]"] == "2"
+    assert params["criteria[1][search]"] == "High"
+    assert params["criteria[1][link]"] == "AND"
+    assert params["criteria[2][field]"] == "3"
+    assert params["criteria[2][search]"] == "Incident"
+    assert "criteria[2][link]" not in params
+
+
 @pytest.mark.asyncio
 async def test_load_field_ids():
     class FakeSession:
@@ -33,3 +52,19 @@ async def test_load_field_ids():
 
     mapping = await CriteriaBuilder.load_field_ids(FakeSession())
     assert mapping == {"status": 5, "group": 12}
+
+
+@pytest.mark.asyncio
+async def test_load_field_ids_cache():
+    calls = []
+
+    class FakeSession:
+        async def list_search_options(self, itemtype):
+            calls.append(itemtype)
+            return {"5": {"name": "Status"}}
+
+    CriteriaBuilder._cache.clear()
+    mapping1 = await CriteriaBuilder.load_field_ids(FakeSession())
+    mapping2 = await CriteriaBuilder.load_field_ids(FakeSession())
+    assert mapping1 == mapping2 == {"status": 5}
+    assert calls.count("Ticket") == 1


### PR DESCRIPTION
## Summary
- log added filter in English
- avoid repeated list length calculation
- add tests for mixed links and caching

## Testing
- `pre-commit run --files glpi_criteria_builder.py tests/test_glpi_criteria_builder.py`
- `PYTEST_ADDOPTS="" pytest -q tests/test_glpi_criteria_builder.py`

------
https://chatgpt.com/codex/tasks/task_e_6881c3cb74a48320b00f694ebe6a8034