### PR TITLE
Add metrics overview API

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,1 @@
+"""Main application package."""

--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -1,0 +1,9 @@
+"""API routers for the dashboard service."""
+
+from fastapi import APIRouter
+
+router = APIRouter()
+
+from . import metrics  # noqa: E402,F401
+
+__all__ = ["router"]

--- a/app/api/metrics.py
+++ b/app/api/metrics.py
@@ -1,0 +1,99 @@
+"""Endpoints providing aggregated ticket metrics."""
+
+from __future__ import annotations
+
+import logging
+from typing import Dict, Optional
+
+import pandas as pd
+from backend.application.glpi_api_client import (
+    GlpiApiClient,
+    create_glpi_api_client,
+)
+from backend.infrastructure.glpi.normalization import process_raw
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+from shared.utils.redis_client import RedisClient, redis_client
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+
+class MetricsOverview(BaseModel):
+    """Summary of key ticket metrics."""
+
+    open_tickets: Dict[str, int] = Field(default_factory=dict)
+    resolved_this_month: Dict[str, int] = Field(default_factory=dict)
+    status_distribution: Dict[str, int] = Field(default_factory=dict)
+
+
+async def _fetch_dataframe(client: Optional[GlpiApiClient]) -> pd.DataFrame:
+    """Return tickets as a normalized DataFrame."""
+    client = client or create_glpi_api_client()
+    if client is None:
+        raise RuntimeError("GLPI client unavailable")
+
+    async with client:
+        tickets = await client.fetch_tickets()
+
+    data = [t.model_dump() for t in tickets]
+    return process_raw(data)
+
+
+async def compute_overview(
+    client: Optional[GlpiApiClient] = None,
+    cache: Optional[RedisClient] = None,
+    ttl_seconds: int = 300,
+) -> MetricsOverview:
+    """Compute metrics and cache the result."""
+    cache = cache or redis_client
+    cache_key = "metrics:overview"
+
+    cached = await cache.get(cache_key)
+    if cached:
+        try:
+            return MetricsOverview.model_validate(cached)
+        except Exception as exc:  # pragma: no cover - bad cache content
+            logger.warning("Ignoring invalid cache entry: %s", exc)
+
+    df = await _fetch_dataframe(client)
+    df["status"] = df["status"].astype(str).str.lower()
+
+    open_mask = ~df["status"].isin(["closed", "solved"])
+    open_by_level = (
+        df[open_mask].groupby("group", observed=True).size().astype(int).to_dict()
+    )
+
+    now = pd.Timestamp.utcnow()
+    month_start = pd.Timestamp(year=now.year, month=now.month, day=1)
+    closed_mask = df["status"].isin(["closed", "solved"]) & (
+        df["date_creation"] >= month_start
+    )
+    resolved_by_level = (
+        df[closed_mask].groupby("group", observed=True).size().astype(int).to_dict()
+    )
+
+    status_counts = df["status"].value_counts().astype(int).to_dict()
+
+    result = MetricsOverview(
+        open_tickets=open_by_level,
+        resolved_this_month=resolved_by_level,
+        status_distribution=status_counts,
+    )
+
+    try:
+        await cache.set(cache_key, result.model_dump(), ttl_seconds=ttl_seconds)
+    except Exception as exc:  # pragma: no cover - cache failures
+        logger.warning("Failed to store metrics in cache: %s", exc)
+
+    return result
+
+
+@router.get("/metrics/overview", response_model=MetricsOverview)
+async def metrics_overview() -> MetricsOverview:
+    """Return aggregated ticket metrics for the dashboard."""
+    try:
+        return await compute_overview()
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.exception("Error computing metrics overview: %s", exc)
+        raise HTTPException(status_code=500, detail="Failed to compute metrics")


### PR DESCRIPTION
## Summary
- create new FastAPI router under `app/api`
- implement `/metrics/overview` with Redis caching

## Testing
- `pre-commit run --files app/__init__.py app/api/__init__.py app/api/metrics.py`
- `pytest tests/test_aggregated_metrics.py -k status_by_group_counts -q`

------
https://chatgpt.com/codex/tasks/task_e_6881c79f7fdc8320b2ee6e12dfb515d4

## Resumo por Sourcery

Adiciona um novo endpoint de API `/metrics/overview` para fornecer métricas agregadas de tickets usando FastAPI, com suporte de cache Redis e obtenção de dados do GLPI.

Novas Funcionalidades:
- Expõe o endpoint `/metrics/overview` retornando tickets abertos por grupo, tickets resolvidos este mês e a distribuição geral do status
- Implementa `compute_overview` para buscar tickets via API do GLPI, normalizar em um DataFrame e agregar as principais métricas

Melhorias:
- Integra o cache Redis com TTL para a visão geral das métricas e lida com entradas de cache inválidas ou falhas de forma elegante

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a new `/metrics/overview` API endpoint to provide aggregated ticket metrics using FastAPI, backed by Redis caching and GLPI data fetching.

New Features:
- Expose `/metrics/overview` endpoint returning open tickets by group, resolved tickets this month, and overall status distribution
- Implement `compute_overview` to fetch tickets via GLPI API, normalize into a DataFrame, and aggregate key metrics

Enhancements:
- Integrate Redis caching with TTL for the metrics overview and handle invalid or failed cache entries gracefully

</details>