### PR TITLE
Refactor GLPI enrichment service

### DIFF
--- a/tests/test_glpi_enrichment.py
+++ b/tests/test_glpi_enrichment.py
@@ -1,8 +1,7 @@
 from unittest.mock import AsyncMock
 
 import pytest
-
-from glpi_enrichment import GLPIEnrichmentService
+from backend.services.glpi_enrichment import GLPIEnrichmentService
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- move `glpi_enrichment` into `src/backend/services`
- add `DEFAULT_UNKNOWN_VALUE` constant and `_owns_session` handling
- catch specific exceptions in `_load_statuses`
- ensure ID checks don't skip zero and gather with error handling
- update tests for new import path

## Testing
- `pre-commit run --files src/backend/services/glpi_enrichment.py tests/test_glpi_enrichment.py`
- `pytest tests/test_glpi_enrichment.py -q` *(fails: ModuleNotFoundError: No module named 'tenacity')*

------
https://chatgpt.com/codex/tasks/task_e_6881c80a36b08320ab5e6290fa4ecc3d

## Resumo por Sourcery

Refatorar o serviço de enriquecimento GLPI, relocando-o para os serviços de backend, introduzindo uma constante de valor desconhecido padrão, melhorando o tratamento de erros e sessões, fortalecendo as verificações de ID e atualizando o enriquecimento em lote e os testes de acordo.

Melhorias:
- Mover o serviço `glpi_enrichment` para o diretório `src/backend/services`
- Introduzir a constante `DEFAULT_UNKNOWN_VALUE` e usá-la para campos ausentes
- Adicionar a flag `_owns_session` para fechar apenas as sessões criadas internamente
- Capturar exceções específicas `ValueError` e `TypeError` ao carregar status
- Mudar o fallback de "Unknown" literal para `DEFAULT_UNKNOWN_VALUE` em métodos de nomenclatura
- Permitir IDs com valor zero verificando `None` em vez de veracidade
- Usar `asyncio.gather` com `return_exceptions` para pesquisas paralelas de usuário/grupo

Testes:
- Atualizar importações e caminhos nos testes de enriquecimento GLPI para corresponder à nova localização do módulo

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the GLPI enrichment service by relocating it under the backend services, introducing a default unknown value constant, improving error and session handling, strengthening ID checks, and updating batch enrichment and tests accordingly.

Enhancements:
- Move glpi_enrichment service into src/backend/services directory
- Introduce DEFAULT_UNKNOWN_VALUE constant and use it for missing fields
- Add _owns_session flag to only close sessions created internally
- Catch specific ValueError and TypeError exceptions when loading statuses
- Change fallback from literal "Unknown" to DEFAULT_UNKNOWN_VALUE in naming methods
- Allow zero-valued IDs by checking for None instead of truthiness
- Use asyncio.gather with return_exceptions for parallel user/group lookups

Tests:
- Update imports and paths in glpi enrichment tests to match new module location

</details>