### PR TITLE
Add fixture to isolate CriteriaBuilder cache

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,3 +40,16 @@ def glpi_unavailable(monkeypatch: pytest.MonkeyPatch):
         _fail,
     )
     yield
+
+
+@pytest.fixture()
+def fresh_criteria_cache():
+    """Provide a clean CriteriaBuilder cache and restore it afterwards."""
+    from glpi_criteria_builder import CriteriaBuilder
+
+    saved = CriteriaBuilder._cache.copy()
+    CriteriaBuilder._cache.clear()
+    try:
+        yield
+    finally:
+        CriteriaBuilder._cache = saved

--- a/tests/test_glpi_criteria_builder.py
+++ b/tests/test_glpi_criteria_builder.py
@@ -55,7 +55,7 @@ async def test_load_field_ids():
 
 
 @pytest.mark.asyncio
-async def test_load_field_ids_cache():
+async def test_load_field_ids_cache(fresh_criteria_cache):
     calls = []
 
     class FakeSession:
@@ -63,7 +63,6 @@ async def test_load_field_ids_cache():
             calls.append(itemtype)
             return {"5": {"name": "Status"}}
 
-    CriteriaBuilder._cache.clear()
     mapping1 = await CriteriaBuilder.load_field_ids(FakeSession())
     mapping2 = await CriteriaBuilder.load_field_ids(FakeSession())
     assert mapping1 == mapping2 == {"status": 5}


### PR DESCRIPTION
## Summary
- provide `fresh_criteria_cache` fixture in `tests/conftest.py`
- use the fixture in `test_load_field_ids_cache`

## Testing
- `pre-commit run --files tests/conftest.py tests/test_glpi_criteria_builder.py`
- `pytest -k test_glpi_criteria_builder.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6881c7f4bc248320aa140640dc475007

## Resumo do Sourcery

Melhorar o isolamento dos testes adicionando um fixture pytest para limpar e restaurar o cache do `CriteriaBuilder` e aplicando-o ao teste de carregamento de IDs de campo.

Testes:
- Introduzir o fixture `fresh_criteria_cache` para fornecer um cache `CriteriaBuilder` limpo e restaurá-lo após cada teste
- Atualizar `test_load_field_ids_cache` para usar o fixture `fresh_criteria_cache` e remover a limpeza manual do cache

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve test isolation by adding a pytest fixture to clear and restore the CriteriaBuilder cache and applying it to the field ID loading test.

Tests:
- Introduce fresh_criteria_cache fixture to provide a clean CriteriaBuilder cache and restore it after each test
- Update test_load_field_ids_cache to use the fresh_criteria_cache fixture and remove manual cache clearing

</details>