### PR TITLE
Fix cache restoration in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,4 +52,5 @@ def fresh_criteria_cache():
     try:
         yield
     finally:
-        CriteriaBuilder._cache = saved
+        CriteriaBuilder._cache.clear()
+        CriteriaBuilder._cache.update(saved)


### PR DESCRIPTION
## Summary
- correct the cleanup logic for `fresh_criteria_cache` fixture

## Testing
- `pytest tests/test_glpi_criteria_builder.py::test_load_field_ids_cache -q`

------
https://chatgpt.com/codex/tasks/task_e_6881cd389b04832090e3e98c1d382ded

## Resumo por Sourcery

Correções de Bugs:
- Usar `clear` e `update` em `CriteriaBuilder._cache` em vez de atribuição direta para restaurar o cache salvo

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Use clear and update on CriteriaBuilder._cache instead of direct assignment to restore the saved cache

</details>