### PR TITLE
Remove redundant noqa in GLPI enrichment

### DIFF
--- a/src/backend/services/glpi_enrichment.py
+++ b/src/backend/services/glpi_enrichment.py
@@ -67,7 +67,7 @@ class GLPIEnrichmentService:
             try:
                 sid = int(item.get("id"))
                 name = str(item.get("name"))
-            except (ValueError, TypeError):  # noqa: BLE001
+            except (ValueError, TypeError):
                 continue
             mapping[sid] = name
         self._status_map.update(mapping)


### PR DESCRIPTION
## Summary
- clean up exception handling for `_load_statuses`

## Testing
- `pre-commit run --files src/backend/services/glpi_enrichment.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'playwright')*

------
https://chatgpt.com/codex/tasks/task_e_6881cd2134e883209281c0521dd7fb48