### PR TITLE
Fix metrics router and timezone handling

### DIFF
--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -6,4 +6,6 @@ router = APIRouter()
 
 from . import metrics  # noqa: E402,F401
 
+router.include_router(metrics.router)
+
 __all__ = ["router"]

--- a/app/api/metrics.py
+++ b/app/api/metrics.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Dict, Optional
+from typing import Optional
 
 import pandas as pd
 from backend.application.glpi_api_client import (
@@ -11,20 +11,24 @@ from backend.application.glpi_api_client import (
     create_glpi_api_client,
 )
 from backend.infrastructure.glpi.normalization import process_raw
-from fastapi import APIRouter, HTTPException
-from pydantic import BaseModel, Field
+from fastapi import HTTPException
+from pydantic import BaseModel, Field, ValidationError
 from shared.utils.redis_client import RedisClient, redis_client
 
+from . import router
+
 logger = logging.getLogger(__name__)
-router = APIRouter()
+
+# Cache key used to store the metrics overview in Redis
+CACHE_KEY_OVERVIEW = "metrics:overview"
 
 
 class MetricsOverview(BaseModel):
     """Summary of key ticket metrics."""
 
-    open_tickets: Dict[str, int] = Field(default_factory=dict)
-    resolved_this_month: Dict[str, int] = Field(default_factory=dict)
-    status_distribution: Dict[str, int] = Field(default_factory=dict)
+    open_tickets: dict[str, int] = Field(default_factory=dict)
+    created_and_resolved_this_month: dict[str, int] = Field(default_factory=dict)
+    status_distribution: dict[str, int] = Field(default_factory=dict)
 
 
 async def _fetch_dataframe(client: Optional[GlpiApiClient]) -> pd.DataFrame:
@@ -47,13 +51,16 @@ async def compute_overview(
 ) -> MetricsOverview:
     """Compute metrics and cache the result."""
     cache = cache or redis_client
-    cache_key = "metrics:overview"
+    cache_key = CACHE_KEY_OVERVIEW
 
     cached = await cache.get(cache_key)
     if cached:
         try:
             return MetricsOverview.model_validate(cached)
-        except Exception as exc:  # pragma: no cover - bad cache content
+        except (
+            ValidationError,
+            TypeError,
+        ) as exc:  # pragma: no cover - bad cache content
             logger.warning("Ignoring invalid cache entry: %s", exc)
 
     df = await _fetch_dataframe(client)
@@ -64,12 +71,16 @@ async def compute_overview(
         df[open_mask].groupby("group", observed=True).size().astype(int).to_dict()
     )
 
-    now = pd.Timestamp.utcnow()
-    month_start = pd.Timestamp(year=now.year, month=now.month, day=1)
+    now = pd.Timestamp.utcnow().tz_localize("UTC")
+    month_start = pd.Timestamp(year=now.year, month=now.month, day=1, tz="UTC")
+    if df["date_creation"].dt.tz is None:
+        df["date_creation"] = df["date_creation"].dt.tz_localize("UTC")
+    else:
+        df["date_creation"] = df["date_creation"].dt.tz_convert("UTC")
     closed_mask = df["status"].isin(["closed", "solved"]) & (
         df["date_creation"] >= month_start
     )
-    resolved_by_level = (
+    created_and_resolved_by_level = (
         df[closed_mask].groupby("group", observed=True).size().astype(int).to_dict()
     )
 
@@ -77,7 +88,7 @@ async def compute_overview(
 
     result = MetricsOverview(
         open_tickets=open_by_level,
-        resolved_this_month=resolved_by_level,
+        created_and_resolved_this_month=created_and_resolved_by_level,
         status_distribution=status_counts,
     )
 
@@ -95,5 +106,7 @@ async def metrics_overview() -> MetricsOverview:
     try:
         return await compute_overview()
     except Exception as exc:  # pragma: no cover - defensive
-        logger.exception("Error computing metrics overview: %s", exc)
-        raise HTTPException(status_code=500, detail="Failed to compute metrics")
+        logger.exception("Error computing metrics overview")
+        raise HTTPException(
+            status_code=500, detail="Failed to compute metrics"
+        ) from exc


### PR DESCRIPTION
## Summary
- align metrics router with main API router
- clarify the resolved tickets metric
- standardize timezone handling for monthly metrics

## Testing
- `pre-commit run --files app/api/metrics.py app/api/__init__.py`
- `make test-backend` *(fails: tests/test_clean_ticket_dto.py ...)*

------
https://chatgpt.com/codex/tasks/task_e_6881ccfed76c8320826e30731efdd6ec

## Resumo por Sourcery

Alinhar o roteador de métricas com o roteador principal da API, esclarecer a nomenclatura da métrica de tickets resolvidos mensalmente e padronizar o tratamento do fuso horário UTC

Correções de Bugs:
- Padronizar a localização e conversão UTC para timestamps de data de tickets
- Capturar `ValidationError` e `TypeError` explícitos ao desserializar entradas de cache

Melhorias:
- Incluir o roteador de métricas no roteador principal da API
- Renomear a métrica `resolved_this_month` para `created_and_resolved_this_month`
- Introduzir a constante `CACHE_KEY_OVERVIEW` para a chave de cache
- Refinar o tratamento de exceções para entradas de cache inválidas e propagação de erros

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align metrics router with main API router, clarify monthly resolved tickets metric naming, and standardize UTC timezone handling

Bug Fixes:
- Standardize UTC localization and conversion for ticket date timestamps
- Catch explicit ValidationError and TypeError when deserializing cache entries

Enhancements:
- Include metrics router in the main API router
- Rename resolved_this_month metric to created_and_resolved_this_month
- Introduce CACHE_KEY_OVERVIEW constant for cache key
- Refine exception handling for invalid cache entries and error propagation

</details>