### PR TITLE
Add retry utility for GLPI HTTP calls

### DIFF
--- a/glpi_http_utils.py
+++ b/glpi_http_utils.py
@@ -1,0 +1,108 @@
+import logging
+import time
+from threading import Lock
+from typing import Any, Dict, Optional
+
+import requests
+
+__all__ = [
+    "GLPIAuthError",
+    "GLPIPermissionError",
+    "GLPIRetryError",
+    "http_request_with_retry",
+]
+
+
+logger = logging.getLogger(__name__)
+
+
+class GLPIAuthError(Exception):
+    """Raised when authentication fails even after refresh."""
+
+
+class GLPIPermissionError(Exception):
+    """Raised when the user lacks permission for the requested resource."""
+
+
+class GLPIRetryError(Exception):
+    """Raised when a request keeps failing after retries."""
+
+
+_refresh_lock = Lock()
+
+
+def http_request_with_retry(
+    session: requests.Session,
+    method: str,
+    url: str,
+    *,
+    headers: Optional[Dict[str, str]] = None,
+    auth_client: Optional[Any] = None,
+    max_attempts: int = 3,
+    **kwargs: Any,
+) -> requests.Response:
+    """Perform an HTTP request with retry and GLPI specific error handling."""
+
+    attempt = 1
+    wait_seconds = 1
+    headers = headers or {}
+
+    while attempt <= max_attempts:
+        try:
+            resp = session.request(method, url, headers=headers, **kwargs)
+        except requests.RequestException as exc:
+            if attempt >= max_attempts:
+                logger.error("GLPI API network error: %s", exc)
+                raise GLPIRetryError(str(exc)) from exc
+            logger.warning(
+                "GLPI API falhou com %s, tentativa %s de %s em %ss",
+                type(exc).__name__,
+                attempt,
+                max_attempts,
+                wait_seconds,
+            )
+            time.sleep(wait_seconds)
+            wait_seconds *= 2
+            attempt += 1
+            continue
+
+        status = resp.status_code
+        if status == 401 and auth_client is not None:
+            logger.warning(
+                "Session token expirado, obtendo novo token e repetindo requisicao"
+            )
+            with _refresh_lock:
+                token = auth_client.get_session_token(force_refresh=True)
+                headers["Session-Token"] = token
+            if attempt >= max_attempts:
+                raise GLPIAuthError("Unauthorized after token refresh")
+            attempt += 1
+            continue
+
+        if status == 403:
+            logger.warning("Permissao negada para %s", url)
+            raise GLPIPermissionError(f"permission denied: {url}")
+
+        if status >= 500:
+            if attempt >= max_attempts:
+                logger.error(
+                    "GLPI API retornou %s, esgotadas %s tentativas",
+                    status,
+                    max_attempts,
+                )
+                raise GLPIRetryError(f"status {status}")
+            logger.warning(
+                "GLPI API falhou com %s, tentativa %s de %s em %ss",
+                status,
+                attempt,
+                max_attempts,
+                wait_seconds,
+            )
+            time.sleep(wait_seconds)
+            wait_seconds *= 2
+            attempt += 1
+            continue
+
+        return resp
+
+    raise GLPIRetryError(f"Max attempts reached for {url}")

--- a/tests/test_http_retry.py
+++ b/tests/test_http_retry.py
@@ -1,0 +1,114 @@
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from glpi_http_utils import (
+    GLPIPermissionError,
+    GLPIRetryError,
+    http_request_with_retry,
+)
+
+
+class DummyResponse(requests.Response):
+    def __init__(self, status: int, data: dict | None = None) -> None:
+        super().__init__()
+        self.status_code = status
+        self._content = json.dumps(data or {}).encode()
+        self.headers = requests.structures.CaseInsensitiveDict(
+            {"Content-Type": "application/json"}
+        )
+        self.request = MagicMock(url="http://example.com")
+
+
+def make_session(responses):
+    def side_effect(*args, **kwargs):
+        result = responses.pop(0)
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+    session = SimpleNamespace()
+    session.request = MagicMock(side_effect=side_effect)
+    return session
+
+
+class FakeAuth:
+    def __init__(self, tokens):
+        self.tokens = list(tokens)
+        self.calls = 0
+
+    def get_session_token(self, force_refresh: bool = False):
+        self.calls += 1
+        return self.tokens.pop(0)
+
+
+def test_retry_on_5xx_eventual_success():
+    session = make_session(
+        [
+            DummyResponse(502, {}),
+            DummyResponse(502, {}),
+            DummyResponse(200, {"ok": True}),
+        ]
+    )
+    auth = FakeAuth(["a"])
+    with patch("time.sleep") as sleep:
+        resp = http_request_with_retry(
+            session,
+            "GET",
+            "http://example.com",
+            headers={},
+            auth_client=auth,
+            max_attempts=4,
+        )
+    assert resp.status_code == 200
+    assert session.request.call_count == 3
+    assert sleep.call_count == 2
+
+
+def test_refresh_on_401():
+    session = make_session([DummyResponse(401, {}), DummyResponse(200, {"ok": True})])
+    auth = FakeAuth(["old", "new"])
+    with patch("time.sleep") as sleep:
+        resp = http_request_with_retry(
+            session,
+            "GET",
+            "http://example.com",
+            headers={"Session-Token": "old"},
+            auth_client=auth,
+            max_attempts=2,
+        )
+    assert resp.status_code == 200
+    assert auth.calls == 1
+    assert session.request.call_count == 2
+    sleep.assert_not_called()
+
+
+def test_permission_error():
+    session = make_session([DummyResponse(403, {})])
+    with pytest.raises(GLPIPermissionError):
+        http_request_with_retry(
+            session,
+            "GET",
+            "http://example.com",
+            headers={},
+            auth_client=FakeAuth(["tok"]),
+        )
+    assert session.request.call_count == 1
+
+
+def test_retry_error_after_max_attempts():
+    session = make_session([requests.ConnectionError("boom")] * 3)
+    with patch("time.sleep"):
+        with pytest.raises(GLPIRetryError):
+            http_request_with_retry(
+                session,
+                "GET",
+                "http://example.com",
+                headers={},
+                auth_client=FakeAuth(["tok"]),
+                max_attempts=3,
+            )
+    assert session.request.call_count == 3


### PR DESCRIPTION
## Summary
- create `http_request_with_retry` in `glpi_http_utils.py`
- refactor `GLPITicketClient.list_tickets` to use new retry helper
- adjust ticket client tests for new logic
- add new `test_http_retry` suite covering retry behaviours

## Testing
- `pre-commit run --files glpi_http_utils.py glpi_ticket_client.py tests/test_glpi_ticket_client.py tests/test_http_retry.py`
- `pytest tests/test_http_retry.py tests/test_glpi_ticket_client.py -q` *(fails: some tests require additional dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6881d01f82908320962908507f034620