### PR TITLE
Add metrics endpoints with caching

### DIFF
--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -6,4 +6,6 @@ router = APIRouter()
 
 from . import metrics  # noqa: E402,F401
 
+router.include_router(metrics.router)
+
 __all__ = ["router"]

--- a/app/api/metrics.py
+++ b/app/api/metrics.py
@@ -1,4 +1,9 @@
-"""Endpoints providing aggregated ticket metrics."""
+"""Endpoints providing aggregated ticket metrics.
+
+This module exposes simple REST routes used by the dashboard frontend. The
+metrics are computed from GLPI tickets using :mod:`pandas` and cached in Redis
+to keep the responses fast even when the dataset is large.
+"""
 
 from __future__ import annotations
 
@@ -24,6 +29,14 @@ class MetricsOverview(BaseModel):
 
     open_tickets: Dict[str, int] = Field(default_factory=dict)
     resolved_this_month: Dict[str, int] = Field(default_factory=dict)
+    status_distribution: Dict[str, int] = Field(default_factory=dict)
+
+
+class LevelMetrics(BaseModel):
+    """Metrics for a specific support level."""
+
+    open_tickets: int = 0
+    resolved_this_month: int = 0
     status_distribution: Dict[str, int] = Field(default_factory=dict)
 
 
@@ -89,6 +102,53 @@ async def compute_overview(
     return result
 
 
+async def compute_level_metrics(
+    level: str,
+    client: Optional[GlpiApiClient] = None,
+    cache: Optional[RedisClient] = None,
+    ttl_seconds: int = 300,
+) -> LevelMetrics:
+    """Compute metrics for a single support level and cache the result."""
+    cache = cache or redis_client
+    cache_key = f"metrics:level:{level}"
+
+    cached = await cache.get(cache_key)
+    if cached:
+        try:
+            return LevelMetrics.model_validate(cached)
+        except Exception as exc:  # pragma: no cover - bad cache content
+            logger.warning("Ignoring invalid cache entry for %s: %s", level, exc)
+
+    df = await _fetch_dataframe(client)
+    df["status"] = df["status"].astype(str).str.lower()
+    level_df = df[df["group"] == level]
+
+    open_mask = ~level_df["status"].isin(["closed", "solved"])
+    open_count = int(level_df[open_mask].shape[0])
+
+    now = pd.Timestamp.utcnow()
+    month_start = pd.Timestamp(year=now.year, month=now.month, day=1)
+    closed_mask = level_df["status"].isin(["closed", "solved"]) & (
+        level_df["date_creation"] >= month_start
+    )
+    resolved_count = int(level_df[closed_mask].shape[0])
+
+    status_counts = level_df["status"].value_counts().astype(int).to_dict()
+
+    result = LevelMetrics(
+        open_tickets=open_count,
+        resolved_this_month=resolved_count,
+        status_distribution=status_counts,
+    )
+
+    try:
+        await cache.set(cache_key, result.model_dump(), ttl_seconds=ttl_seconds)
+    except Exception as exc:  # pragma: no cover - cache failures
+        logger.warning("Failed to store level metrics in cache: %s", exc)
+
+    return result
+
+
 @router.get("/metrics/overview", response_model=MetricsOverview)
 async def metrics_overview() -> MetricsOverview:
     """Return aggregated ticket metrics for the dashboard."""
@@ -96,4 +156,15 @@ async def metrics_overview() -> MetricsOverview:
         return await compute_overview()
     except Exception as exc:  # pragma: no cover - defensive
         logger.exception("Error computing metrics overview: %s", exc)
+        raise HTTPException(status_code=500, detail="Failed to compute metrics")
+
+
+@router.get("/metrics/level/{level}", response_model=LevelMetrics)
+async def metrics_level(level: str) -> LevelMetrics:
+    """Return metrics for a single support level (e.g. N1, N2)."""
+    try:
+        normalized = level.upper()
+        return await compute_level_metrics(normalized)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.exception("Error computing level metrics for %s: %s", level, exc)
         raise HTTPException(status_code=500, detail="Failed to compute metrics")

--- a/tests/test_metrics_api.py
+++ b/tests/test_metrics_api.py
@@ -1,0 +1,116 @@
+import importlib
+import sys
+import types
+
+import pandas as pd
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+class FakeTicket:
+    def __init__(self, **data):
+        self.__dict__.update(data)
+
+    def model_dump(self):
+        return self.__dict__
+
+
+class DummyCache:
+    def __init__(self):
+        self.data = {}
+
+    async def get(self, key):
+        return self.data.get(key)
+
+    async def set(self, key, value, ttl_seconds=None):
+        self.data[key] = value
+
+
+class FakeClient:
+    def __init__(self, items):
+        self._items = items
+        self.calls = 0
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    async def fetch_tickets(self):
+        self.calls += 1
+        return [FakeTicket(**i) for i in self._items]
+
+
+sample_tickets = [
+    {"id": 1, "status": "new", "group": "N1", "date_creation": "2024-06-10"},
+    {"id": 2, "status": "closed", "group": "N1", "date_creation": "2024-06-05"},
+    {"id": 3, "status": "pending", "group": "N2", "date_creation": "2024-05-20"},
+    {"id": 4, "status": "closed", "group": "N2", "date_creation": "2024-06-02"},
+]
+
+
+@pytest.fixture
+def test_client(monkeypatch):
+    cache = DummyCache()
+    client = FakeClient(sample_tickets)
+
+    # Create dummy module before importing metrics
+    fake_module = types.SimpleNamespace(
+        create_glpi_api_client=lambda: client, GlpiApiClient=object
+    )
+    sys.modules["backend.application.glpi_api_client"] = fake_module  # type: ignore[assignment]
+
+    def fake_process(data):
+        df = pd.DataFrame(data)
+        if "date_creation" in df.columns:
+            df["date_creation"] = pd.to_datetime(df["date_creation"])
+        return df
+
+    fake_norm = types.SimpleNamespace(process_raw=fake_process)
+    sys.modules["backend.infrastructure.glpi.normalization"] = fake_norm  # type: ignore[assignment]
+    fake_redis = types.SimpleNamespace(RedisClient=object, redis_client=cache)
+    sys.modules["shared.utils.redis_client"] = fake_redis  # type: ignore[assignment]
+
+    metrics_module = importlib.import_module("app.api.metrics")
+    monkeypatch.setattr(metrics_module, "redis_client", cache)
+
+    api_pkg = importlib.import_module("app.api")
+    app = FastAPI()
+    app.include_router(api_pkg.router)
+    return TestClient(app), client, cache, metrics_module
+
+
+def test_overview_endpoint(test_client):
+    client, api_client, cache, metrics_module = test_client
+    resp = client.get("/metrics/overview")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["open_tickets"] == {"N1": 1, "N2": 1}
+    assert data["resolved_this_month"] == {}
+    assert data["status_distribution"] == {"new": 1, "closed": 2, "pending": 1}
+    # call again should hit cache
+    resp = client.get("/metrics/overview")
+    assert resp.status_code == 200
+    assert api_client.calls == 1
+
+
+def test_level_endpoint(test_client):
+    client, api_client, cache, metrics_module = test_client
+    resp = client.get("/metrics/level/N1")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["open_tickets"] == 1
+    assert data["resolved_this_month"] == 0
+
+
+def test_error_handling(monkeypatch, test_client):
+    client, api_client, cache, metrics_module = test_client
+
+    async def fail(*args, **kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(metrics_module, "_fetch_dataframe", fail)
+    resp = client.get("/metrics/overview")
+    assert resp.status_code == 500


### PR DESCRIPTION
## Summary
- add FastAPI endpoints for aggregated ticket metrics
- support per-level metrics with Redis caching
- cover metrics API with unit tests

## Testing
- `pre-commit run --files app/api/metrics.py app/api/__init__.py tests/test_metrics_api.py`
- `pytest tests/test_metrics_api.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6881d00b208c8320bd6ab66b2c49b074

## Resumo por Sourcery

Adiciona endpoint de métricas por nível com cache Redis, introduz o modelo LevelMetrics e adiciona testes unitários para a API de métricas

Novas Funcionalidades:
- Introduz o modelo LevelMetrics e a função compute_level_metrics com cache Redis
- Adiciona o endpoint GET /metrics/level/{level} para métricas de tickets por nível
- Expõe o roteador de métricas em app/api/__init__.py para incluir novos endpoints de métricas

Testes:
- Adiciona testes unitários para os endpoints metrics/overview e metrics/level cobrindo o comportamento de cache e o tratamento de erros

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add per-level metrics endpoint with Redis caching, introduce LevelMetrics model, and add unit tests for metrics API

New Features:
- Introduce LevelMetrics model and compute_level_metrics function with Redis caching
- Add GET /metrics/level/{level} endpoint for per-level ticket metrics
- Expose metrics router in app/api/__init__.py to include new metrics endpoints

Tests:
- Add unit tests for metrics/overview and metrics/level endpoints covering caching behavior and error handling

</details>