### PR TITLE
Implement GlpiApiClient facade

### DIFF
--- a/glpi_api_client.py
+++ b/glpi_api_client.py
@@ -1,0 +1,81 @@
+import asyncio
+import logging
+from typing import Any, Dict, List, Optional
+
+from backend.infrastructure.glpi.glpi_auth import GLPIAuthClient
+from backend.services.glpi_enrichment import GLPIEnrichmentService
+from shared.dto import CleanTicketDTO
+
+from app.api.metrics import compute_overview
+from glpi_ticket_client import GLPITicketClient
+
+logger = logging.getLogger(__name__)
+
+
+class GlpiApiClient:
+    """Facade that orchestrates GLPI API modules."""
+
+    def __init__(
+        self,
+        *,
+        auth_client: Optional[GLPIAuthClient] = None,
+        ticket_client: Optional[GLPITicketClient] = None,
+        enrichment: Optional[GLPIEnrichmentService] = None,
+    ) -> None:
+        self.auth_client = auth_client or GLPIAuthClient()
+        self.ticket_client = ticket_client or GLPITicketClient(
+            auth_client=self.auth_client
+        )
+        self.enrichment = enrichment or GLPIEnrichmentService(
+            auth_client=self.auth_client
+        )
+
+    async def __aenter__(self) -> "GlpiApiClient":
+        await self.refresh_session()
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        await self.enrichment.close()
+
+    async def refresh_session(self) -> str:
+        """Force a new session token."""
+        token = await self.auth_client.get_session_token(force_refresh=True)
+        logger.info("Session refreshed")
+        return token
+
+    async def get_tickets(
+        self,
+        filters: Optional[Dict[str, str]] = None,
+        page: int = 1,
+        page_size: int = 50,
+    ) -> List[Dict[str, Any]]:
+        """Return enriched ticket dictionaries."""
+        logger.info("Buscando tickets com filtros %s", filters)
+        result = await asyncio.to_thread(
+            self.ticket_client.list_tickets,
+            filters,
+            page,
+            page_size,
+        )
+        enriched = await self.enrichment.enrich_tickets(result)
+        return enriched
+
+    async def fetch_tickets(self) -> List[CleanTicketDTO]:
+        """Return validated tickets without filters."""
+        records = await self.get_tickets()
+        validated: List[CleanTicketDTO] = []
+        for r in records:
+            try:
+                validated.append(CleanTicketDTO.model_validate(r))
+            except Exception as exc:  # pragma: no cover - validation edge
+                logger.error("validation error for ticket %s: %s", r.get("id"), exc)
+        return validated
+
+    async def get_metrics_overview(self) -> Dict[str, Any]:
+        """Return aggregated metrics computed from tickets."""
+        logger.info("Obtendo métricas agregadas")
+        overview = await compute_overview(client=self)
+        return overview.model_dump()
+
+
+__all__ = ["GlpiApiClient"]

--- a/tests/test_glpi_api_client_v2.py
+++ b/tests/test_glpi_api_client_v2.py
@@ -1,0 +1,62 @@
+import pytest
+
+# mypy: disable-error-code=arg-type
+from glpi_api_client import GlpiApiClient
+
+
+class FakeAuth:
+    def __init__(self):
+        self.called = False
+
+    async def get_session_token(self, force_refresh: bool = False):
+        self.called = True
+        return "tok"
+
+
+class FakeTicketClient:
+    def __init__(self):
+        self.called_with = None
+
+    def list_tickets(self, filters=None, page=1, page_size=50):
+        self.called_with = {
+            "filters": filters,
+            "page": page,
+            "page_size": page_size,
+        }
+        return [{"id": 1, "status": 2}]
+
+
+class FakeEnrichment:
+    def __init__(self):
+        self.called = False
+
+    async def enrich_tickets(self, tickets):
+        self.called = True
+        for t in tickets:
+            t["status_name"] = "Ok"
+        return tickets
+
+    async def close(self):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_get_tickets_flow():
+    auth = FakeAuth()
+    ticket_client = FakeTicketClient()
+    enrichment = FakeEnrichment()
+    client = GlpiApiClient(  # type: ignore[misc]
+        auth_client=auth, ticket_client=ticket_client, enrichment=enrichment
+    )
+
+    async with client:
+        tickets = await client.get_tickets({"status": "new"}, page=2, page_size=10)
+
+    assert ticket_client.called_with == {
+        "filters": {"status": "new"},
+        "page": 2,
+        "page_size": 10,
+    }
+    assert enrichment.called
+    assert tickets[0]["status_name"] == "Ok"
+    assert auth.called


### PR DESCRIPTION
## Summary
- implement `GlpiApiClient` facade using existing modules
- add basic test for the facade

## Testing
- `pytest tests/test_glpi_api_client_v2.py -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_688261a9260c8320b6dd96d7802219bd

## Resumo por Sourcery

Adiciona uma fachada assíncrona GlpiApiClient que encapsula autenticação, recuperação de tickets, enriquecimento, validação e cálculo de métricas com suporte a gerenciador de contexto e inclui um teste básico para o fluxo `get_tickets`.

Novas Funcionalidades:
- Implementa a fachada GlpiApiClient para orquestrar interações com a API GLPI

Melhorias:
- Adiciona suporte a gerenciador de contexto assíncrono para gerenciamento e limpeza de sessões
- Fornece métodos para atualizar tokens de sessão, buscar tickets enriquecidos, validar tickets e calcular uma visão geral das métricas

Testes:
- Adiciona um pytest básico para o fluxo de recuperação de tickets usando clientes falsos para verificar a atualização da sessão, listagem de tickets e enriquecimento

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add an asynchronous GlpiApiClient facade that wraps authentication, ticket retrieval, enrichment, validation, and metrics computation with context manager support and includes a basic test for the get_tickets flow.

New Features:
- Implement GlpiApiClient facade for orchestrating GLPI API interactions

Enhancements:
- Add async context manager support for session management and cleanup
- Provide methods to refresh session tokens, fetch enriched tickets, validate tickets, and compute metrics overview

Tests:
- Add basic pytest for ticket retrieval flow using fake clients to verify session refresh, ticket listing, and enrichment

</details>