### PR TITLE
refactor dashboard to use react-query

### DIFF
--- a/src/frontend/react_app/src/components/__tests__/Dashboard.test.tsx
+++ b/src/frontend/react_app/src/components/__tests__/Dashboard.test.tsx
@@ -1,9 +1,9 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import Dashboard from '../Dashboard'
-import axios from 'axios'
+import { useMetricsOverview } from '../../hooks/useMetricsOverview'
 
-jest.mock('axios')
-const mockedGet = axios.get as jest.Mock
+jest.mock('../../hooks/useMetricsOverview')
+const mockedHook = useMetricsOverview as jest.Mock
 
 const mockMetrics = {
   N1: { open: 5, closed: 2 },
@@ -16,31 +16,59 @@ function setup() {
 
 describe('Dashboard component', () => {
   beforeEach(() => {
-    mockedGet.mockReset()
-    ;(axios as any).CancelToken = {
-      source: () => ({ token: 't', cancel: jest.fn() }),
-    }
+    mockedHook.mockReset()
   })
 
-  it('shows loading indicator initially', async () => {
-    mockedGet.mockResolvedValue({ data: mockMetrics })
+  it('shows loading indicator initially', () => {
+    mockedHook.mockReturnValue({
+      metrics: undefined,
+      isLoading: true,
+      isError: false,
+      error: null,
+      refreshMetrics: jest.fn(),
+    })
     setup()
     expect(screen.getByRole('status')).toBeInTheDocument()
-    await waitFor(() => expect(screen.getByTestId('dashboard')).toBeInTheDocument())
   })
 
-  it('renders metric cards after fetch', async () => {
-    mockedGet.mockResolvedValue({ data: mockMetrics })
+  it('renders metric cards after fetch', () => {
+    mockedHook.mockReturnValue({
+      metrics: mockMetrics,
+      isLoading: false,
+      isError: false,
+      error: null,
+      refreshMetrics: jest.fn(),
+    })
     setup()
-    await waitFor(() => screen.getByTestId('card-N1'))
+    expect(screen.getByTestId('card-N1')).toBeInTheDocument()
     expect(screen.getByText('Abertos: 5')).toBeInTheDocument()
     expect(screen.getByText('Fechados: 2')).toBeInTheDocument()
   })
 
-  it('shows error message on failure', async () => {
-    mockedGet.mockRejectedValue(new Error('fail'))
+  it('shows error message on failure', () => {
+    mockedHook.mockReturnValue({
+      metrics: undefined,
+      isLoading: false,
+      isError: true,
+      error: new Error('fail'),
+      refreshMetrics: jest.fn(),
+    })
     setup()
-    await waitFor(() => screen.getByText(/Não foi possível carregar/))
+    expect(screen.getByText(/Não foi possível carregar/)).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /tentar novamente/i })).toBeInTheDocument()
+  })
+
+  it('retries fetch when retry button is clicked', () => {
+    const refresh = jest.fn()
+    mockedHook.mockReturnValue({
+      metrics: undefined,
+      isLoading: false,
+      isError: true,
+      error: new Error('fail'),
+      refreshMetrics: refresh,
+    })
+    setup()
+    screen.getByRole('button', { name: /tentar novamente/i }).click()
+    expect(refresh).toHaveBeenCalled()
   })
 })

--- a/src/frontend/react_app/src/hooks/useMetricsOverview.ts
+++ b/src/frontend/react_app/src/hooks/useMetricsOverview.ts
@@ -1,0 +1,48 @@
+'use client'
+
+import { useMemo } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
+import { useApiQuery } from './useApiQuery'
+import type { MetricsOverview } from '../types/metricsOverview'
+
+export const POLLING_INTERVAL_MS = 60000
+
+interface ApiMetricsEntry {
+  open_tickets: number
+  tickets_closed_this_month: number
+}
+
+export function useMetricsOverview() {
+  const queryClient = useQueryClient()
+  const query = useApiQuery<Record<string, ApiMetricsEntry>, Error>(
+    ['metrics-overview'],
+    '/metrics/overview',
+    {
+      refetchInterval: POLLING_INTERVAL_MS,
+    },
+  )
+
+  const metrics = useMemo(() => {
+    if (!query.data) return undefined
+    const transformed: MetricsOverview = {}
+    for (const level of Object.keys(query.data)) {
+      const item = query.data[level]
+      transformed[level] = {
+        open: item.open_tickets ?? 0,
+        closed: item.tickets_closed_this_month ?? 0,
+      }
+    }
+    return transformed
+  }, [query.data])
+
+  const refreshMetrics = () =>
+    queryClient.invalidateQueries({ queryKey: ['metrics-overview'] })
+
+  return {
+    metrics,
+    refreshMetrics,
+    isLoading: query.isLoading,
+    isError: query.isError,
+    error: query.error,
+  }
+}

--- a/src/frontend/react_app/src/types/metricsOverview.ts
+++ b/src/frontend/react_app/src/types/metricsOverview.ts
@@ -1,7 +1,6 @@
 export interface LevelMetrics {
   open: number
   closed: number
-  [key: string]: number
 }
 
 export interface MetricsOverview {


### PR DESCRIPTION
## Summary
- add `useMetricsOverview` hook for polling metrics
- refactor `Dashboard` component to use the new hook
- tighten `LevelMetrics` type
- rewrite dashboard tests for the hook API

## Testing
- `NODE_OPTIONS=--experimental-vm-modules NEXT_PUBLIC_API_BASE_URL=http://test npm --prefix src/frontend/react_app test` *(fails: SyntaxError: Cannot use 'import.meta' outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68826dcdb1ac8320a413508ea5b07081

## Resumo por Sourcery

Refatorar o componente Dashboard para substituir o polling manual com axios por um hook `useMetricsOverview` baseado em `react-query`, aprimorar os tipos de métricas e atualizar os testes de acordo.

Novas Funcionalidades:
- Adicionar o hook `useMetricsOverview` para polling e transformação de métricas via `react-query`

Melhorias:
- Refatorar o componente Dashboard para depender de `useMetricsOverview` para os estados de carregamento, erro e dados
- Aprimorar o tipo `LevelMetrics` removendo sua assinatura de índice

Testes:
- Reescrever os testes do Dashboard para simular o hook `useMetricsOverview` e cobrir o comportamento de carregamento, sucesso, erro e nova tentativa

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the Dashboard component to replace manual axios polling with a react-query-based useMetricsOverview hook, tighten metric types, and update tests accordingly.

New Features:
- Add useMetricsOverview hook for polling and transforming metrics via react-query

Enhancements:
- Refactor Dashboard component to rely on useMetricsOverview for loading, error, and data states
- Tighten LevelMetrics type by removing its index signature

Tests:
- Rewrite Dashboard tests to mock useMetricsOverview hook and cover loading, success, error, and retry behavior

</details>