### PR TITLE
Improve logging infrastructure with filters

### DIFF
--- a/dashboard_app.py
+++ b/dashboard_app.py
@@ -5,10 +5,6 @@ import logging
 import os
 
 import pandas as pd
-from dash import Dash
-from flask import Flask
-from flask_caching import Cache
-
 from backend.core.settings import (
     DASH_PORT,
     GLPI_APP_TOKEN,
@@ -19,11 +15,15 @@ from backend.core.settings import (
     USE_MOCK_DATA,
 )
 from backend.domain.exceptions import GLPIAPIError
-from backend.infrastructure.glpi.glpi_client_logging import setup_logger
+from backend.infrastructure.glpi import glpi_client_logging
 from backend.infrastructure.glpi.glpi_session import Credentials, GLPISession
 from backend.utils import process_raw
+from dash import Dash
+from flask import Flask
+from flask_caching import Cache
 from frontend.callbacks.callbacks import register_callbacks
 from frontend.layout.layout import build_layout
+from shared.utils.logging import init_logging
 
 __all__ = ["create_app", "main"]
 
@@ -53,7 +53,8 @@ if cache_type != "simple":
 
 log_level_name = os.getenv("LOG_LEVEL", "INFO")
 log_level = getattr(logging, log_level_name.upper(), logging.INFO)
-setup_logger(__name__, level=log_level)
+init_logging(log_level)
+glpi_client_logging.init_logging(log_level)
 
 
 @cache.memoize(timeout=300)

--- a/src/backend/api/request_id_middleware.py
+++ b/src/backend/api/request_id_middleware.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import uuid
+from typing import Callable
+
+from shared.utils.logging import set_correlation_id
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.types import ASGIApp
+
+
+class RequestIdMiddleware(BaseHTTPMiddleware):
+    """Attach a ``request_id`` to each request via context variables."""
+
+    def __init__(self, app: ASGIApp) -> None:
+        super().__init__(app)
+
+    async def dispatch(self, request, call_next: Callable):
+        request_id = uuid.uuid4().hex
+        set_correlation_id(request_id)
+        try:
+            response = await call_next(request)
+        finally:
+            set_correlation_id(None)
+        response.headers["X-Request-ID"] = request_id
+        return response

--- a/src/shared/utils/redis_client.py
+++ b/src/shared/utils/redis_client.py
@@ -9,14 +9,13 @@ from typing import Any, Dict, Optional
 
 import pandas as pd
 import redis.asyncio as redis
-import redis.exceptions
-
 from backend.core.settings import (
     REDIS_DB,
     REDIS_HOST,
     REDIS_PORT,
     REDIS_TTL_SECONDS,
 )
+from redis import exceptions as redis_exceptions
 
 logger = logging.getLogger(__name__)
 
@@ -71,7 +70,7 @@ class RedisClient:
             try:
                 await _maybe_await(self._client.ping())
                 logger.info("Successfully connected to Redis.")
-            except redis.exceptions.ConnectionError as e:
+            except redis_exceptions.ConnectionError as e:
                 logger.error("Could not connect to Redis: %s", e)
                 self._client = None
                 raise
@@ -97,7 +96,7 @@ class RedisClient:
             self.metrics.misses += 1
             logger.debug("Cache MISS for key: %s", key)
             return None
-        except redis.exceptions.ConnectionError as e:
+        except redis_exceptions.ConnectionError as e:
             logger.error("Redis connection error during GET: %s", e)
             self._client = None
             return None
@@ -124,7 +123,7 @@ class RedisClient:
                 )
             )
             logger.debug("Cache SET for key %s with TTL %s", redis_key, ttl)
-        except redis.exceptions.ConnectionError as e:
+        except redis_exceptions.ConnectionError as e:
             logger.error("Redis connection error during SET: %s", e)
             self._client = None
         except Exception as e:
@@ -138,8 +137,8 @@ class RedisClient:
             await _maybe_await(client.delete(redis_key))
             logger.debug("Cache DELETE for key: %s", redis_key)
         except (
-            redis.exceptions.AuthenticationError,
-            redis.exceptions.ConnectionError,
+            redis_exceptions.AuthenticationError,
+            redis_exceptions.ConnectionError,
         ) as e:
             logger.error("Redis connection error during DELETE: %s", e)
             self._client = None
@@ -154,8 +153,8 @@ class RedisClient:
             ttl = await _maybe_await(client.ttl(redis_key))
             return int(ttl)
         except (
-            redis.exceptions.AuthenticationError,
-            redis.exceptions.ConnectionError,
+            redis_exceptions.AuthenticationError,
+            redis_exceptions.ConnectionError,
         ) as e:
             logger.error("Redis connection error during TTL: %s", e)
             self._client = None

--- a/worker.py
+++ b/worker.py
@@ -14,22 +14,22 @@ with contextlib.suppress(ImportError):
     # Load environment variables from .env file for local development
     load_dotenv()
 
-from backend.infrastructure.glpi.glpi_client_logging import setup_logger
+from backend.infrastructure.glpi import glpi_client_logging
 from shared.utils.logging import init_logging
+
 from src.backend.api.worker_api import (
     create_app,
-)
-from src.backend.api.worker_api import main as _main
-from src.backend.api.worker_api import (
     redis_client,
 )
+from src.backend.api.worker_api import main as _main
 from src.backend.core.settings import KNOWLEDGE_BASE_FILE
 from src.backend.infrastructure.glpi.glpi_session import GLPISession
 
-# Initialize logging as early as possible
+# Initialize structured logging as early as possible
 log_level_name = os.getenv("LOG_LEVEL", "INFO")
 log_level = getattr(logging, log_level_name.upper(), logging.INFO)
-setup_logger(__name__, level=log_level)
+init_logging(log_level)
+glpi_client_logging.init_logging(log_level)
 
 __all__ = ["create_app", "redis_client", "GLPISession", "main"]
 


### PR DESCRIPTION
## Summary
- initialize structured logging early in worker API and Dash app
- filter sensitive GLPI tokens from logs
- add request ID middleware to FastAPI
- sanitize Redis client exceptions for typing
- hook logging utils into worker script

## Testing
- `pre-commit run --files dashboard_app.py src/backend/api/worker_api.py src/shared/utils/logging.py worker.py src/backend/api/request_id_middleware.py src/shared/utils/redis_client.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'playwright')*

------
https://chatgpt.com/codex/tasks/task_e_68826f2fa358832091fca2f3bda24ae2