### PR TITLE
Add alias unit tests with mocks

### DIFF
--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,78 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import fakeredis
+import pytest
+from backend.infrastructure.glpi.glpi_auth import GLPIAuthClient, GLPIAuthError
+
+from tests.helpers import make_cm
+
+pytest.importorskip("aiohttp")  # noqa: E402
+
+
+def make_session(responses):
+    def side(lst):
+        calls = list(lst)
+
+        def _inner(*args, **kwargs):
+            result = calls.pop(0)
+            if isinstance(result, Exception):
+                raise result
+            return result
+
+        return _inner
+
+    session = SimpleNamespace()
+    session.get = MagicMock(side_effect=side(responses))
+    return session
+
+
+@pytest.mark.asyncio
+async def test_init_session_success(monkeypatch):
+    monkeypatch.setenv("DISABLE_RETRY_BACKOFF", "1")
+    redis = fakeredis.FakeRedis(decode_responses=True)
+    session = make_session([make_cm(200, {"session_token": "tok"})])
+    client = GLPIAuthClient(
+        base_url="http://example.com/apirest.php",
+        app_token="APP",
+        user_token="USER",
+        redis_conn=redis,
+        session=session,
+    )
+    token = await client.init_session()
+    assert token == "tok"
+    assert await redis.get("glpi:session_token") is None
+
+
+@pytest.mark.asyncio
+async def test_init_session_failure(monkeypatch):
+    monkeypatch.setenv("DISABLE_RETRY_BACKOFF", "1")
+    redis = fakeredis.FakeRedis(decode_responses=True)
+    session = make_session([make_cm(401, {})])
+    client = GLPIAuthClient(
+        base_url="http://example.com/apirest.php",
+        app_token="APP",
+        user_token="USER",
+        redis_conn=redis,
+        session=session,
+    )
+    with pytest.raises(GLPIAuthError):
+        await client.init_session()
+
+
+@pytest.mark.asyncio
+async def test_get_session_token_cache(monkeypatch):
+    monkeypatch.setenv("DISABLE_RETRY_BACKOFF", "1")
+    redis = fakeredis.FakeRedis(decode_responses=True)
+    await redis.set("glpi:session_token", "cached")
+    session = make_session([])
+    client = GLPIAuthClient(
+        base_url="http://example.com/apirest.php",
+        app_token="APP",
+        user_token="USER",
+        redis_conn=redis,
+        session=session,
+    )
+    token = await client.get_session_token()
+    assert token == "cached"
+    session.get.assert_not_called()

--- a/tests/test_criteria_builder_alias.py
+++ b/tests/test_criteria_builder_alias.py
@@ -1,0 +1,16 @@
+import pytest
+
+from glpi_criteria_builder import CriteriaBuilder
+
+
+def test_add_simple_alias():
+    builder = CriteriaBuilder(field_map={"status": 1})
+    builder.where_status("Closed")
+    params = builder.build()
+    assert params == {"criteria[0][field]": "1", "criteria[0][search]": "Closed"}
+
+
+def test_unknown_field_alias():
+    builder = CriteriaBuilder(field_map={"status": 1})
+    with pytest.raises(KeyError):
+        builder.add("foo", "bar")

--- a/tests/test_enrichment_alias.py
+++ b/tests/test_enrichment_alias.py
@@ -1,0 +1,18 @@
+from unittest.mock import AsyncMock
+
+import pytest
+from backend.services.glpi_enrichment import GLPIEnrichmentService
+
+
+@pytest.mark.asyncio
+async def test_enrich_ticket_cache(monkeypatch):
+    svc = GLPIEnrichmentService()
+    svc._status_map = {2: "OK"}
+    svc._user_cache = {7: "Fulano"}
+    svc._group_cache = {4: "N2"}
+    monkeypatch.setattr(svc, "_fetch_user_name", AsyncMock())
+    monkeypatch.setattr(svc, "_fetch_group_name", AsyncMock())
+    ticket = {"id": 1, "status": 2, "users_id_recipient": 7, "groups_id_assign": 4}
+    result = await svc.enrich_ticket(ticket)
+    assert result["user_name"] == "Fulano"
+    assert result["group_name"] == "N2"

--- a/tests/test_metrics_alias.py
+++ b/tests/test_metrics_alias.py
@@ -1,0 +1,29 @@
+import pandas as pd
+from fastapi.testclient import TestClient
+
+from app.api import metrics as metrics_module
+from worker import create_app
+
+
+def test_overview_endpoint_alias(monkeypatch):
+    tickets = [
+        {"id": 1, "status": "new", "group": "N1", "date_creation": "2024-06-01"},
+        {
+            "id": 2,
+            "status": "closed",
+            "group": "N1",
+            "date_creation": "2024-06-02",
+            "date_resolved": "2024-06-03",
+        },
+    ]
+
+    async def fake_fetch(_client):
+        return [t for t in tickets]
+
+    monkeypatch.setattr(
+        metrics_module, "fetch_dataframe", lambda client: pd.DataFrame(tickets)
+    )
+    app = create_app()
+    client = TestClient(app)
+    resp = client.get("/metrics/overview")
+    assert resp.status_code == 200

--- a/tests/test_ticket_client.py
+++ b/tests/test_ticket_client.py
@@ -1,0 +1,77 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from glpi_http_utils import GLPIPermissionError
+from glpi_ticket_client import GLPITicketClient
+
+
+class DummyResponse:
+    def __init__(self, status, data):
+        self.status_code = status
+        self.data = data
+
+    def json(self):
+        return self.data
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise GLPIPermissionError()
+
+
+def make_session(responses):
+    def side_effect(*args, **kwargs):
+        result = responses.pop(0)
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+    session = SimpleNamespace()
+    session.request = MagicMock(side_effect=side_effect)
+    session.get = session.request
+    return session
+
+
+class FakeAuth:
+    def __init__(self, tokens):
+        self.tokens = list(tokens)
+        self.calls = 0
+
+    def get_session_token(self, force_refresh=False):
+        self.calls += 1
+        return self.tokens.pop(0)
+
+
+def test_list_tickets_basic():
+    resp = DummyResponse(200, {"data": [{"id": 1}]})
+    session = make_session([resp])
+    client = GLPITicketClient(
+        base_url="http://example.com/apirest.php",
+        auth_client=FakeAuth(["tok"]),
+        session=session,
+    )
+    result = client.list_tickets({"status": "new"}, page=1, page_size=50)
+    assert result == [{"id": 1}]
+    assert session.request.call_args.args[0] == "GET"
+
+
+def test_retry_on_401():
+    responses = [DummyResponse(401, {}), DummyResponse(200, {"data": [{"id": 2}]})]
+    session = make_session(responses)
+    auth = FakeAuth(["old", "new"])
+    client = GLPITicketClient(
+        base_url="http://example.com", auth_client=auth, session=session
+    )
+    result = client.list_tickets()
+    assert result == [{"id": 2}]
+    assert auth.calls == 2
+
+
+def test_http_error():
+    session = make_session([DummyResponse(403, {})])
+    client = GLPITicketClient(
+        base_url="http://example.com", auth_client=FakeAuth(["tok"]), session=session
+    )
+    with pytest.raises(GLPIPermissionError):
+        client.list_tickets()


### PR DESCRIPTION
## Summary
- add additional alias test files for auth, ticket client, criteria builder, enrichment service and metrics
- use fakeredis and mocks for isolation

## Testing
- `pytest tests/test_criteria_builder_alias.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68827c3d66c0832098e030818dba5bf9

## Resumo por Sourcery

Adiciona testes unitários de alias para autenticação, cliente de tickets, construtor de critérios, serviço de enriquecimento e métricas, usando Fakeredis e mocks para isolamento.

Testes:
- Adiciona testes unitários para GLPIAuthClient cobrindo sucesso na inicialização da sessão, falha e cache de token com Fakeredis
- Adiciona testes unitários para GLPITicketClient cobrindo listagem de tickets, retentativa em 401 e tratamento de erro de permissão
- Adiciona testes unitários para o endpoint FastAPI de visão geral de métricas usando alias de pandas DataFrame
- Adiciona testes unitários para GLPIEnrichmentService validando a lógica de cache de enriquecimento de tickets
- Adiciona testes unitários para CriteriaBuilder funcionalidade de alias para campos simples e desconhecidos

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add alias unit tests for auth, ticket client, criteria builder, enrichment service, and metrics using Fakeredis and mocks for isolation

Tests:
- Add unit tests for GLPIAuthClient covering session initialization success, failure, and token caching with Fakeredis
- Add unit tests for GLPITicketClient covering ticket listing, retry on 401, and permission error handling
- Add unit tests for metrics overview FastAPI endpoint using pandas DataFrame alias
- Add unit tests for GLPIEnrichmentService validating ticket enrichment caching logic
- Add unit tests for CriteriaBuilder alias functionality for simple and unknown fields

</details>