### PR TITLE
Cleanup test helpers and remove unused code

### DIFF
--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,30 +1,10 @@
-from types import SimpleNamespace
-from unittest.mock import MagicMock
-
-import fakeredis
+import fakeredis.aioredis as fakeredis
 import pytest
 from backend.infrastructure.glpi.glpi_auth import GLPIAuthClient, GLPIAuthError
 
-from tests.helpers import make_cm
+from tests.helpers import make_cm, make_session
 
 pytest.importorskip("aiohttp")  # noqa: E402
-
-
-def make_session(responses):
-    def side(lst):
-        calls = list(lst)
-
-        def _inner(*args, **kwargs):
-            result = calls.pop(0)
-            if isinstance(result, Exception):
-                raise result
-            return result
-
-        return _inner
-
-    session = SimpleNamespace()
-    session.get = MagicMock(side_effect=side(responses))
-    return session
 
 
 @pytest.mark.asyncio

--- a/tests/test_metrics_alias.py
+++ b/tests/test_metrics_alias.py
@@ -17,9 +17,6 @@ def test_overview_endpoint_alias(monkeypatch):
         },
     ]
 
-    async def fake_fetch(_client):
-        return [t for t in tickets]
-
     monkeypatch.setattr(
         metrics_module, "fetch_dataframe", lambda client: pd.DataFrame(tickets)
     )

--- a/tests/test_ticket_client.py
+++ b/tests/test_ticket_client.py
@@ -1,10 +1,8 @@
-from types import SimpleNamespace
-from unittest.mock import MagicMock
-
 import pytest
 
 from glpi_http_utils import GLPIPermissionError
 from glpi_ticket_client import GLPITicketClient
+from tests.helpers import make_session
 
 
 class DummyResponse:
@@ -18,19 +16,6 @@ class DummyResponse:
     def raise_for_status(self):
         if self.status_code >= 400:
             raise GLPIPermissionError()
-
-
-def make_session(responses):
-    def side_effect(*args, **kwargs):
-        result = responses.pop(0)
-        if isinstance(result, Exception):
-            raise result
-        return result
-
-    session = SimpleNamespace()
-    session.request = MagicMock(side_effect=side_effect)
-    session.get = session.request
-    return session
 
 
 class FakeAuth:


### PR DESCRIPTION
## Summary
- share `make_session` helper across tests
- remove unused `fake_fetch` helper
- use async fakeredis for `test_auth`
- minor formatting fixes

## Testing
- `pre-commit run --files tests/test_ticket_client.py tests/test_auth.py tests/helpers.py tests/test_metrics_alias.py`
- `pytest tests/test_auth.py::test_init_session_success -vv -s`
- `pytest tests/test_ticket_client.py::test_list_tickets_basic -vv`


------
https://chatgpt.com/codex/tasks/task_e_6882825849908320b1c9f42b8f0e570e

## Resumo por Sourcery

Limpeza do conjunto de testes ao consolidar os auxiliares de mock de sessão, remover código morto, atualizar importações e aplicar correções de formatação

Melhorias:
- Extrair o auxiliar make_session para tests/helpers.py e remover definições duplicadas
- Remover o auxiliar fake_fetch não utilizado em test_metrics_alias.py
- Atualizar test_auth para importar fakeredis.aioredis para suporte assíncrono ao Redis
- Aplicar pequenas correções de formatação e adicionar noqa às importações

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Cleanup test suite by consolidating session mock helpers, removing dead code, updating imports, and applying formatting fixes

Enhancements:
- Extract make_session helper into tests/helpers.py and remove duplicate definitions
- Remove unused fake_fetch helper in test_metrics_alias.py
- Update test_auth to import fakeredis.aioredis for async Redis support
- Apply minor formatting fixes and add noqa to imports

</details>