### PR TITLE
Update CI workflow per review

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -19,19 +19,23 @@ jobs:
         run: |
           python -m pip install -U pip
           pip install -r requirements.txt
-          pip install flake8 black pytest pip-audit
+          pip install black isort pytest ruff pip-audit
       - name: Lint
         run: |
           black --check .
-          flake8
+          isort --check-only .
+          ruff check .
       - name: Run tests
-        run: pytest -k "nomatch" -q
+        run: pytest -q
       - name: Security audit
         run: pip-audit
 
   docker-build:
     needs: lint-test
-    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
+    # Run on direct pushes to main, PR merges to main, and tags
+    if: |
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -41,7 +45,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.GHCR_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Extract version
         id: version
         run: echo "value=$(grep -oP '^version\s*=\s*\"\K[0-9.]+(?=\")' pyproject.toml)" >> $GITHUB_OUTPUT
@@ -62,4 +66,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Deploy image
-        run: echo "Deploying ${{ needs.docker-build.outputs.version }} to production"
+        run: |
+          bash scripts/deploy/deploy_production.sh \
+            ghcr.io/${{ github.repository_owner }}/glpi-dashboard-cau:${{ needs.docker-build.outputs.version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,9 @@ ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
 COPY requirements.txt ./
 RUN --mount=type=cache,target=/root/.cache/pip \
-    pip install --no-cache-dir -r requirements.txt
+    pip install -r requirements.txt
 COPY . .
-RUN pip install --no-cache-dir -e .
+RUN pip install .
 
 FROM python:3.11-slim
 RUN useradd -m appuser

--- a/README.md
+++ b/README.md
@@ -1002,7 +1002,7 @@ for details on how this script was used during the structural refactor.
 This project is released under the [MIT License](LICENSE).
 
 ### CI/CD Pipeline
-A GitHub Actions workflow (`cicd.yml`) runs linting, a minimal test suite and builds a Docker image for pushes to `main` or version tags. The resulting image is published to GHCR and can be deployed automatically.
+A GitHub Actions workflow (`cicd.yml`) runs linting with **ruff**, **black** and **isort**, executes the full pytest suite and builds a Docker image for pushes to `main` or version tags. The resulting image is published to GHCR and deployed through `scripts/deploy/deploy_production.sh`.
 For CI/CD governance guidelines, see [docs/governanca_tecnica_prompt.md](docs/governanca_tecnica_prompt.md).
 Guidance on connecting the API to Copilot Studio is available in
 [docs/copilot_integration.md](docs/copilot_integration.md).

--- a/scripts/deploy/deploy_production.sh
+++ b/scripts/deploy/deploy_production.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -euo pipefail
+
+IMAGE="$1"
+
+# Pull the image and restart the service using docker compose.
+
+echo "Pulling $IMAGE"
+docker pull "$IMAGE"
+
+echo "Updating service"
+docker compose -f docker-compose.prod.yml up -d


### PR DESCRIPTION
## Summary
- replace flake8 with ruff and add isort checks
- drop minimal test filter and use GITHUB_TOKEN for GHCR login
- improve Docker build and deployment steps
- adjust Dockerfile install commands
- document updated pipeline in README

## Testing
- `pre-commit run --files .github/workflows/cicd.yml Dockerfile README.md scripts/deploy/deploy_production.sh`
- `pytest tests/test_backend_config.py::test_get_redis_connection_failure_logs_warning -q`

------
https://chatgpt.com/codex/tasks/task_e_68828691da708320a084eb0b1748f936

## Resumo por Sourcery

Atualiza o workflow de CI para usar linting com ruff e isort, executar testes completos, ajustar gatilhos de CI e etapas de build do Docker, mudar a autenticação do GHCR para GITHUB_TOKEN, adicionar um script de deploy de produção e documentar o pipeline atualizado.

Novos Recursos:
- Adiciona verificações de lint isort ao workflow de CI
- Introduz um script de deploy de produção e o integra ao CI

Melhorias:
- Substitui flake8 por ruff para linting
- Executa a suíte completa do pytest em vez de um filtro de teste mínimo
- Usa GITHUB_TOKEN para autenticação no GHCR
- Expande os gatilhos de CI para eventos de push em main e tags
- Simplifica os comandos de instalação do Dockerfile

Deploy:
- Adiciona scripts/deploy/deploy_production.sh para puxar e atualizar o serviço de produção

Documentação:
- Atualiza o README para refletir as novas ferramentas de lint, suíte de testes completa e processo de deploy

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update CI workflow to use ruff and isort linting, run full tests, adjust CI triggers and Docker build steps, switch GHCR auth to GITHUB_TOKEN, add a production deployment script, and document the updated pipeline

New Features:
- Add isort lint checks to the CI workflow
- Introduce a production deployment script and integrate it into CI

Enhancements:
- Replace flake8 with ruff for linting
- Run the full pytest suite instead of a minimal test filter
- Use GITHUB_TOKEN for GHCR authentication
- Expand CI triggers to push events on main and tags
- Simplify Dockerfile install commands

Deployment:
- Add scripts/deploy/deploy_production.sh for pulling and updating the production service

Documentation:
- Update README to reflect the new lint tools, full test suite, and deployment process

</details>