### PR TITLE
fix ticket aliasing for frontend

### DIFF
--- a/src/backend/application/batch_fetch.py
+++ b/src/backend/application/batch_fetch.py
@@ -40,7 +40,8 @@ async def fetch_all_tickets(ids: List[int]) -> List[dict]:
     client = GlpiApiClient(session=session)
     async with client:
         tickets = await client.fetch_tickets_by_ids(ids)
-    return [t.model_dump() for t in tickets]
+    # Preserve original GLPI field names when exporting to JSON
+    return [t.model_dump(by_alias=True) for t in tickets]
 
 
 async def fetch_all_tickets_tool(params: BatchFetchParams) -> str:

--- a/src/backend/application/ticket_loader.py
+++ b/src/backend/application/ticket_loader.py
@@ -6,9 +6,6 @@ from pathlib import Path
 from typing import AsyncGenerator, List, Optional, cast
 
 import pandas as pd
-from fastapi import HTTPException
-from fastapi.responses import Response
-
 from backend.adapters.factory import create_glpi_session
 from backend.application.aggregated_metrics import (
     cache_aggregated_metrics,
@@ -20,6 +17,8 @@ from backend.application.aggregated_metrics import (
 from backend.application.glpi_api_client import GlpiApiClient
 from backend.core.settings import MOCK_TICKETS_FILE, USE_MOCK_DATA
 from backend.infrastructure.glpi.normalization import process_raw
+from fastapi import HTTPException
+from fastapi.responses import Response
 from shared.dto import CleanTicketDTO
 from shared.utils.redis_client import RedisClient, redis_client
 
@@ -135,7 +134,8 @@ async def load_tickets(
         try:
             async with client:
                 tickets = await client.fetch_tickets()
-            data = [t.model_dump() for t in cast(list, tickets)]
+            # Use aliases so ``name`` and ``date_creation`` are preserved
+            data = [t.model_dump(by_alias=True) for t in cast(list, tickets)]
             logger.info("Sucesso ao buscar %d tickets da API do GLPI.", len(data))
         except Exception as exc:
             logger.exception(


### PR DESCRIPTION
## Summary
- ensure ticket_loader and batch_fetch preserve alias field names

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fakeredis')*

------
https://chatgpt.com/codex/tasks/task_e_68828e2c86b883208d88f99db0aa003b

## Resumo por Sourcery

Correções de Bugs:
- Usar `model_dump(by_alias=True)` em `ticket_loader.load_tickets` e `batch_fetch.fetch_all_tickets` para manter nomes de campos com alias

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Use model_dump(by_alias=True) in ticket_loader.load_tickets and batch_fetch.fetch_all_tickets to maintain alias field names

</details>