### PR TITLE
Fix API token handling and logging

### DIFF
--- a/src/backend/api/worker_api.py
+++ b/src/backend/api/worker_api.py
@@ -44,7 +44,6 @@ from shared.utils.api_auth import verify_api_key
 from shared.utils.json import UTF8JSONResponse
 from shared.utils.logging import init_logging
 from shared.utils.redis_client import redis_client
-from shared.utils.security import validate_glpi_tokens
 from strawberry.fastapi import GraphQLRouter
 from strawberry.types import Info
 
@@ -149,8 +148,6 @@ class Query:
 def create_app(client: Optional[GlpiApiClient] = None, cache=None) -> FastAPI:
     """Create FastAPI app with REST and GraphQL routes."""
     cache = cache or redis_client
-
-    validate_glpi_tokens()
 
     if client is None:
         client = create_glpi_api_client()

--- a/src/shared/utils/api_auth.py
+++ b/src/shared/utils/api_auth.py
@@ -3,14 +3,14 @@ import os
 from fastapi import HTTPException, Security
 from fastapi.security import APIKeyHeader
 
-API_TOKEN = os.getenv("DASHBOARD_API_TOKEN")
 api_key_header = APIKeyHeader(name="X-API-Token", auto_error=False)
 
 
-def verify_api_key(api_key: str = Security(api_key_header)) -> bool:
+def verify_api_key(api_key: str | None = Security(api_key_header)) -> bool:
     """Verify dashboard API token."""
-    if API_TOKEN and api_key == API_TOKEN:
+    token = os.getenv("DASHBOARD_API_TOKEN")
+    if token and api_key == token:
         return True
-    if API_TOKEN:
+    if token:
         raise HTTPException(status_code=401, detail="Unauthorized")
     return True

--- a/src/shared/utils/logging.py
+++ b/src/shared/utils/logging.py
@@ -24,7 +24,7 @@ _SECRET_TOKENS = {
         os.getenv("GLPI_APP_TOKEN"),
         os.getenv("GLPI_USER_TOKEN"),
     )
-    if token
+    if token is not None
 }
 _SESSION_RE = re.compile(r"session_token=([A-Za-z0-9\-]+)")
 # Generic pattern for API tokens (hex strings >=40 chars)

--- a/tests/integration/test_dashboard.py
+++ b/tests/integration/test_dashboard.py
@@ -9,9 +9,9 @@ from pathlib import Path
 from types import ModuleType
 
 import pytest
-from aiohttp import web
 
 pytest.importorskip("aiohttp")
+from aiohttp import web  # noqa: E402
 
 ROOT = Path(__file__).resolve().parents[2]
 main_globals = runpy.run_path(str(ROOT / "dashboard_app.py"))


### PR DESCRIPTION
## Summary
- sanitize tokens with strict `is not None` check
- read `DASHBOARD_API_TOKEN` in `verify_api_key` on each call
- remove unused token validation in `create_app`
- reorder aiohttp import in integration tests

## Testing
- `pre-commit run --files src/shared/utils/logging.py src/shared/utils/api_auth.py src/backend/api/worker_api.py tests/integration/test_dashboard.py`
- `pytest -q` *(fails: ModuleNotFoundError: 'playwright', 'libcst', 'pandas', 'fakeredis', 'redis'...)*

------
https://chatgpt.com/codex/tasks/task_e_6882924bcd70832087cddd3c53944fea

## Resumo por Sourcery

Melhorar o tratamento de tokens de API buscando o token em tempo de execução, reforçando as verificações de presença do token e removendo validações redundantes, e corrigir a ordem das importações em testes de integração

Melhorias:
- Ler a variável de ambiente DASHBOARD_API_TOKEN em cada invocação de `verify_api_key` em vez de no momento da importação
- Usar verificação explícita de `None` para tokens na utilidade de log para sanear adequadamente valores falsy
- Remover a chamada não utilizada `validate_glpi_tokens` da criação do aplicativo FastAPI

Testes:
- Reordenar a importação de `aiohttp` após `pytest.importorskip` no teste de integração

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhance API token handling by fetching the token at runtime, tightening token presence checks, and removing redundant validation, and fix import ordering in integration tests

Enhancements:
- Read the DASHBOARD_API_TOKEN environment variable on each verify_api_key invocation instead of at import time
- Use explicit None check for tokens in logging utility to properly sanitize falsy values
- Remove unused validate_glpi_tokens call from FastAPI app creation

Tests:
- Reorder aiohttp import after pytest.importorskip in integration test

</details>