### PR TITLE
Add priority normalization

### DIFF
--- a/src/backend/infrastructure/glpi/normalization.py
+++ b/src/backend/infrastructure/glpi/normalization.py
@@ -14,7 +14,14 @@ import pandas as pd
 
 TicketData = Union[List[dict], pd.DataFrame, pd.Series]
 
-REQUIRED_FIELDS = ["id", "status", "group", "assigned_to", "date_creation"]
+REQUIRED_FIELDS = [
+    "id",
+    "status",
+    "group",
+    "assigned_to",
+    "date_creation",
+    "priority",
+]
 
 # Map alternate/underscore-prefixed field names returned by the GLPI API to the
 # canonical column names used by the dashboard.
@@ -69,6 +76,11 @@ def process_raw(data: TicketData) -> pd.DataFrame:
         .str.lower()
         .astype("category")
     )
+    df["priority"] = pd.to_numeric(
+        df.get("priority", pd.Series([pd.NA] * len(df), index=idx)),
+        errors="coerce",
+        downcast="integer",
+    ).astype("Int64")
     df["group"] = (
         df.get("group", pd.Series([""] * len(df), index=idx)).fillna("").astype(str)
     ).astype("category")
@@ -83,7 +95,9 @@ def process_raw(data: TicketData) -> pd.DataFrame:
         assigned_to = assigned_raw.astype(str)
     df["assigned_to"] = assigned_to.replace({"<NA>": "", "nan": ""}).fillna("")
 
-    return df[["id", "name", "status", "assigned_to", "group", "date_creation"]].copy()
+    return df[
+        ["id", "name", "status", "priority", "assigned_to", "group", "date_creation"]
+    ].copy()
 
 
 __all__ = [

--- a/src/backend/infrastructure/glpi/normalization.py
+++ b/src/backend/infrastructure/glpi/normalization.py
@@ -77,7 +77,7 @@ def process_raw(data: TicketData) -> pd.DataFrame:
         .astype("category")
     )
     df["priority"] = pd.to_numeric(
-        df.get("priority", pd.Series([pd.NA] * len(df), index=idx)),
+        df.get("priority", pd.Series(pd.NA, index=idx)),
         errors="coerce",
         downcast="integer",
     ).astype("Int64")

--- a/tests/test_data_pipeline.py
+++ b/tests/test_data_pipeline.py
@@ -15,11 +15,12 @@ def test_process_raw_sanitization():
     ]
     df = process_raw(raw)
 
-    assert df.shape == (3, 6)
+    assert df.shape == (3, 7)
     assert df.columns.tolist() == [
         "id",
         "name",
         "status",
+        "priority",
         "assigned_to",
         "group",
         "date_creation",
@@ -30,6 +31,7 @@ def test_process_raw_sanitization():
     assert df["name"].iloc[1] == "Chamado A"
     assert df["assigned_to"].iloc[0] == "123"
     assert df["group"].tolist() == ["", "", ""]
+    assert df["priority"].isna().all()
     assert df["date_creation"].isna().all()
 
 
@@ -48,6 +50,7 @@ def test_process_raw_aliases():
     df = process_raw(raw)
 
     assert df.iloc[0]["status"] == "new"
+    assert df.iloc[0]["priority"] == 2
     assert df.iloc[0]["assigned_to"] == "5"
     assert df.iloc[0]["group"] == "N1"
     assert df.iloc[0]["id"] == 1


### PR DESCRIPTION
## Summary
- keep priority column during GLPI ticket normalization
- check priority alias in data pipeline tests

## Testing
- `pre-commit run --files src/backend/infrastructure/glpi/normalization.py tests/test_data_pipeline.py`
- `pytest tests/test_data_pipeline.py`

------
https://chatgpt.com/codex/tasks/task_e_6882b7337e88832090c02c3658570eea

## Resumo por Sourcery

Adiciona suporte para preservar e normalizar o campo de prioridade nos dados de tickets do GLPI, incluindo conversão de tipo, ordenamento de retorno e atualizações correspondentes nos testes

Novas Funcionalidades:
- Inclui a coluna de prioridade na normalização e saída de tickets do GLPI

Melhorias:
- Converte valores de prioridade para o tipo inteiro anulável e os preserva durante a normalização

Testes:
- Atualiza os testes do pipeline de dados para esperar a coluna de prioridade e verificar o mapeamento de apelidos e valores ausentes

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for preserving and normalizing the priority field in GLPI ticket data, including type conversion, return ordering, and corresponding test updates

New Features:
- Include priority column in GLPI ticket normalization and output

Enhancements:
- Convert priority values to nullable integer type and preserve during normalization

Tests:
- Update data pipeline tests to expect the priority column and verify alias mapping and missing values

</details>