### PR TITLE
Update docs for ticket priority string

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,9 +466,10 @@ When the FastAPI service starts it primes the Redis cache by calling
 `load_tickets()`. This fills the `chamados_por_data` and
 `metrics_aggregated` keys so endpoints are responsive immediately.
 
-The service exposes several endpoints:
+- The service exposes several endpoints:
 
-- `/tickets` – full list of tickets in JSON format.
+- `/tickets` – full list of tickets in JSON format. As of v0.2 this payload
+  includes the ticket `priority` as a text label.
 - `/tickets/stream` – Server‑Sent Events (SSE) stream of progress followed by the JSON payload.
 - `/metrics` – summary with `total`, `opened` and `closed` counts.
 - `/metrics/aggregated` – counts grouped by status and technician, pre-computed by the worker.
@@ -477,6 +478,19 @@ The service exposes several endpoints:
 - `/graphql/` – GraphQL API providing the same information.
 - `/cache/stats` – returns cache hit/miss metrics.
 - `/health` – quick check that the worker can reach the GLPI API.
+
+Example ticket payload:
+
+```json
+[
+  {
+    "id": 42,
+    "title": "Network issue",
+    "status": "New",
+    "priority": "High"
+  }
+]
+```
 
 ### Offline fallback
 

--- a/docs/ARCHITECTURE_backup.md
+++ b/docs/ARCHITECTURE_backup.md
@@ -15,7 +15,7 @@ This document provides a quick overview of how the repository is structured, the
 
 1. `glpi_session.py` authenticates against the GLPI REST API.
 2. Background workers normalise the responses into `pandas.DataFrame` objects and store them in Redis/PostgreSQL.
-3. The FastAPI layer (`src/backend/api/worker_api.py`) exposes `/tickets` and `/metrics` endpoints that read from this cache.
+3. The FastAPI layer (`src/backend/api/worker_api.py`) exposes `/tickets` and `/metrics` endpoints that read from this cache. The `/tickets` response now includes the `priority` string.
 4. Dash components or the React front‑end request these endpoints to render tables and charts.
 
 ```text

--- a/docs/developer_usage.md
+++ b/docs/developer_usage.md
@@ -74,9 +74,23 @@ python worker.py
 Endpoints relevantes:
 
 - `/tickets` – lista completa de chamados
+-   A resposta inclui o campo `priority` em formato textual.
 - `/metrics` – contagem de abertos/fechados
 - `/graphql/` – versão GraphQL
 - `/cache/stats` – estatísticas de cache
+
+Exemplo de retorno:
+
+```json
+[
+  {
+    "id": 7,
+    "title": "Falha no proxy",
+    "status": "Closed",
+    "priority": "Medium"
+  }
+]
+```
 
 ## Utilizando o ETL
 

--- a/docs/developer_usage.md
+++ b/docs/developer_usage.md
@@ -74,7 +74,7 @@ python worker.py
 Endpoints relevantes:
 
 - `/tickets` – lista completa de chamados
--   A resposta inclui o campo `priority` em formato textual.
+- A resposta inclui o campo `priority` em formato textual.
 - `/metrics` – contagem de abertos/fechados
 - `/graphql/` – versão GraphQL
 - `/cache/stats` – estatísticas de cache

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -97,7 +97,7 @@ Imports reference `@/` as a shortcut to the `src/` folder. Both Vite and TypeScr
 
 ### API Integration
 
-Start the worker with `python worker.py` (it listens on port `8000` by default) and point the front-end to it using the `NEXT_PUBLIC_API_BASE_URL` variable. Example fetching ticket metrics:
+Start the worker with `python worker.py` (it listens on port `8000` by default) and point the front-end to it using the `NEXT_PUBLIC_API_BASE_URL` variable. The `/tickets` endpoint now returns the `priority` as a string. Example fetching ticket metrics:
 
 ```ts
 const resp = await fetch(`${import.meta.env.NEXT_PUBLIC_API_BASE_URL}/tickets/metrics`);


### PR DESCRIPTION
## Summary
- document that `/tickets` now returns the priority string
- show small example payloads highlighting `priority`

## Testing
- `make test` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6882c1241a9083209a2e3b3887746776

## Resumo por Sourcery

Atualizar a documentação para refletir que o endpoint `/tickets` agora retorna um campo `priority` textual e adicionar exemplos de payloads ilustrando seu uso

Documentação:
- Mencionar o campo `priority` nas respostas de `/tickets` em README, developer_usage, architecture e frontend docs
- Adicionar exemplos JSON mostrando a `priority` do ticket em README e developer_usage.md

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update documentation to reflect that the /tickets endpoint now returns a textual `priority` field and add example payloads illustrating its usage

Documentation:
- Mention `priority` field in /tickets responses across README, developer_usage, architecture, and frontend docs
- Add JSON examples showing the ticket `priority` in README and developer_usage.md

</details>