### PR TITLE
Implement header-aware pagination

### DIFF
--- a/src/backend/infrastructure/glpi/glpi_session.py
+++ b/src/backend/infrastructure/glpi/glpi_session.py
@@ -795,9 +795,10 @@ class GLPISession:
                 "range": f"{offset}-{offset + page_size - 1}",
             }
 
-            data, headers = await self.get(
+            response = await self.get(
                 endpoint, params=page_params, return_headers=True
             )
+            data, headers = response if isinstance(response, tuple) else (response, {})
 
             if total is None:
                 range_header = headers.get("Content-Range")

--- a/src/backend/infrastructure/glpi/glpi_session.py
+++ b/src/backend/infrastructure/glpi/glpi_session.py
@@ -10,6 +10,8 @@ from urllib.parse import urlsplit, urlunsplit
 
 import aiohttp
 from aiohttp import BasicAuth, ClientResponse, ClientSession, FormData, TCPConnector
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
 from backend.core.settings import (
     GLPI_APP_TOKEN,
     GLPI_BASE_URL,
@@ -30,7 +32,6 @@ from backend.domain.exceptions import (
     GLPIUnauthorizedError,
 )
 from backend.domain.tool_error import ToolError
-from pydantic import BaseModel, ConfigDict, Field, model_validator
 from shared.utils.resilience import call_with_breaker, retry_api_call
 
 logger = logging.getLogger(__name__)
@@ -787,15 +788,22 @@ class GLPISession:
 
         results: List[Dict[str, Any]] = []
         offset = 0
+        total: Optional[int] = None
         while True:
             page_params: Dict[str, Any] = {
                 **params,
                 "range": f"{offset}-{offset + page_size - 1}",
             }
 
-            data: Union[Dict[str, Any], List[Any]] = await self.get(
-                endpoint, params=page_params
+            data, headers = await self.get(
+                endpoint, params=page_params, return_headers=True
             )
+
+            if total is None:
+                range_header = headers.get("Content-Range")
+                if range_header and "/" in range_header:
+                    with contextlib.suppress(ValueError):
+                        total = int(range_header.split("/")[-1])
 
             items: Any = data.get("data", data) if isinstance(data, dict) else data
             if isinstance(items, dict):
@@ -805,6 +813,9 @@ class GLPISession:
                 break
 
             results.extend(items)
+
+            if total is not None and offset + len(items) >= total:
+                break
 
             if len(items) < page_size:
                 break


### PR DESCRIPTION
## Summary
- rely on `Content-Range` header in `_paginate_search`
- add regression test for header-based pagination

## Testing
- `pre-commit run --files src/backend/infrastructure/glpi/glpi_session.py tests/test_glpi_rest_client.py`
- `pytest -q` *(fails: ModuleNotFoundError: playwright, libcst, pandas, ...)*

------
https://chatgpt.com/codex/tasks/task_e_6882cdf909e0832087613361a844f315

## Resumo por Sourcery

Habilita a paginação ciente do cabeçalho para sessões GLPI, analisando o cabeçalho `Content-Range` para determinar o total de registros e parar precocemente, e adiciona testes de regressão para este comportamento.

Novas Funcionalidades:
- Analisa o cabeçalho `Content-Range` em `_paginate_search` para calcular o total de itens e interromper a paginação quando atingido

Melhorias:
- Refatora `_paginate_search` para retornar cabeçalhos de resposta via flag `return_headers`
- Remove importações pydantic não utilizadas do módulo `glpi_session`

Testes:
- Adiciona teste para parada antecipada orientada por `content-range` em `index_all_paginated`
- Ajusta importações de teste para incluir `aiohttp` e consolidar classes de resposta fictícias

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable header-aware pagination for GLPI sessions by parsing the Content-Range header to determine total records and stop early, and add regression tests for this behavior.

New Features:
- Parse Content-Range header in _paginate_search to compute total items and halt pagination when reached

Enhancements:
- Refactor _paginate_search to return response headers via return_headers flag
- Remove unused pydantic imports from glpi_session module

Tests:
- Add test for content-range–driven early stop in index_all_paginated
- Adjust test imports to include aiohttp and consolidate dummy response classes

</details>