### PR TITLE
Add priority label mapping

### DIFF
--- a/src/backend/adapters/mapping_service.py
+++ b/src/backend/adapters/mapping_service.py
@@ -5,9 +5,20 @@ from typing import Any, Dict, Optional, cast
 
 import aiohttp
 import redis.asyncio as redis
+
 from backend.core.settings import REDIS_DB, REDIS_HOST, REDIS_PORT
 from backend.infrastructure.glpi.glpi_session import GLPIAPIError, GLPISession
 from shared.utils.redis_client import RedisClient
+
+# Map numeric priority levels to human readable labels used in the dashboard.
+PRIORITY_MAP = {
+    1: "Muito Baixa",
+    2: "Baixa",
+    3: "Média",
+    4: "Alta",
+    5: "Muito Alta",
+    6: "Maior",
+}
 
 logger = logging.getLogger(__name__)
 
@@ -102,6 +113,10 @@ class MappingService:
         """Return user name for ``user_id`` or ``"Unassigned"`` if missing."""
         user_map = await self.get_user_map()
         return user_map.get(user_id, "Unassigned")
+
+    def priority_label(self, pid: int) -> str:
+        """Return the human readable label for ``pid``."""
+        return PRIORITY_MAP.get(pid, "Unknown")
 
     async def get_search_options(self, itemtype: str) -> Dict[str, Any]:
         """Return cached search options for ``itemtype`` or fetch from GLPI."""

--- a/src/shared/dto.py
+++ b/src/shared/dto.py
@@ -33,7 +33,7 @@ PRIORITY_MAP = {
 }
 
 # Fallback title assigned when a ticket comes with an empty or null name
-DEFAULT_TITLE = "Untitled ticket"
+DEFAULT_TITLE = "[Título não informado]"
 
 
 class RawTicketFromAPI(BaseModel):
@@ -68,7 +68,12 @@ class CleanTicketDTO(BaseModel):
     @classmethod
     def _sanitize_title(cls, data: Dict[str, Any]) -> Dict[str, Any]:
         title = data.get("name")
-        data["name"] = DEFAULT_TITLE if title in (None, "") else str(title)
+        if "name" not in data or title == "":
+            data["name"] = DEFAULT_TITLE
+        elif title is None:
+            data["name"] = ""
+        else:
+            data["name"] = str(title)
         return data
 
     @field_validator("status", mode="before")
@@ -91,9 +96,16 @@ class CleanTicketDTO(BaseModel):
     @field_validator("priority", mode="before")
     @classmethod
     def _validate_priority(
-        cls, v: Optional[int]
+        cls, v: int | str | None
     ) -> Optional[str]:  # pragma: no cover - simple mapping
-        return None if v is None else PRIORITY_MAP.get(v, "Unknown")
+        if v is None:
+            return None
+        if isinstance(v, str) and not v.isdigit():
+            return v
+        try:
+            return PRIORITY_MAP.get(int(v), "Unknown")
+        except (ValueError, TypeError):  # noqa: PERF203
+            return "Unknown"
 
 
 class TicketTranslator:
@@ -111,11 +123,17 @@ class TicketTranslator:
         if validated_raw.users_id_assign:
             assigned_to = await self.mapper.get_username(validated_raw.users_id_assign)
 
+        priority_label = (
+            self.mapper.priority_label(validated_raw.priority)
+            if validated_raw.priority is not None
+            else None
+        )
+
         clean_data: Dict[str, Any] = {
             "id": validated_raw.id,
             "name": validated_raw.name,
             "status": validated_raw.status,
-            "priority": validated_raw.priority,
+            "priority": priority_label,
             "date_creation": validated_raw.date_creation,
             "assigned_to": assigned_to,
         }

--- a/tests/test_clean_ticket_dto.py
+++ b/tests/test_clean_ticket_dto.py
@@ -94,3 +94,17 @@ def test_clean_ticket_dto_text_status():
     ticket = CleanTicketDTO.model_validate(data)
 
     assert ticket.status == "Closed"
+
+
+@pytest.mark.unit
+def test_clean_ticket_dto_preconverted_priority():
+    data = {
+        "id": 4,
+        "name": "Router",
+        "status": 1,
+        "priority": "Alta",
+    }
+
+    ticket = CleanTicketDTO.model_validate(data)
+
+    assert ticket.priority == "Alta"

--- a/tests/test_mapping_service.py
+++ b/tests/test_mapping_service.py
@@ -1,9 +1,12 @@
 import aiohttp
 import pytest
+from redis.asyncio import Redis
+
 from backend.adapters.mapping_service import MappingService
 from backend.infrastructure.glpi.glpi_session import GLPISession
-from redis.asyncio import Redis
 from shared.utils.redis_client import RedisClient
+
+INVALID_CACHE_VALUE = object()
 
 
 @pytest.mark.asyncio
@@ -148,3 +151,10 @@ async def test_get_search_options_network_error(mocker):
         {},
         ttl_seconds=300,
     )
+
+
+@pytest.mark.unit
+def test_priority_label_lookup(mocker) -> None:
+    svc = MappingService(mocker.Mock())
+    assert svc.priority_label(3) == "Média"
+    assert svc.priority_label(99) == "Unknown"

--- a/tests/test_ticket_translator.py
+++ b/tests/test_ticket_translator.py
@@ -8,6 +8,7 @@ from shared.dto import CleanTicketDTO, TicketTranslator
 async def test_translate_ticket_maps_values(mocker):
     mapper = mocker.Mock(spec=MappingService)
     mapper.get_username = mocker.AsyncMock(return_value="Alice")
+    mapper.priority_label = mocker.Mock(return_value="High")
 
     translator = TicketTranslator(mapper)
     raw = {
@@ -46,3 +47,25 @@ async def test_translate_ticket_unassigned(mocker):
     ticket = await translator.translate_ticket(raw)
 
     assert ticket.assigned_to == "Unassigned"
+
+
+@pytest.mark.asyncio
+async def test_translate_ticket_uses_priority_label(mocker):
+    mapper = mocker.Mock(spec=MappingService)
+    mapper.get_username = mocker.AsyncMock(return_value="Bob")
+    mapper.priority_label = mocker.Mock(return_value="Alta")
+
+    translator = TicketTranslator(mapper)
+    raw = {
+        "id": 3,
+        "name": "Network issue",
+        "status": 1,
+        "priority": 4,
+        "date_creation": "2024-01-03T00:00:00",
+        "users_id_assign": None,
+    }
+
+    ticket = await translator.translate_ticket(raw)
+
+    mapper.priority_label.assert_called_once_with(4)
+    assert ticket.priority == "Alta"


### PR DESCRIPTION
## Summary
- define `PRIORITY_MAP` in `mapping_service`
- add `priority_label` helper and integrate in `TicketTranslator`
- make `CleanTicketDTO` accept pre-converted priorities and adjust title sanitizing
- update unit tests for new mapping logic

## Testing
- `pre-commit run --files src/shared/dto.py tests/test_ticket_translator.py tests/test_clean_ticket_dto.py tests/test_mapping_service.py src/backend/adapters/mapping_service.py`
- `pytest tests/test_mapping_service.py tests/test_ticket_translator.py tests/test_clean_ticket_dto.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6882d14649a083208d2b3e6163546fb7