### PR TITLE
Implement dynamic ticket field discovery

### DIFF
--- a/src/backend/application/glpi_api_client.py
+++ b/src/backend/application/glpi_api_client.py
@@ -76,7 +76,7 @@ class GlpiApiClient:
             self._forced_fields = FORCED_DISPLAY_FIELDS.copy()
             return
 
-        mapping = {str(info.get("field")): fid for fid, info in options.items()}
+        mapping = {str(field): fid for fid, info in options.items() if (field := info.get("field")) is not None}
         id_field = _safe_int(mapping.get("id"))
         name_field = _safe_int(mapping.get("name"))
         date_field = _safe_int(mapping.get("date_creation"))

--- a/src/backend/application/glpi_api_client.py
+++ b/src/backend/application/glpi_api_client.py
@@ -85,10 +85,7 @@ class GlpiApiClient:
         if None in (id_field, name_field, date_field, priority_field):
             self._forced_fields = FORCED_DISPLAY_FIELDS.copy()
         else:
-            assert id_field is not None
-            assert name_field is not None
-            assert date_field is not None
-            assert priority_field is not None
+            # All fields are guaranteed to be non-None due to the preceding condition.
             self._forced_fields = [id_field, name_field, date_field, priority_field]
 
     async def get_all_paginated(


### PR DESCRIPTION
## Summary
- dynamically resolve GLPI ticket field IDs using `MappingService.get_search_options`
- store discovered IDs in `self._forced_fields` with fallback to `FORCED_DISPLAY_FIELDS`
- update `get_all_paginated` to use the resolved fields
- test new `_resolve_ticket_fields` behaviour

## Testing
- `ruff check src/backend/application/glpi_api_client.py tests/test_glpi_api_client.py`
- `pytest tests/test_glpi_api_client.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6882d1376d2083208c965ece1883c70c

## Resumo por Sourcery

Implementa a descoberta dinâmica de IDs de campos essenciais de tickets GLPI usando MappingService, atualiza as requisições de paginação para usar os campos resolvidos com um fallback para os padrões, e inclui testes para a lógica de resolução.

Novas Funcionalidades:
- Resolve e aplica dinamicamente IDs de campos essenciais de tickets para chamadas de API GLPI em vez de usar valores fixos (hardcoded).

Melhorias:
- Adiciona função auxiliar para analisar (parsear) valores em inteiros de forma segura.
- Persiste os IDs de campos de ticket descobertos com fallback para a lista padrão em caso de falha.

Testes:
- Adiciona testes unitários para resolução dinâmica de campos de ticket bem-sucedida e falha.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement dynamic discovery of essential GLPI ticket field IDs using MappingService, update pagination requests to use the resolved fields with a fallback to defaults, and include tests for the resolution logic.

New Features:
- Dynamically resolve and apply essential ticket field IDs for GLPI API calls instead of using hardcoded values.

Enhancements:
- Add helper function to safely parse values into integers.
- Persist discovered ticket field IDs with fallback to default list on failure.

Tests:
- Add unit tests for successful and failed dynamic ticket field resolution.

</details>