### PR TITLE
Update DTO fields for ticket models

### DIFF
--- a/tests/test_convert_ticket.py
+++ b/tests/test_convert_ticket.py
@@ -4,7 +4,6 @@ import pytest
 
 from shared.models import (
     Impact,
-    Priority,
     RawTicketDTO,
     TicketStatus,
     TicketType,
@@ -30,7 +29,7 @@ def test_convert_ticket_enum_mapping() -> None:
     ticket = convert_ticket(raw)
 
     assert ticket.status is TicketStatus.NEW
-    assert ticket.priority is Priority.LOW
+    assert ticket.priority == "Baixa"
     assert ticket.urgency is Urgency.MEDIUM
     assert ticket.impact is Impact.HIGH
     assert ticket.type is TicketType.INCIDENT
@@ -68,4 +67,4 @@ def test_convert_ticket_missing_name(raw_name: str | None) -> None:
 
     ticket = convert_ticket(raw)
 
-    assert ticket.name == "[Título não informado]"
+    assert ticket.title == "[Título não informado]"


### PR DESCRIPTION
## Summary
- rename name to title in CleanTicketDTO
- rename date_creation to creation_date with alias
- map priority codes to labels
- update convert_ticket accordingly
- adjust tests for new interface

## Testing
- `pre-commit run --files src/backend/domain/ticket_models.py tests/test_convert_ticket.py`
- `pytest -q tests/test_convert_ticket.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fakeredis')*

------
https://chatgpt.com/codex/tasks/task_e_6882d9bbf150832080209efe5816bb73