### PR TITLE
Update Docker CMD to use package entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,4 @@ COPY --from=builder /usr/local /usr/local
 COPY --from=builder /app /app
 USER appuser
 EXPOSE 80
-CMD ["uvicorn", "src.backend.api.worker_api:app", "--host", "0.0.0.0", "--port", "80"]
+CMD ["python", "-m", "backend.api.worker_api", "--host", "0.0.0.0", "--port", "80"]


### PR DESCRIPTION
## Summary
- update Dockerfile to start the worker via `python -m backend.api.worker_api`
- confirm backend package is installed from `src` via `package-dir`

## Testing
- `pre-commit run --files Dockerfile pyproject.toml`
- `python -m backend.api.worker_api --host 127.0.0.1 --port 8001 & sleep 2; kill $!`

------
https://chatgpt.com/codex/tasks/task_e_6882e1ea5a708320afc02d0338306bb5

## Resumo por Sourcery

Melhorias:
- Substituir CMD no Dockerfile para usar python -m backend.api.worker_api para iniciar o serviço

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Replace CMD in Dockerfile to use python -m backend.api.worker_api for starting the service

</details>