### PR TITLE
Add mise support for Node version

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,5 @@
+[settings]
+idiomatic_version_file_enable_tools = ["node"]
+
+[tools]
+node = "20.19.0"

--- a/.mise.toml
+++ b/.mise.toml
@@ -2,4 +2,3 @@
 idiomatic_version_file_enable_tools = ["node"]
 
 [tools]
-node = "20.19.0"

--- a/README.md
+++ b/README.md
@@ -139,16 +139,10 @@ This starts PostgreSQL, Redis, the FastAPI worker and the Dash app. Access the d
 - Python 3.10\u20133.12
 - PostgreSQL and Redis instances running locally (or update the `.env` file)
 - Node.js >=20.19.0 is required to run the React frontend locally. The required
-  version is stored in the `.nvmrc` file at the repository root. If you use
-  [mise](https://github.com/jdx/mise) for tool management run the following once
-  to silence the deprecation warning about `.nvmrc`:
-
-  ```bash
-  mise settings add idiomatic_version_file_enable_tools node
-  ```
-
-  Install the same version with [nvm](https://github.com/nvm-sh/nvm) if you
-  prefer:
+  version is stored in the `.nvmrc` file at the repository root. This version is
+  picked up automatically by [mise](https://github.com/jdx/mise) thanks to the
+  `.mise.toml` configuration, so no manual settings are needed. Install the same
+  version with [nvm](https://github.com/nvm-sh/nvm) if you prefer:
 
   ```bash
   nvm install


### PR DESCRIPTION
## Summary
- configure `.mise.toml` so that mise reads `.nvmrc`
- mention automatic Node version pickup in README

## Testing
- `pre-commit run --files README.md .mise.toml`
- `pytest -c /dev/null -q` *(fails: ModuleNotFoundError: No module named 'playwright')*

------
https://chatgpt.com/codex/tasks/task_e_6882e6847db48320ae34d923c0d458d2

## Resumo por Sourcery

Habilitar o gerenciamento automático de versão do Node.js via mise e atualizar a documentação de acordo

Novas funcionalidades:
- Adicionar configuração `.mise.toml` para permitir que o mise detecte a versão do Node.js a partir do `.nvmrc`

Documentação:
- Atualizar o README para mencionar a detecção automática da versão do Node.js pelo mise

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable automatic Node.js version management via mise and update documentation accordingly

New Features:
- Add .mise.toml configuration to enable mise to pick up Node.js version from .nvmrc

Documentation:
- Update README to mention automatic Node.js version pickup by mise

</details>