### PR TITLE
Add mise note about idiomatic files

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,21 +138,22 @@ This starts PostgreSQL, Redis, the FastAPI worker and the Dash app. Access the d
 
 - Python 3.10\u20133.12
 - PostgreSQL and Redis instances running locally (or update the `.env` file)
+
 - Node.js >=20.19.0 is required to run the React frontend locally. The required
-  version is stored in the `.nvmrc` file at the repository root. If you use
-  [mise](https://github.com/jdx/mise) for tool management run the following once
-  to silence the deprecation warning about `.nvmrc`:
-
-  ```bash
-  mise settings add idiomatic_version_file_enable_tools node
-  ```
-
-  Install the same version with [nvm](https://github.com/nvm-sh/nvm) if you
-  prefer:
+  version is stored in the `.nvmrc` file at the repository root. Install the
+  same version with [nvm](https://github.com/nvm-sh/nvm):
 
   ```bash
   nvm install
   nvm use 20.19.0
+  ```
+
+  If you use [mise](https://github.com/jdx/mise) for tool management run the
+  following once to silence the deprecation warning about `.nvmrc` (or disable
+  idiomatic files):
+
+  ```bash
+  mise settings add idiomatic_version_file_enable_tools node
   ```
 
   Docker remains an optional alternative for running the entire stack if the

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -54,7 +54,7 @@ Follow these steps inside the `src/frontend/react_app` folder to start developin
 ```bash
 cd src/frontend/react_app
 nvm install         # installs the version pinned in .nvmrc
-nvm use 20.19.0
+nvm use             # uses the version specified in .nvmrc
 mise settings add idiomatic_version_file_enable_tools node  # or disable idiomatic files
 npm install         # installs dotenv, @eslint/js and other dev dependencies
 # npm ci can be used for reproducible installs

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -54,7 +54,7 @@ Follow these steps inside the `src/frontend/react_app` folder to start developin
 ```bash
 cd src/frontend/react_app
 nvm install         # installs the version pinned in .nvmrc
-nvm use             # uses the version specified in .nvmrc
+nvm use
 mise settings add idiomatic_version_file_enable_tools node  # or disable idiomatic files
 npm install         # installs dotenv, @eslint/js and other dev dependencies
 # npm ci can be used for reproducible installs

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -53,6 +53,9 @@ Follow these steps inside the `src/frontend/react_app` folder to start developin
 
 ```bash
 cd src/frontend/react_app
+nvm install         # installs the version pinned in .nvmrc
+nvm use 20.19.0
+mise settings add idiomatic_version_file_enable_tools node  # or disable idiomatic files
 npm install         # installs dotenv, @eslint/js and other dev dependencies
 # npm ci can be used for reproducible installs
 npm run dev         # launch Vite dev server


### PR DESCRIPTION
## Summary
- explain how to silence mise warning about `.nvmrc`
- show the mise setting in front-end instructions

## Testing
- `pre-commit run --files README.md docs/frontend_architecture.md`

------
https://chatgpt.com/codex/tasks/task_e_6882e88cd82483209b369a04bc388ab0

## Resumo por Sourcery

Esclarecer os passos de instalação do Node.js e mostrar como silenciar avisos do mise sobre .nvmrc tanto no README quanto na documentação de front-end

Melhorias:
- Reordenar e esclarecer as instruções de instalação/uso do nvm antes de referenciar o mise
- Adicionar instrução para usar `mise settings add idiomatic_version_file_enable_tools node` para silenciar avisos de depreciação

Documentação:
- Incluir detalhes das configurações do mise na seção de instalação do README
- Atualizar o guia de arquitetura de front-end com comandos de configuração do nvm e mise

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clarify Node.js installation steps and show how to silence mise warnings about .nvmrc in both README and front-end docs

Enhancements:
- Reorder and clarify nvm install/use instructions before referencing mise
- Add instruction to use mise settings add idiomatic_version_file_enable_tools node to silence deprecation warnings

Documentation:
- Include mise setting details in README installation section
- Update front-end architecture guide with nvm and mise configuration commands

</details>