### PR TITLE
Add HOST_DB_PORT configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,7 +18,8 @@ GLPI_PASSWORD=
 # -----------------------------------------------------------------------------
 DB_HOST=db
 DB_PORT=5432
-# Host port used by the PostgreSQL container. Adjust if 55432 is occupied.
+# Host port bound to the PostgreSQL container (maps to container's port 5432).
+# Adjust if 55432 is occupied.
 HOST_DB_PORT=55432
 DB_NAME=glpi_dashboard
 DB_USER=user

--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,8 @@ GLPI_PASSWORD=
 # -----------------------------------------------------------------------------
 DB_HOST=db
 DB_PORT=5432
+# Host port used by the PostgreSQL container. Adjust if 55432 is occupied.
+HOST_DB_PORT=55432
 DB_NAME=glpi_dashboard
 DB_USER=user
 DB_PASSWORD=password

--- a/README.md
+++ b/README.md
@@ -634,6 +634,7 @@ container also executes on first startup.
   conhecidos utilizado pelo worker (padrão `docs/knowledge_base_errors.md`)
 - `DB_HOST` – PostgreSQL host
 - `DB_PORT` – PostgreSQL port
+- `HOST_DB_PORT` – host port bound to the PostgreSQL container (default `55432`)
 - `DB_NAME` – database name
 - `DB_USER` – database username
 - `DB_PASSWORD` – database password
@@ -765,6 +766,10 @@ cp .env.example .env
 ```
 
 Docker Compose loads `.env` automatically when it exists.
+
+PostgreSQL binds to port `${HOST_DB_PORT:-55432}` on the host. Change
+`HOST_DB_PORT` in `.env` if this port is already taken or if you prefer a
+different mapping.
 
 If the file is missing the backend falls back to `REDIS_HOST=redis` so the
 services can communicate with the bundled `redis` container.

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -31,7 +31,7 @@ services:
 
   db:
     ports:
-      - "55432:5432"
+      - "${HOST_DB_PORT:-55432}:5432"
 
   redis:
     ports:


### PR DESCRIPTION
## Summary
- introduce `HOST_DB_PORT` in `.env.example`
- expose the DB port mapping through `${HOST_DB_PORT}` in `docker-compose.override.yml`
- document the new variable and port conflict advice in the README

## Testing
- `make test-backend` *(fails: ModuleNotFoundError: No module named 'dash_bootstrap_components')*

------
https://chatgpt.com/codex/tasks/task_e_6882e88731ec83208f61351a8917ed6a

## Resumo por Sourcery

Adiciona suporte para personalizar a vinculação da porta do host do contêiner PostgreSQL, expõe a nova variável HOST_DB_PORT na configuração e atualiza a documentação de acordo.

Melhorias:
- Introduz a variável de ambiente HOST_DB_PORT para configurar a porta do host vinculada ao contêiner PostgreSQL

Implantação:
- Modifica docker-compose.override.yml para mapear a porta do contêiner via a variável HOST_DB_PORT

Documentação:
- Atualiza .env.example e README para incluir HOST_DB_PORT e fornecer orientação sobre conflitos de porta

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for customizing the host port binding of the PostgreSQL container, expose the new HOST_DB_PORT variable in config and update documentation accordingly

Enhancements:
- Introduce HOST_DB_PORT environment variable to configure the host port bound to the PostgreSQL container

Deployment:
- Modify docker-compose.override.yml to map the container port via the HOST_DB_PORT variable

Documentation:
- Update .env.example and README to include HOST_DB_PORT and provide port conflict guidance

</details>