### PR TITLE
Update setup docs for test dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,9 +279,14 @@ under `src/frontend/modules/` for Dash.
 **Important:** Install packages from **both** `requirements.txt` and
 `requirements-dev.txt` before running `pytest` or invoking `make test`.
 The `requirements-dev.txt` file contains extras such as `dash[testing]`,
-`playwright`, `testcontainers` and `pact-python` which are needed for the full
-suite. Install them with `pip install -r requirements-dev.txt` or use
-`pip install -e '.[dev]'` to ensure all development extras are available.
+`playwright`, `fakeredis`, `testcontainers` and `pact-python` which are needed
+for the full suite. Install them with:
+
+```bash
+pip install -r requirements-dev.txt --break-system-packages
+```
+
+Alternatively use `pip install -e '.[dev]'` to install all development extras.
 
 ## Installing Dependencies Behind a Proxy or Offline
 

--- a/README.md
+++ b/README.md
@@ -286,7 +286,18 @@ for the full suite. Install them with:
 pip install -r requirements-dev.txt --break-system-packages
 ```
 
+**Note:** The `--break-system-packages` flag is used here to bypass Python's external package management protection. This is necessary in some environments where system-level packages need to be updated directly. However, this approach can interfere with system packages and is not recommended for general use. To avoid potential issues, consider using a virtual environment as described below.
+
 Alternatively use `pip install -e '.[dev]'` to install all development extras.
+
+### Using a Virtual Environment
+
+To safely manage dependencies, set up a virtual environment:
+
+```bash
+python3 -m venv venv
+source venv/bin/activate
+pip install -r requirements-dev.txt
 
 ## Installing Dependencies Behind a Proxy or Offline
 

--- a/docs/DEV_SETUP.md
+++ b/docs/DEV_SETUP.md
@@ -25,3 +25,15 @@ these guidelines to avoid unnecessary re-renders:
 - **Avoid `JSON.stringify`** – property order can change and functions are lost,
   causing unstable strings. Our `useApiQuery` hook uses a `stableStringify`
   helper instead. **Note**: it does not handle nested objects.
+
+### Running tests
+Install the runtime dependencies from `requirements.txt` **and** the development
+set before running `pytest`. The optional extras in `requirements-dev.txt`
+include `dash[testing]`, `playwright`, `fakeredis`, `testcontainers` and
+`pact-python`.
+
+```bash
+pip install -r requirements-dev.txt --break-system-packages
+```
+This command installs the dev tools compiled via `pip-compile`. Make sure the
+runtime dependencies are installed as well.

--- a/docs/DEV_SETUP.md
+++ b/docs/DEV_SETUP.md
@@ -35,5 +35,8 @@ include `dash[testing]`, `playwright`, `fakeredis`, `testcontainers` and
 ```bash
 pip install -r requirements-dev.txt --break-system-packages
 ```
-This command installs the dev tools compiled via `pip-compile`. Make sure the
-runtime dependencies are installed as well.
+**Note**: The `--break-system-packages` flag bypasses Python's external package management protection and can interfere with system packages. This flag is necessary for this project to ensure compatibility with certain development tools. However, it is strongly recommended to use a virtual environment to isolate dependencies and prevent interference with system-level Python packages. You can create and activate a virtual environment as follows:
+
+```bash
+python -m venv venv
+source venv/bin/activate  # On Windows, use `venv\Scripts\activate`


### PR DESCRIPTION
## Summary
- document running tests in `docs/DEV_SETUP.md`
- clarify `README` test instructions with `--break-system-packages`

## Testing
- `pre-commit run --files README.md docs/DEV_SETUP.md`

------
https://chatgpt.com/codex/tasks/task_e_6883aca5f1fc8320814710a309e4432b

## Resumo por Sourcery

Atualiza a documentação de configuração de testes para incluir a dependência `fakeredis`, usar a flag `--break-system-packages` e adicionar uma seção dedicada à execução de testes.

Documentação:
- Esclarece as instruções do README para instalar as dependências de desenvolvimento (incluindo `dash[testing]`, `playwright`, `fakeredis`, `testcontainers` e `pact-python`) usando `pip install -r requirements-dev.txt --break-system-packages`
- Adiciona uma seção de execução de testes em `docs/DEV_SETUP.md` com orientações sobre como instalar as dependências de tempo de execução e de desenvolvimento antes de executar `pytest`

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update test setup documentation to include the fakeredis dependency, use the --break-system-packages flag, and add a dedicated running tests section.

Documentation:
- Clarify README instructions to install development dependencies (including dash[testing], playwright, fakeredis, testcontainers, and pact-python) using pip install -r requirements-dev.txt --break-system-packages
- Add a running tests section in docs/DEV_SETUP.md with guidance on installing runtime and development dependencies before running pytest

</details>