### PR TITLE
Add shell startup script

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -1,0 +1,10 @@
+# Project-specific bash configuration
+# Ensures standard utilities are unaliased and available.
+
+# Unalias common tools in case other environment managers define them
+for cmd in ls grep sed awk; do
+    unalias "$cmd" 2>/dev/null || true
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+        echo "WARNING: $cmd not found in PATH" >&2
+    fi
+done

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -1,3 +1,13 @@
 - `NEXT_PUBLIC_API_BASE_URL`: must point to `http://localhost:8000` when running under Docker Compose.
   You can also create `.env.local` with this setting for local scripts outside Docker.
 - `DISALLOWED_PROXIES`: comma-separated list of proxy hosts ignored by `scripts/validate_credentials.py`.
+
+## Shell configuration
+
+A project `.bashrc` is provided at the repository root. Source this file after running `scripts/setup/setup_env.sh` to ensure standard utilities like `ls`, `grep` and `sed` are not aliased by tools such as `mise`:
+
+```bash
+source .bashrc
+```
+
+The script unaliases these commands and warns if any are missing from `$PATH`.


### PR DESCRIPTION
## Summary
- add project `.bashrc` to unalias standard utilities
- explain how to source it in `docs/ENVIRONMENT.md`

## Testing
- `pre-commit run --files docs/ENVIRONMENT.md .bashrc`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'playwright')*

------
https://chatgpt.com/codex/tasks/task_e_6883aca9135c83209950db78a8c8b213