### PR TITLE
Format with Ruff and enforce lint via pre-commit

### DIFF
--- a/githooks/pre-commit
+++ b/githooks/pre-commit
@@ -1,4 +1,13 @@
 #!/bin/bash
-# Run lint and tests via pre-commit
+# Enforce Ruff linting before running the full pre-commit suite.
 set -e
+
+# Only run Ruff on staged Python files to keep hooks fast.
+changed_files=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.py$' || true)
+if [[ -n "$changed_files" ]]; then
+    echo "Running Ruff on staged files..."
+    ruff check --fix $changed_files
+    git add $changed_files
+fi
+
 pre-commit run --color always --show-diff-on-failure

--- a/githooks/pre-commit
+++ b/githooks/pre-commit
@@ -6,8 +6,8 @@ set -e
 changed_files=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.py$' || true)
 if [[ -n "$changed_files" ]]; then
     echo "Running Ruff on staged files..."
-    ruff check --fix $changed_files
-    git add $changed_files
+    ruff check --fix "$changed_files"
+    git add "$changed_files"
 fi
 
 pre-commit run --color always --show-diff-on-failure


### PR DESCRIPTION
## Summary
- run `ruff --fix` and sort imports
- hook `githooks/pre-commit` to run Ruff before the pre-commit suite

## Testing
- `ruff check`
- `pytest tests/test_dashboard_layout.py::test_build_layout_none_returns_alert -q`


------
https://chatgpt.com/codex/tasks/task_e_6883aca792f08320ab4afdebd7865c90

## Resumo por Sourcery

Impor a formatação e o linting do código com Ruff em todo o repositório e integrá-lo ao fluxo de trabalho de pre-commit

Melhorias:
- Adicionar correção automática e ordenação de imports via Ruff
- Executar Ruff como parte do script githooks/pre-commit antes de outras verificações

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enforce code formatting and linting with Ruff across the repository and integrate it into the pre-commit workflow

Enhancements:
- Add automatic fixing and import sorting via Ruff
- Run Ruff as part of the githooks/pre-commit script before other checks

</details>