### PR TITLE
Improve cancellation test

### DIFF
--- a/tests/test_glpi_session.py
+++ b/tests/test_glpi_session.py
@@ -626,7 +626,9 @@ async def test_aexit_suppresses_cancellation(
     mock_client_session.get.return_value = make_cm(200, {})
 
     async def sleep_forever() -> None:
-        await aio.sleep(10)
+        """Run indefinitely but yield control so cancellation is fast."""
+        await aio.sleep(0)
+        await aio.Event().wait()
 
     async def fake_refresh():
         glpi_session._session_token = "tok"


### PR DESCRIPTION
## Summary
- use zero-delay sleep for _proactive_refresh_loop
- check that cancellation still completes

## Testing
- `pre-commit run --files tests/test_glpi_session.py`
- `pytest tests/test_glpi_session.py -k test_aexit_suppresses_cancellation -o addopts='' -q`

------
https://chatgpt.com/codex/tasks/task_e_6883c217d38483208f86c8ea5069ace7

## Resumo por Sourcery

Refinar o teste de cancelamento para o loop de atualização proativa, substituindo uma longa espera por um `yield` de atraso zero, seguido por uma espera infinita e verificando que o cancelamento é concluído.

Melhorias:
- Acelerar o teste de cancelamento usando uma espera de atraso zero e espera imediata de evento

Testes:
- Atualizar `test_aexit_suppresses_cancellation` para usar a nova estratégia de espera e confirmar que o cancelamento ainda é concluído

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine the cancellation test for the proactive refresh loop by replacing a long sleep with a zero-delay yield followed by an infinite wait and verifying that cancellation completes

Enhancements:
- Accelerate cancellation test by using a zero-delay sleep and immediate event wait

Tests:
- Update test_aexit_suppresses_cancellation to use the new sleep strategy and confirm cancellation still completes

</details>