### PR TITLE
feat(models): add requester field

### DIFF
--- a/src/frontend/react_app/src/types/api.ts
+++ b/src/frontend/react_app/src/types/api.ts
@@ -50,4 +50,8 @@ export interface CleanTicketDTO {
    * Creation timestamp
    */
   date_creation?: string | null;
+  /**
+   * Requester
+   */
+  requester?: string | null;
 }

--- a/src/shared/models/ts_models.py
+++ b/src/shared/models/ts_models.py
@@ -26,6 +26,7 @@ class CleanTicketDTO(BaseModel):
     impact: Impact = Field(Impact.UNKNOWN, description="Impact")
     type: TicketType = Field(TicketType.UNKNOWN, description="Ticket type")
     date_creation: datetime | None = Field(None, description="Creation timestamp")
+    requester: str | None = Field(None, description="Requester")
 
     model_config = ConfigDict(extra="forbid")
 


### PR DESCRIPTION
## Summary
- add optional `requester` field in `CleanTicketDTO`
- regenerate TypeScript types with `npm run generate-types`

## Testing
- `pre-commit run --files src/shared/models/ts_models.py src/frontend/react_app/src/types/api.ts`
- `pytest tests/test_clean_ticket_dto.py::test_clean_ticket_dto_valid_creation`


------
https://chatgpt.com/codex/tasks/task_e_6883d8a534c4832090700eb1bcd679d0

## Resumo por Sourcery

Adiciona um novo campo opcional `requester` a `CleanTicketDTO` tanto no backend quanto no frontend, atualiza os tipos `TypeScript` gerados e inclui um teste de unidade para o modelo atualizado.

Novos Recursos:
- Adiciona o campo opcional `requester` ao modelo `Pydantic` `CleanTicketDTO`
- Expõe a propriedade opcional `requester` na interface `TypeScript` `CleanTicketDTO` do frontend

Melhorias:
- Regenera os tipos `TypeScript` para refletir as mudanças no esquema

Testes:
- Adiciona teste de unidade para validar a criação de `CleanTicketDTO` com o novo campo `requester`

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a new optional requester field to CleanTicketDTO on both backend and frontend, update generated TypeScript types, and include a unit test for the updated model

New Features:
- Add optional requester field to CleanTicketDTO Pydantic model
- Expose optional requester property in the frontend CleanTicketDTO TypeScript interface

Enhancements:
- Regenerate TypeScript types to reflect schema changes

Tests:
- Add unit test to validate CleanTicketDTO creation with the new requester field

</details>