### PR TITLE
Add requester field to Ticket types

### DIFF
--- a/src/frontend/react_app/src/hooks/useTickets.ts
+++ b/src/frontend/react_app/src/hooks/useTickets.ts
@@ -10,6 +10,7 @@ function toTicket(dto: CleanTicketDTO): Ticket {
     status: dto.status != null ? String(dto.status) : undefined,
     priority: dto.priority != null ? String(dto.priority) : undefined,
     name: dto.name ?? "",
+    requester: dto.requester ?? undefined,
     // Prefer `undefined` over `null` when the API omits the field
     date_creation:
       dto.date_creation != null ? new Date(dto.date_creation) : undefined,

--- a/src/frontend/react_app/src/types/api.ts
+++ b/src/frontend/react_app/src/types/api.ts
@@ -50,4 +50,5 @@ export interface CleanTicketDTO {
    * Creation timestamp
    */
   date_creation?: string | null;
+  requester?: string | null;
 }

--- a/src/frontend/react_app/src/types/ticket.ts
+++ b/src/frontend/react_app/src/types/ticket.ts
@@ -10,6 +10,7 @@ export interface Ticket {
   impact?: Impact
   type?: TicketType
   date_creation?: Date | null
+  requester?: string
   assigned_to?: string
   solvedate?: string | null
   closedate?: string | null


### PR DESCRIPTION
## Summary
- add optional `requester` to `Ticket` and `CleanTicketDTO`
- include requester mapping in `useTickets` hook

## Testing
- `npm test` *(fails: Jest config issues)*
- `pre-commit run --files src/frontend/react_app/src/types/ticket.ts src/frontend/react_app/src/types/api.ts src/frontend/react_app/src/hooks/useTickets.ts`
- `pytest -q` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6883d91561e08320b239495e5561e543

## Resumo por Sourcery

Adiciona um novo campo opcional 'requester' às definições de tipo de ticket e garante que ele seja propagado no hook `useTickets`

Novos Recursos:
- Adiciona o campo opcional 'requester' aos tipos `CleanTicketDTO` e `Ticket`

Melhorias:
- Inclui o mapeamento de 'requester' no hook `useTickets`

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a new optional 'requester' field to the ticket type definitions and ensure it is propagated in the useTickets hook

New Features:
- Add optional 'requester' field to CleanTicketDTO and Ticket types

Enhancements:
- Include 'requester' mapping in useTickets hook

</details>