### PR TITLE
Adjust requester mapping

### DIFF
--- a/docs/prompt_cookbook_codex.md
+++ b/docs/prompt_cookbook_codex.md
@@ -27,7 +27,7 @@ Crie **glpi_session.py** com:
 Você é um especialista em ETL.
 Crie backend/utils/pipeline.py com:
 - process_raw(data: List[dict]) -> pandas.DataFrame
-- Campos obrigatórios: id, status, group, date_creation, assigned_to
+- Campos obrigatórios: id, status, group, date_creation, assigned_to, requester
 - Converta datas para datetime, preencha NaN com None
 - Função save_json(df, path="mock/sample_data.json")
 ```

--- a/src/backend/infrastructure/glpi/normalization.py
+++ b/src/backend/infrastructure/glpi/normalization.py
@@ -19,6 +19,7 @@ REQUIRED_FIELDS = [
     "status",
     "group",
     "assigned_to",
+    "requester",
     "date_creation",
     "priority",
 ]
@@ -31,7 +32,7 @@ FIELD_ALIASES = {
     "users_id_recipient": "assigned_to",
     "users_id_assign": "assigned_to",
     "_users_id_assign": "assigned_to",
-    "_users_id_requester": "assigned_to",
+    "_users_id_requester": "requester",
     "creation_date": "date_creation",
     "date": "date_creation",
     "_status": "status",
@@ -95,8 +96,25 @@ def process_raw(data: TicketData) -> pd.DataFrame:
         assigned_to = assigned_raw.astype(str)
     df["assigned_to"] = assigned_to.replace({"<NA>": "", "nan": ""}).fillna("")
 
+    requester_raw = df.get("requester", pd.Series([None] * len(df), index=idx))
+    numeric_requester = pd.to_numeric(requester_raw, errors="coerce")
+    if numeric_requester.notna().any():
+        requester = numeric_requester.astype("Int64").astype(str)
+    else:
+        requester = requester_raw.astype(str)
+    df["requester"] = requester.replace({"<NA>": "", "nan": "", "None": ""}).fillna("")
+
     return df[
-        ["id", "name", "status", "priority", "assigned_to", "group", "date_creation"]
+        [
+            "id",
+            "name",
+            "status",
+            "priority",
+            "assigned_to",
+            "requester",
+            "group",
+            "date_creation",
+        ]
     ].copy()
 
 

--- a/tests/test_data_pipeline.py
+++ b/tests/test_data_pipeline.py
@@ -15,13 +15,14 @@ def test_process_raw_sanitization():
     ]
     df = process_raw(raw)
 
-    assert df.shape == (3, 7)
+    assert df.shape == (3, 8)
     assert df.columns.tolist() == [
         "id",
         "name",
         "status",
         "priority",
         "assigned_to",
+        "requester",
         "group",
         "date_creation",
     ]
@@ -30,6 +31,7 @@ def test_process_raw_sanitization():
     assert df["status"].tolist() == ["closed", "", "new"]
     assert df["name"].iloc[1] == "Chamado A"
     assert df["assigned_to"].iloc[0] == "123"
+    assert df["requester"].tolist() == ["", "", ""]
     assert df["group"].tolist() == ["", "", ""]
     assert df["priority"].isna().all()
     assert df["date_creation"].isna().all()
@@ -43,6 +45,7 @@ def test_process_raw_aliases():
             "_status": "New",
             "_priority": 2,
             "_users_id_assign": 5,
+            "_users_id_requester": 9,
             "groups_name": "N1",
             "creation_date": "2024-05-01",
         }
@@ -55,6 +58,7 @@ def test_process_raw_aliases():
         "status",
         "priority",
         "assigned_to",
+        "requester",
         "group",
         "date_creation",
     }
@@ -64,6 +68,7 @@ def test_process_raw_aliases():
     assert df.iloc[0]["priority"] == 2
     assert str(df.dtypes["priority"]) == "Int64"
     assert df.iloc[0]["assigned_to"] == "5"
+    assert df.iloc[0]["requester"] == "9"
     assert df.iloc[0]["group"] == "N1"
     assert df.iloc[0]["id"] == 1
     assert df.iloc[0]["date_creation"].strftime("%Y-%m-%d") == "2024-05-01"


### PR DESCRIPTION
## Summary
- map `_users_id_requester` to `requester`
- include `requester` in required fields and processed columns
- update docs and tests accordingly

## Testing
- `pytest tests/test_data_pipeline.py::test_process_raw_sanitization -q`


------
https://chatgpt.com/codex/tasks/task_e_6883d8894ae08320ba1e2014a6cfe972

## Resumo por Sourcery

Adiciona mapeamento de solicitante na normalização de dados do GLPI e atualiza a documentação e os testes de acordo

Novas Funcionalidades:
- Mapeia o alias `_users_id_requester` para o campo `requester` durante o processamento de dados brutos

Melhorias:
- Inclui `requester` nas colunas de saída e implementa lógica de sanitização e formatação para o campo `requester`

Documentação:
- Adiciona `requester` à lista de campos obrigatórios na documentação do pipeline

Testes:
- Atualiza os testes para esperar uma coluna `requester` e valida seus valores padrão e baseados em alias

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add requester mapping in GLPI data normalization and update docs and tests accordingly

New Features:
- Map `_users_id_requester` alias to the `requester` field during raw data processing

Enhancements:
- Include `requester` in the output columns and implement sanitization and formatting logic for the `requester` field

Documentation:
- Add `requester` to the list of required fields in the pipeline documentation

Tests:
- Update tests to expect an `requester` column and validate its default and alias-based values

</details>