### PR TITLE
Add requester field to ticket DTOs

### DIFF
--- a/src/backend/domain/ticket_models.py
+++ b/src/backend/domain/ticket_models.py
@@ -172,7 +172,7 @@ def convert_ticket(raw: RawTicketDTO) -> CleanTicketDTO:
         impact=impact,
         type=ttype,
         creation_date=created,
-        requester=None,
+        requester=_resolve_requester_name(raw.users_id_requester, ticket_id),
     )
 
 

--- a/src/backend/domain/ticket_models.py
+++ b/src/backend/domain/ticket_models.py
@@ -43,6 +43,7 @@ class RawTicketDTO(BaseModel):
     impact: int | None = Field(None, description="Impact code")
     type: int | None = Field(None, description="Ticket type code")
     date_creation: str | None = Field(None, description="ISO date string")
+    users_id_requester: int | None = Field(None, description="Requester user ID")
 
     model_config = ConfigDict(extra="allow")
 
@@ -65,6 +66,7 @@ class CleanTicketDTO(BaseModel):
     creation_date: datetime | None = Field(
         None, alias="date_creation", description="Creation timestamp"
     )
+    requester: str | None = Field(None, description="Requester user name")
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True)
 
@@ -170,6 +172,7 @@ def convert_ticket(raw: RawTicketDTO) -> CleanTicketDTO:
         impact=impact,
         type=ttype,
         creation_date=created,
+        requester=None,
     )
 
 

--- a/src/shared/dto.py
+++ b/src/shared/dto.py
@@ -45,6 +45,7 @@ class RawTicketFromAPI(BaseModel):
     priority: Optional[int] = Field(default=None)
     date_creation: Optional[datetime] = Field(default=None)
     users_id_assign: Optional[int] = Field(None, alias="users_id_assign")
+    users_id_requester: Optional[int] = Field(None, alias="users_id_requester")
 
     model_config = ConfigDict(populate_by_name=True)
 
@@ -61,6 +62,7 @@ class CleanTicketDTO(BaseModel):
     priority: Optional[str] = Field(default=None)
     created_at: Optional[datetime] = Field(default=None, alias="date_creation")
     assigned_to: str = "Unassigned"
+    requester: Optional[str] = None
 
     model_config = ConfigDict(populate_by_name=True)
 
@@ -124,6 +126,10 @@ class TicketTranslator:
         if validated_raw.users_id_assign:
             assigned_to = await self.mapper.get_username(validated_raw.users_id_assign)
 
+        requester = None
+        if validated_raw.users_id_requester:
+            requester = await self.mapper.get_username(validated_raw.users_id_requester)
+
         priority_label = (
             self.mapper.priority_label(validated_raw.priority)
             if validated_raw.priority is not None
@@ -137,5 +143,6 @@ class TicketTranslator:
             "priority": priority_label,
             "date_creation": validated_raw.date_creation,
             "assigned_to": assigned_to,
+            "requester": requester,
         }
         return CleanTicketDTO.model_validate(clean_data)

--- a/tests/test_clean_ticket_dto.py
+++ b/tests/test_clean_ticket_dto.py
@@ -13,6 +13,7 @@ def test_clean_ticket_dto_valid_creation():
         "priority": 2,
         "date_creation": "2024-01-01T12:00:00",
         "assigned_to": "Alice",
+        "requester": "Alice",
     }
 
     ticket = CleanTicketDTO.model_validate(data)
@@ -22,6 +23,7 @@ def test_clean_ticket_dto_valid_creation():
     assert ticket.status == "New"
     assert ticket.priority == "Low"
     assert ticket.assigned_to == "Alice"
+    assert ticket.requester == "Alice"
 
 
 @pytest.mark.unit
@@ -79,6 +81,7 @@ def test_clean_ticket_dto_missing_optional_fields():
 
     assert ticket.priority is None
     assert ticket.created_at is None
+    assert ticket.requester is None
 
 
 @pytest.mark.unit

--- a/tests/test_dto.py
+++ b/tests/test_dto.py
@@ -26,6 +26,7 @@ async def test_translate_ticket_success(mock_mapping_service: AsyncMock) -> None
         "priority": 3,  # Medium
         "date_creation": "2024-01-01T12:00:00Z",
         "users_id_assign": 42,
+        "users_id_requester": 7,
     }
     translated_ticket = await translator.translate_ticket(raw_ticket)
     assert isinstance(translated_ticket, CleanTicketDTO)
@@ -37,3 +38,6 @@ async def test_translate_ticket_success(mock_mapping_service: AsyncMock) -> None
         "2024-01-01T12:00:00+00:00"
     )
     assert translated_ticket.assigned_to == "Test User"
+    assert translated_ticket.requester == "Test User"
+    mock_mapping_service.get_username.assert_awaited()
+    assert mock_mapping_service.get_username.await_count == 2

--- a/tests/test_ticket_translator.py
+++ b/tests/test_ticket_translator.py
@@ -18,6 +18,7 @@ async def test_translate_ticket_maps_values(mocker):
         "priority": 4,
         "date_creation": "2024-01-01T00:00:00",
         "users_id_assign": 5,
+        "users_id_requester": 9,
     }
 
     ticket = await translator.translate_ticket(raw)
@@ -27,6 +28,10 @@ async def test_translate_ticket_maps_values(mocker):
     assert ticket.status == "Processing (assigned)"
     assert ticket.priority == "High"
     assert ticket.assigned_to == "Alice"
+    assert ticket.requester == "Alice"
+    mapper.get_username.assert_any_await(5)
+    mapper.get_username.assert_any_await(9)
+    assert mapper.get_username.await_count == 2
 
 
 @pytest.mark.asyncio
@@ -42,11 +47,14 @@ async def test_translate_ticket_unassigned(mocker):
         "priority": 3,
         "date_creation": "2024-01-02T00:00:00",
         "users_id_assign": None,
+        "users_id_requester": 7,
     }
 
     ticket = await translator.translate_ticket(raw)
 
     assert ticket.assigned_to == "Unassigned"
+    assert ticket.requester == "Bob"
+    mapper.get_username.assert_awaited_once_with(7)
 
 
 @pytest.mark.asyncio
@@ -63,9 +71,12 @@ async def test_translate_ticket_uses_priority_label(mocker):
         "priority": 4,
         "date_creation": "2024-01-03T00:00:00",
         "users_id_assign": None,
+        "users_id_requester": 7,
     }
 
     ticket = await translator.translate_ticket(raw)
 
     mapper.priority_label.assert_called_once_with(4)
     assert ticket.priority == "Alta"
+    assert ticket.requester == "Bob"
+    mapper.get_username.assert_awaited_once_with(7)


### PR DESCRIPTION
## Summary
- capture requester on raw GLPI tickets
- expose requester field on CleanTicketDTO
- translate requester name using MappingService
- support new field in domain models
- test coverage for requester field

## Testing
- `pre-commit run --files src/shared/dto.py src/backend/domain/ticket_models.py tests/test_clean_ticket_dto.py tests/test_dto.py tests/test_ticket_translator.py`
- `pytest -k test_tickets` *(fails: ModuleNotFoundError: No module named 'fakeredis')*
- `npm run test:unit -- -u` *(fails: Missing script: "test:unit")*
- `npm run build` *(fails: NEXT_PUBLIC_API_BASE_URL not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6883d86a42d4832082c096804cf0d680

## Resumo por Sourcery

Adicionar um campo `requester` aos DTOs de ticket e propagá-lo através dos modelos de tradução e de domínio

Novas Funcionalidades:
- Adicionar o campo `users_id_requester` a `RawTicketFromAPI` e `RawTicketDTO`
- Adicionar a propriedade `requester` a `CleanTicketDTO` nos modelos compartilhado e de domínio
- Preencher `requester` usando `MappingService` na tradução de tickets

Testes:
- Estender os testes para cobrir a tradução do campo `requester` e o comportamento padrão em `CleanTicketDTO`

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a requester field to ticket DTOs and propagate it through translation and domain models

New Features:
- Add users_id_requester field to RawTicketFromAPI and RawTicketDTO
- Add requester property to CleanTicketDTO in shared and domain models
- Populate requester using MappingService in ticket translation

Tests:
- Extend tests to cover requester field translation and default behavior in CleanTicketDTO

</details>