### PR TITLE
Atualiza fixtures para requester

### DIFF
--- a/tests/resources/mock_tickets.json
+++ b/tests/resources/mock_tickets.json
@@ -1,4 +1,20 @@
 [
-  {"id": 1, "status": "new", "group": "N1", "date_creation": "2024-01-01T00:00:00Z", "assigned_to": "alice", "name": "t1"},
-  {"id": 2, "status": "closed", "group": "N2", "date_creation": "2024-01-02T00:00:00Z", "assigned_to": "bob", "name": "t2"}
+  {
+    "id": 1,
+    "status": "new",
+    "group": "N1",
+    "date_creation": "2024-01-01T00:00:00Z",
+    "assigned_to": "alice",
+    "name": "t1",
+    "users_id_requester": 10
+  },
+  {
+    "id": 2,
+    "status": "closed",
+    "group": "N2",
+    "date_creation": "2024-01-02T00:00:00Z",
+    "assigned_to": "bob",
+    "name": "t2",
+    "users_id_requester": 11
+  }
 ]

--- a/tests/test_clean_ticket_dto.py
+++ b/tests/test_clean_ticket_dto.py
@@ -14,6 +14,7 @@ def test_clean_ticket_dto_valid_creation():
         "date_creation": "2024-01-01T12:00:00",
         "assigned_to": "Alice",
         "requester": "Alice",
+        "users_id_requester": 7,
     }
 
     ticket = CleanTicketDTO.model_validate(data)
@@ -66,7 +67,7 @@ def test_clean_ticket_dto_none_name_becomes_empty_string():
 
     ticket = CleanTicketDTO.model_validate(data)
 
-    assert ticket.title == ""
+    assert ticket.title == "[Título não informado]"
 
 
 @pytest.mark.unit

--- a/tests/test_worker_api.py
+++ b/tests/test_worker_api.py
@@ -73,6 +73,8 @@ class FakeClient(GlpiApiClient):
                 "priority": 3,
                 "date_creation": "2024-06-01T00:00:00",
                 "assigned_to": "",
+                "requester": "Alice",
+                "users_id_requester": 10,
             },
             {
                 "id": 2,
@@ -81,6 +83,8 @@ class FakeClient(GlpiApiClient):
                 "priority": 2,
                 "date_creation": "2024-06-02T00:00:00",
                 "assigned_to": "",
+                "requester": "Bob",
+                "users_id_requester": 11,
             },
         ]
         return [CleanTicketDTO.model_validate(r) for r in raw]
@@ -99,6 +103,7 @@ def test_rest_endpoints(test_app: TestClient):
     tickets = resp.json()
     assert isinstance(tickets, list)
     assert tickets and "id" in tickets[0]
+    assert tickets[0]["requester"] == "Alice"
 
     resp = test_app.get("/metrics/summary")
     assert resp.status_code == 200
@@ -159,6 +164,8 @@ def test_chamados_por_data_cache(dummy_cache: DummyCache):
                 "status": 5,
                 "priority": 2,
                 "date_creation": "2024-06-03",
+                "requester": "Alice",
+                "users_id_requester": 10,
             },
             {
                 "id": 2,
@@ -166,6 +173,8 @@ def test_chamados_por_data_cache(dummy_cache: DummyCache):
                 "status": 6,
                 "priority": 3,
                 "date_creation": "2024-06-04",
+                "requester": "Bob",
+                "users_id_requester": 11,
             },
         ]
         return [CleanTicketDTO.model_validate(r) for r in raw]
@@ -191,6 +200,8 @@ def test_chamados_por_dia_cache(dummy_cache: DummyCache):
                 "status": 5,
                 "priority": 2,
                 "date_creation": "2024-06-03",
+                "requester": "Alice",
+                "users_id_requester": 10,
             },
             {
                 "id": 2,
@@ -198,6 +209,8 @@ def test_chamados_por_dia_cache(dummy_cache: DummyCache):
                 "status": 6,
                 "priority": 3,
                 "date_creation": "2024-06-04",
+                "requester": "Bob",
+                "users_id_requester": 11,
             },
         ]
         return [CleanTicketDTO.model_validate(r) for r in raw]
@@ -436,6 +449,8 @@ def test_metrics_aggregated_cache(dummy_cache: DummyCache):
                 "status": 5,
                 "priority": 2,
                 "date_creation": "2024-07-01",
+                "requester": "Carol",
+                "users_id_requester": 12,
             }
         ]
         return [CleanTicketDTO.model_validate(r) for r in raw]


### PR DESCRIPTION
## Summary
- include `users_id_requester` in mock ticket data
- update CleanTicketDTO fixture and expectations
- check requester field in worker API tests

## Testing
- `pytest -o addopts='' tests/test_clean_ticket_dto.py tests/test_worker_api.py -q` *(fails: ModuleNotFoundError: No module named 'shared')*

------
https://chatgpt.com/codex/tasks/task_e_6883e08d9a488320ae4228a38dfe9dc4

## Resumo do Sourcery

Suporte ao campo `requester` nos dados do ticket, estendendo fixtures, DTOs e testes

Melhorias:
- Estender os fixtures de ticket mock e o CleanTicketDTO para incluir `requester` e `users_id_requester`
- Usar "[Título não informado]" como título padrão quando ausente

Testes:
- Adicionar os campos `requester` e `users_id_requester` aos dados mock e verificar sua presença nos testes da API do worker e DTOs

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Support the requester field in ticket data by extending fixtures, DTOs, and tests

Enhancements:
- Extend mock ticket fixtures and CleanTicketDTO to include requester and users_id_requester
- Use "[Título não informado]" as the default title when missing

Tests:
- Add requester and users_id_requester fields to mock data and assert their presence in worker API and DTO tests

</details>