### PR TITLE
Update docs for new requester field

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,8 +478,8 @@ When the FastAPI service starts it primes the Redis cache by calling
 
 - The service exposes several endpoints:
 
-- `/tickets` – full list of tickets in JSON format. As of v0.2 this payload
-  includes the ticket `priority` as a text label.
+ - `/tickets` – full list of tickets in JSON format. The payload includes the
+   ticket `priority` label and the `requester` name when available.
 - `/tickets/stream` – Server‑Sent Events (SSE) stream of progress followed by the JSON payload.
 - `/metrics` – summary with `total`, `opened` and `closed` counts.
 - `/metrics/aggregated` – counts grouped by status and technician, pre-computed by the worker.
@@ -497,7 +497,8 @@ Example ticket payload:
     "id": 42,
     "title": "Network issue",
     "status": "New",
-    "priority": "High"
+    "priority": "High",
+    "requester": "Maria"
   }
 ]
 ```

--- a/docs/ARCHITECTURE_backup.md
+++ b/docs/ARCHITECTURE_backup.md
@@ -15,7 +15,7 @@ This document provides a quick overview of how the repository is structured, the
 
 1. `glpi_session.py` authenticates against the GLPI REST API.
 2. Background workers normalise the responses into `pandas.DataFrame` objects and store them in Redis/PostgreSQL.
-3. The FastAPI layer (`src/backend/api/worker_api.py`) exposes `/tickets` and `/metrics` endpoints that read from this cache. The `/tickets` response now includes the `priority` string.
+3. The FastAPI layer (`src/backend/api/worker_api.py`) exposes `/tickets` and `/metrics` endpoints that read from this cache. The `/tickets` response now includes the `priority` label and the requester name.
 4. Dash components or the React front‑end request these endpoints to render tables and charts.
 
 ```text

--- a/docs/developer_usage.md
+++ b/docs/developer_usage.md
@@ -74,7 +74,7 @@ python worker.py
 Endpoints relevantes:
 
 - `/tickets` – lista completa de chamados
-- A resposta inclui o campo `priority` em formato textual.
+ - A resposta inclui os campos `priority` e `requester` em formato textual.
 - `/metrics` – contagem de abertos/fechados
 - `/graphql/` – versão GraphQL
 - `/cache/stats` – estatísticas de cache
@@ -87,7 +87,8 @@ Exemplo de retorno:
     "id": 7,
     "title": "Falha no proxy",
     "status": "Closed",
-    "priority": "Medium"
+    "priority": "Medium",
+    "requester": "Alice"
   }
 ]
 ```

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -163,7 +163,7 @@ Execute o Storybook para visualizar componentes isoladamente. Dentro de
 ```bash
 npm run storybook      # inicia em http://localhost:6006
 npm run build-storybook  # gera a versão estática em storybook-static/
-npx storybook test --watchAll=false  # atualiza os snapshots
+npx storybook test -u --watchAll=false # atualiza os snapshots
 ```
 
 Use these stories to validate different loading states and to document props

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -100,7 +100,7 @@ Imports reference `@/` as a shortcut to the `src/` folder. Both Vite and TypeScr
 
 ### API Integration
 
-Start the worker with `python worker.py` (it listens on port `8000` by default) and point the front-end to it using the `NEXT_PUBLIC_API_BASE_URL` variable. The `/tickets` endpoint now returns the `priority` as a string. Example fetching ticket metrics:
+Start the worker with `python worker.py` (it listens on port `8000` by default) and point the front-end to it using the `NEXT_PUBLIC_API_BASE_URL` variable. The `/tickets` endpoint now returns the `priority` label and the `requester` name. Example fetching ticket metrics:
 
 ```ts
 const resp = await fetch(`${import.meta.env.NEXT_PUBLIC_API_BASE_URL}/tickets/metrics`);
@@ -163,6 +163,7 @@ Execute o Storybook para visualizar componentes isoladamente. Dentro de
 ```bash
 npm run storybook      # inicia em http://localhost:6006
 npm run build-storybook  # gera a versão estática em storybook-static/
+npx storybook test --watchAll=false  # atualiza os snapshots
 ```
 
 Use these stories to validate different loading states and to document props


### PR DESCRIPTION
## Summary
- mention `requester` in `/tickets` response docs
- refresh example payloads in README and docs
- add snapshot command in Storybook instructions

## Testing
- `pre-commit run --files README.md docs/developer_usage.md docs/frontend_architecture.md docs/ARCHITECTURE_backup.md`
- `pytest -k test_tickets` *(fails: unrecognized arguments)*
- `NODE_ENV=test npm test -- -u` *(fails: Jest encountered unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_6883e08f86108320a06271d23cca7b63

## Resumo por Sourcery

Documenta a adição do campo `requester` no endpoint `/tickets`, atualiza os payloads de exemplo de acordo e aprimora as instruções do Storybook adicionando um comando de teste de snapshot.

Documentação:
- Menciona o campo `requester` na documentação de resposta do `/tickets` em todo o README, uso do desenvolvedor, arquitetura de frontend e backup de arquitetura
- Atualiza os payloads de exemplo de tickets para incluir o novo campo `requester`
- Adiciona o comando de snapshot `npx storybook test --watchAll=false` às instruções de configuração do Storybook

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Document the addition of the `requester` field in the `/tickets` endpoint, update example payloads accordingly, and enhance Storybook instructions by adding a snapshot test command.

Documentation:
- Mention the `requester` field in the `/tickets` response docs across README, developer usage, frontend architecture, and architecture backup
- Refresh example ticket payloads to include the new `requester` field
- Add `npx storybook test --watchAll=false` snapshot command to the Storybook setup instructions

</details>