### PR TITLE
docs: clarify requirements for running tests

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -7,7 +7,10 @@ pip install -r requirements.txt -r requirements-dev.txt  # generated via pip-com
 pip install -e .
 ```
 
-`requirements-dev.txt` already pulls in **Playwright** for Dash component tests. After installing the packages run `playwright install` so the browsers are available.
+After installing the packages, run the following to make the browsers available:
+
+```bash
+playwright install
 
 Running a subset of tests can cause failures because `pytest.ini` enforces 85% coverage:
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,11 +1,13 @@
 # Testing Guide
 
-The test suite relies on several optional libraries and expects coverage to be enabled by default. Install all runtime and development dependencies **before** invoking pytest:
+The test suite relies on several optional libraries (such as **Playwright**) and expects coverage to be enabled by default. Install **all** runtime and development dependencies before invoking pytest:
 
 ```bash
 pip install -r requirements.txt -r requirements-dev.txt  # generated via pip-compile
 pip install -e .
 ```
+
+`requirements-dev.txt` already pulls in **Playwright** for Dash component tests. After installing the packages run `playwright install` so the browsers are available.
 
 Running a subset of tests can cause failures because `pytest.ini` enforces 85% coverage:
 
@@ -24,11 +26,13 @@ PYTEST_ADDOPTS="" pytest tests/test_worker_api.py
 
 ### Troubleshooting missing modules
 
-`ModuleNotFoundError` typically means dependencies were not installed. Common cases are:
+`ModuleNotFoundError` typically means development dependencies were not installed. Common cases are:
 
 - `aiohttp` required by the async GLPI client
 - `pydantic>=2` for data models
+- `playwright` for end-to-end tests
 
 Ensure both requirement files are installed and that your virtual environment is active.
+Missing any of these packages will cause import errors during test collection.
 The backend tests expect environment variables like `GLPI_BASE_URL` to be set.
 Create a `.env` file or export minimal values (e.g. `GLPI_BASE_URL=http://example.com/apirest.php`) before running `pytest`.


### PR DESCRIPTION
## Summary
- stress that `requirements-dev.txt` (including Playwright) must be installed before running tests
- explain that missing packages trigger import errors

## Testing
- `pre-commit run --files docs/testing.md`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fakeredis')*

------
https://chatgpt.com/codex/tasks/task_e_6884149cecbc8320a74f65c4ec143af6

## Resumo por Sourcery

Esclarecer o guia de testes para enfatizar a instalação de todas as dependências de desenvolvimento (incluindo Playwright), a execução de `playwright install` para a configuração do navegador e explicar que pacotes ausentes causam erros de importação durante a coleta de testes.

Documentação:
- Enfatizar a instalação de `requirements-dev.txt` (incluindo Playwright) antes de executar `pytest`
- Adicionar instrução para executar `playwright install` para garantir que os navegadores estejam disponíveis para testes end-to-end
- Expandir a seção de solução de problemas para incluir Playwright em módulos ausentes e observar que pacotes ausentes acionam erros de importação

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clarify the testing guide to emphasize installing all development dependencies (including Playwright), running playwright install for browser setup, and explain that missing packages cause import errors during test collection.

Documentation:
- Emphasize installing requirements-dev.txt (including Playwright) before running pytest
- Add instruction to run `playwright install` to ensure browsers are available for end-to-end tests
- Expand troubleshooting section to include Playwright in missing modules and note that missing packages trigger import errors

</details>