### PR TITLE
Add assignee field to ticket resolution

### DIFF
--- a/src/backend/application/glpi_api_client.py
+++ b/src/backend/application/glpi_api_client.py
@@ -8,7 +8,14 @@ from backend.utils import paginate_items
 from shared.dto import CleanTicketDTO, TicketTranslator
 
 # Field names we always include in ticket search results.
-BASE_TICKET_FIELDS = ["id", "name", "date", "priority", "status"]
+BASE_TICKET_FIELDS = [
+    "id",
+    "name",
+    "date",
+    "priority",
+    "status",
+    "users_id_assign",
+]
 # Populated dynamically from MappingService
 FORCED_DISPLAY_FIELDS: list[int] = []
 
@@ -85,14 +92,21 @@ class GlpiApiClient:
         name_field = _safe_int(mapping.get("name"))
         date_field = _safe_int(mapping.get("date_creation"))
         priority_field = _safe_int(mapping.get("priority"))
+        assign_field = _safe_int(mapping.get("users_id_assign"))
 
-        if None in (id_field, name_field, date_field, priority_field):
+        if None in (id_field, name_field, date_field, priority_field, assign_field):
             self._forced_fields = FORCED_DISPLAY_FIELDS.copy()
         else:
             # Only assign non-None integer values to _forced_fields.
             self._forced_fields = [
                 field
-                for field in [id_field, name_field, date_field, priority_field]
+                for field in [
+                    id_field,
+                    name_field,
+                    date_field,
+                    priority_field,
+                    assign_field,
+                ]
                 if field is not None
             ]
 

--- a/tests/test_glpi_api_client.py
+++ b/tests/test_glpi_api_client.py
@@ -1,0 +1,50 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from backend.application.glpi_api_client import (
+    BASE_TICKET_FIELDS,
+    GlpiApiClient,
+)
+
+
+@pytest.mark.asyncio
+async def test_populate_forced_fields(monkeypatch):
+    session = MagicMock()
+    mapper = MagicMock()
+    mapper.initialize = AsyncMock()
+    mapper.get_ticket_field_ids = AsyncMock(return_value=[1, 2, 3, 4, 5, 6])
+    monkeypatch.setattr(
+        "backend.application.glpi_api_client.MappingService", lambda *a, **k: mapper
+    )
+
+    client = GlpiApiClient(session=session)
+    await client._populate_forced_fields()
+
+    assert client._forced_fields == [1, 2, 3, 4, 5, 6]
+    mapper.get_ticket_field_ids.assert_awaited_once_with(BASE_TICKET_FIELDS)
+
+
+@pytest.mark.asyncio
+async def test_resolve_ticket_fields(monkeypatch):
+    session = MagicMock()
+    mapper = MagicMock()
+    mapper.get_search_options = AsyncMock(
+        return_value={
+            "10": {"field": "id"},
+            "11": {"field": "name"},
+            "12": {"field": "date_creation"},
+            "13": {"field": "priority"},
+            "14": {"field": "users_id_assign"},
+        }
+    )
+    monkeypatch.setattr(
+        "backend.application.glpi_api_client.MappingService", lambda *a, **k: mapper
+    )
+
+    client = GlpiApiClient(session=session)
+    client._forced_fields = []
+    await client._resolve_ticket_fields()
+
+    assert client._forced_fields == [10, 11, 12, 13, 14]
+    mapper.get_search_options.assert_awaited_once_with("Ticket")


### PR DESCRIPTION
## Summary
- include `users_id_assign` in BASE_TICKET_FIELDS
- resolve assignee field when mapping ticket search options
- add unit tests covering forced field resolution

## Testing
- `pytest tests/test_glpi_api_client.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68841463d2048320b29179f6098753d5