### PR TITLE
feat(frontend): voice command hook and indicator

### DIFF
--- a/src/frontend/react_app/src/components/Header.tsx
+++ b/src/frontend/react_app/src/components/Header.tsx
@@ -1,10 +1,17 @@
 import { type FC, useCallback } from 'react'
 import { useThemeSwitcher } from '../hooks/useThemeSwitcher'
 import { useFilters } from '../hooks/useFilters'
+import { useVoiceCommands } from '../hooks/useVoiceCommands'
+import VoiceIndicator from './VoiceIndicator'
 
 const Header: FC = () => {
   const { theme, setTheme } = useThemeSwitcher()
   const { toggleFilters } = useFilters()
+  const { isListening, startListening, stopListening } = useVoiceCommands()
+  const toggleVoice = useCallback(
+    () => (isListening ? stopListening() : startListening()),
+    [isListening, startListening, stopListening],
+  )
 
   const setLight = useCallback(() => setTheme('light'), [setTheme])
   const setDark = useCallback(() => setTheme('dark'), [setTheme])
@@ -70,8 +77,13 @@ const Header: FC = () => {
           <i className="fas fa-filter" />
           <span>Filtros</span>
         </button>
+        <button className="refresh-btn" onClick={toggleVoice}>
+          <i className="fas fa-microphone" />
+          <span>{isListening ? 'Parar' : 'Falar'}</span>
+        </button>
         <div className="current-time" id="currentTime" />
       </div>
+      <VoiceIndicator isListening={isListening} />
     </header>
   )
 }

--- a/src/frontend/react_app/src/components/VoiceIndicator.tsx
+++ b/src/frontend/react_app/src/components/VoiceIndicator.tsx
@@ -1,0 +1,13 @@
+import type { FC } from 'react'
+
+interface Props {
+  isListening: boolean
+}
+
+const VoiceIndicator: FC<Props> = ({ isListening }) => (
+  <div className={`voice-indicator show ${isListening ? 'listening' : ''}`}>
+    <i className="fas fa-microphone" aria-hidden="true" />
+  </div>
+)
+
+export default VoiceIndicator

--- a/src/frontend/react_app/src/components/__tests__/Header.test.tsx
+++ b/src/frontend/react_app/src/components/__tests__/Header.test.tsx
@@ -6,4 +6,9 @@ describe('Header', () => {
     render(<Header />)
     expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent('Centro de Comando')
   })
+
+  it('shows voice toggle button', () => {
+    render(<Header />)
+    expect(screen.getByRole('button', { name: /falar/i })).toBeInTheDocument()
+  })
 })

--- a/src/frontend/react_app/src/hooks/__tests__/useVoiceCommands.test.tsx
+++ b/src/frontend/react_app/src/hooks/__tests__/useVoiceCommands.test.tsx
@@ -1,0 +1,34 @@
+import { act, renderHook } from '@testing-library/react'
+import { useVoiceCommands } from '../useVoiceCommands'
+
+declare global {
+  interface Window {
+    webkitSpeechRecognition: typeof SpeechRecognition
+    SpeechRecognition: typeof SpeechRecognition
+  }
+}
+
+class MockRecognition {
+  start = jest.fn()
+  stop = jest.fn()
+  onresult: ((e: any) => void) | null = null
+  onend: (() => void) | null = null
+}
+
+beforeEach(() => {
+  ;(window as any).SpeechRecognition = MockRecognition as any
+  ;(window as any).webkitSpeechRecognition = MockRecognition as any
+})
+
+test('starts and stops listening', () => {
+  const { result } = renderHook(() => useVoiceCommands())
+  act(() => {
+    result.current.startListening()
+  })
+  expect(result.current.isListening).toBe(true)
+
+  act(() => {
+    result.current.stopListening()
+  })
+  expect(result.current.isListening).toBe(false)
+})

--- a/src/frontend/react_app/src/hooks/useVoiceCommands.ts
+++ b/src/frontend/react_app/src/hooks/useVoiceCommands.ts
@@ -9,7 +9,7 @@ export function useVoiceCommands() {
     console.debug('Recognized voice command:', text)
   }, [])
 
-  const createRecognition = () => {
+  const createRecognition = useCallback(() => {
     const Speech =
       (window as any).SpeechRecognition || (window as any).webkitSpeechRecognition
     if (!Speech) return null

--- a/src/frontend/react_app/src/hooks/useVoiceCommands.ts
+++ b/src/frontend/react_app/src/hooks/useVoiceCommands.ts
@@ -1,0 +1,45 @@
+import { useCallback, useRef, useState } from 'react'
+
+export function useVoiceCommands() {
+  const recognitionRef = useRef<SpeechRecognition | null>(null)
+  const [isListening, setIsListening] = useState(false)
+
+  const processCommand = useCallback((text: string) => {
+    // Placeholder for custom voice command processing logic
+    console.debug('Recognized voice command:', text)
+  }, [])
+
+  const createRecognition = () => {
+    const Speech =
+      (window as any).SpeechRecognition || (window as any).webkitSpeechRecognition
+    if (!Speech) return null
+    const recognition: SpeechRecognition = new Speech()
+    recognition.lang = 'pt-BR'
+    recognition.interimResults = false
+    recognition.onresult = (e: SpeechRecognitionEvent) => {
+      const transcript = Array.from(e.results)
+        .map((r) => r[0].transcript)
+        .join(' ')
+      processCommand(transcript.trim().toLowerCase())
+    }
+    recognition.onend = () => setIsListening(false)
+    return recognition
+  }
+
+  const startListening = useCallback(() => {
+    if (isListening) return
+    const recognition = createRecognition()
+    if (recognition) {
+      recognitionRef.current = recognition
+      recognition.start()
+      setIsListening(true)
+    }
+  }, [isListening, processCommand])
+
+  const stopListening = useCallback(() => {
+    recognitionRef.current?.stop()
+    setIsListening(false)
+  }, [])
+
+  return { isListening, startListening, stopListening, processCommand }
+}

--- a/src/frontend/react_app/src/hooks/useVoiceCommands.ts
+++ b/src/frontend/react_app/src/hooks/useVoiceCommands.ts
@@ -12,7 +12,10 @@ export function useVoiceCommands() {
   const createRecognition = useCallback(() => {
     const Speech =
       (window as any).SpeechRecognition || (window as any).webkitSpeechRecognition
-    if (!Speech) return null
+    if (!Speech) {
+      alert('Reconhecimento de voz não está disponível neste navegador.');
+      return null;
+    }
     const recognition: SpeechRecognition = new Speech()
     recognition.lang = 'pt-BR'
     recognition.interimResults = false


### PR DESCRIPTION
## Summary
- add new `useVoiceCommands` hook to manage SpeechRecognition
- display a microphone button in Header to start/stop listening
- render new `<VoiceIndicator>` with existing styles
- cover new logic with unit tests

## Testing
- `npm test` *(fails: SyntaxError: Cannot use 'import.meta' outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_688435582e308320b04f24ca1ce8a587

## Resumo por Sourcery

Adiciona suporte a comandos de voz através de um novo hook, controles de UI e indicador

Novas Funcionalidades:
- Introduz o hook `useVoiceCommands` para gerenciar o início/parada e processamento do SpeechRecognition
- Adiciona um botão de alternância de microfone no `Header` para iniciar e parar a escuta
- Renderiza um componente `VoiceIndicator` para mostrar o estado atual de escuta

Testes:
- Adiciona testes unitários para o hook `useVoiceCommands`

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add voice command support via a new hook, UI controls, and indicator

New Features:
- Introduce useVoiceCommands hook to manage SpeechRecognition start/stop and processing
- Add a microphone toggle button in Header to start and stop listening
- Render a VoiceIndicator component to show the current listening state

Tests:
- Add unit tests for the useVoiceCommands hook

</details>