### PR TITLE
Improve voice command hook tests

### DIFF
--- a/src/frontend/react_app/src/global.d.ts
+++ b/src/frontend/react_app/src/global.d.ts
@@ -9,3 +9,8 @@ declare module 'react-window' {
   }
   export const FixedSizeList: React.ComponentType<unknown>
 }
+
+interface Window {
+  webkitSpeechRecognition: typeof SpeechRecognition
+  SpeechRecognition: typeof SpeechRecognition
+}

--- a/src/frontend/react_app/src/hooks/__tests__/useVoiceCommands.test.tsx
+++ b/src/frontend/react_app/src/hooks/__tests__/useVoiceCommands.test.tsx
@@ -69,6 +69,82 @@ describe('useVoiceCommands', () => {
       'Recognized voice command:',
       'hello world'
     )
+
+    debugSpy.mockRestore()
+  })
+
+  it('processes multiple transcripts in results', () => {
+    const { result } = renderHook(() => useVoiceCommands())
+    const debugSpy = jest.spyOn(console, 'debug').mockImplementation(() => {})
+
+    act(() => {
+      result.current.startListening()
+    })
+
+    const event = { results: [[{ transcript: 'first command' }, { transcript: 'second command' }]] }
+    act(() => {
+      recognitionInstance.triggerResult(event)
+    })
+
+    expect(debugSpy).toHaveBeenCalledWith(
+      'Recognized voice command:',
+      'first command'
+    )
+    expect(debugSpy).toHaveBeenCalledWith(
+      'Recognized voice command:',
+      'second command'
+    )
+
+    debugSpy.mockRestore()
+  })
+
+  it('handles empty results gracefully', () => {
+    const { result } = renderHook(() => useVoiceCommands())
+    const debugSpy = jest.spyOn(console, 'debug').mockImplementation(() => {})
+
+    act(() => {
+      result.current.startListening()
+    })
+
+    const event = { results: [] }
+    act(() => {
+      recognitionInstance.triggerResult(event)
+    })
+
+    expect(debugSpy).not.toHaveBeenCalled()
+
+    debugSpy.mockRestore()
+  })
+
+  it('handles unexpected result structures gracefully', () => {
+    const { result } = renderHook(() => useVoiceCommands())
+    const debugSpy = jest.spyOn(console, 'debug').mockImplementation(() => {})
+
+    act(() => {
+      result.current.startListening()
+    })
+
+    // results is undefined
+    const event1 = {}
+    act(() => {
+      recognitionInstance.triggerResult(event1)
+    })
+
+    // results is not an array
+    const event2 = { results: null }
+    act(() => {
+      recognitionInstance.triggerResult(event2)
+    })
+
+    // results is array but contains non-array
+    const event3 = { results: [null] }
+    act(() => {
+      recognitionInstance.triggerResult(event3)
+    })
+
+    expect(debugSpy).not.toHaveBeenCalled()
+
+    debugSpy.mockRestore()
   })
 
   it('sets isListening to false on end', () => {

--- a/src/frontend/react_app/src/hooks/__tests__/useVoiceCommands.test.tsx
+++ b/src/frontend/react_app/src/hooks/__tests__/useVoiceCommands.test.tsx
@@ -1,34 +1,89 @@
 import { act, renderHook } from '@testing-library/react'
 import { useVoiceCommands } from '../useVoiceCommands'
 
-declare global {
-  interface Window {
-    webkitSpeechRecognition: typeof SpeechRecognition
-    SpeechRecognition: typeof SpeechRecognition
-  }
-}
-
 class MockRecognition {
   start = jest.fn()
   stop = jest.fn()
   onresult: ((e: any) => void) | null = null
   onend: (() => void) | null = null
+
+  triggerResult(event: any) {
+    this.onresult?.(event)
+  }
+
+  triggerEnd() {
+    this.onend?.()
+  }
 }
 
+let recognitionInstance: MockRecognition
+
 beforeEach(() => {
-  ;(window as any).SpeechRecognition = MockRecognition as any
-  ;(window as any).webkitSpeechRecognition = MockRecognition as any
+  jest.clearAllMocks()
+  recognitionInstance = new MockRecognition()
+  ;(window as any).SpeechRecognition = jest
+    .fn(() => recognitionInstance)
+    .mockName('SpeechRecognition')
+  ;(window as any).webkitSpeechRecognition = window.SpeechRecognition
 })
 
-test('starts and stops listening', () => {
-  const { result } = renderHook(() => useVoiceCommands())
-  act(() => {
-    result.current.startListening()
-  })
-  expect(result.current.isListening).toBe(true)
+describe('useVoiceCommands', () => {
+  it('starts listening and calls recognition.start', () => {
+    const { result } = renderHook(() => useVoiceCommands())
 
-  act(() => {
-    result.current.stopListening()
+    act(() => {
+      result.current.startListening()
+    })
+
+    expect(result.current.isListening).toBe(true)
+    expect(recognitionInstance.start).toHaveBeenCalledTimes(1)
   })
-  expect(result.current.isListening).toBe(false)
+
+  it('stops listening and calls recognition.stop', () => {
+    const { result } = renderHook(() => useVoiceCommands())
+
+    act(() => {
+      result.current.startListening()
+    })
+    act(() => {
+      result.current.stopListening()
+    })
+
+    expect(recognitionInstance.stop).toHaveBeenCalledTimes(1)
+  })
+
+  it('processes commands on result', () => {
+    const { result } = renderHook(() => useVoiceCommands())
+    const debugSpy = jest.spyOn(console, 'debug').mockImplementation(() => {})
+
+    act(() => {
+      result.current.startListening()
+    })
+
+    const event = { results: [[{ transcript: 'hello world' }]] }
+    act(() => {
+      recognitionInstance.triggerResult(event)
+    })
+
+    expect(debugSpy).toHaveBeenCalledWith(
+      'Recognized voice command:',
+      'hello world'
+    )
+  })
+
+  it('sets isListening to false on end', () => {
+    const { result } = renderHook(() => useVoiceCommands())
+
+    act(() => {
+      result.current.startListening()
+    })
+
+    expect(result.current.isListening).toBe(true)
+
+    act(() => {
+      recognitionInstance.triggerEnd()
+    })
+
+    expect(result.current.isListening).toBe(false)
+  })
 })

--- a/src/frontend/react_app/src/hooks/useVoiceCommands.ts
+++ b/src/frontend/react_app/src/hooks/useVoiceCommands.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 export function useVoiceCommands() {
   const recognitionRef = useRef<SpeechRecognition | null>(null)
@@ -27,7 +27,7 @@ export function useVoiceCommands() {
     }
     recognition.onend = () => setIsListening(false)
     return recognition
-  }
+  }, [processCommand])
 
   const startListening = useCallback(() => {
     if (isListening) return
@@ -37,11 +37,16 @@ export function useVoiceCommands() {
       recognition.start()
       setIsListening(true)
     }
-  }, [isListening, processCommand])
+  }, [isListening, createRecognition])
 
   const stopListening = useCallback(() => {
     recognitionRef.current?.stop()
-    setIsListening(false)
+  }, [])
+
+  useEffect(() => {
+    return () => {
+      recognitionRef.current?.stop()
+    }
   }, [])
 
   return { isListening, startListening, stopListening, processCommand }

--- a/src/frontend/react_app/src/hooks/useVoiceCommands.ts
+++ b/src/frontend/react_app/src/hooks/useVoiceCommands.ts
@@ -41,7 +41,8 @@ export function useVoiceCommands() {
 
   const stopListening = useCallback(() => {
     recognitionRef.current?.stop()
-  }, [])
+    setIsListening(false)
+  }, [setIsListening])
 
   useEffect(() => {
     return () => {


### PR DESCRIPTION
## Summary
- cleanup when hook unmounts and fix callbacks
- extend global typings for SpeechRecognition
- enhance voice command unit tests with triggerable mock

## Testing
- `npx jest --runTestsByPath src/hooks/__tests__/useVoiceCommands.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_6884399a88d8832095eac7357dd6e010

## Resumo por Sourcery

Melhora a confiabilidade do hook `useVoiceCommands` adicionando uma limpeza adequada e corrigindo as dependências de callback, estende as tipagens globais de `SpeechRecognition` e aprimora os testes unitários com um mock acionável para uma cobertura mais completa.

Melhorias:
- Interrompe o reconhecimento de fala na desmontagem do hook via limpeza do `useEffect`
- Corrige os arrays de dependência do `useCallback` em `useVoiceCommands` para garantir que os callbacks sejam atualizados corretamente
- Adiciona declarações globais de TypeScript para `SpeechRecognition` e `webkitSpeechRecognition`

Testes:
- Refatora os testes do hook de comando de voz para usar um `MockRecognition` acionável e limpar os mocks entre as execuções
- Adiciona casos de teste para eventos de início, parada, processamento de resultados e fim sob um bloco `describe` estruturado

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve the reliability of the useVoiceCommands hook by adding proper cleanup and fixing callback dependencies, extend global SpeechRecognition typings, and enhance unit tests with a triggerable mock for more thorough coverage.

Enhancements:
- Stop speech recognition on hook unmount via useEffect cleanup
- Fix useCallback dependency arrays in useVoiceCommands to ensure callbacks update correctly
- Add global TypeScript declarations for SpeechRecognition and webkitSpeechRecognition

Tests:
- Refactor voice command hook tests to use a triggerable MockRecognition and clear mocks between runs
- Add test cases for start, stop, result processing, and end events under a structured describe block

</details>