### PR TITLE
Fix voice recognition cleanup

### DIFF
--- a/src/frontend/react_app/src/hooks/__tests__/useVoiceCommands.test.tsx
+++ b/src/frontend/react_app/src/hooks/__tests__/useVoiceCommands.test.tsx
@@ -162,4 +162,21 @@ describe('useVoiceCommands', () => {
 
     expect(result.current.isListening).toBe(false)
   })
+
+  it('cleans up recognition handlers on unmount', () => {
+    const { result, unmount } = renderHook(() => useVoiceCommands())
+
+    act(() => {
+      result.current.startListening()
+    })
+
+    expect(recognitionInstance.onend).toBeDefined()
+    expect(recognitionInstance.onresult).toBeDefined()
+
+    unmount()
+
+    expect(recognitionInstance.stop).toHaveBeenCalledTimes(1)
+    expect(recognitionInstance.onend).toBeNull()
+    expect(recognitionInstance.onresult).toBeNull()
+  })
 })

--- a/src/frontend/react_app/src/hooks/useVoiceCommands.ts
+++ b/src/frontend/react_app/src/hooks/useVoiceCommands.ts
@@ -20,10 +20,17 @@ export function useVoiceCommands() {
     recognition.lang = 'pt-BR'
     recognition.interimResults = false
     recognition.onresult = (e: SpeechRecognitionEvent) => {
-      const transcript = Array.from(e.results)
-        .map((r) => r[0].transcript)
-        .join(' ')
-      processCommand(transcript.trim().toLowerCase())
+      const res: any = e.results
+      if (!res || typeof res[Symbol.iterator] !== 'function') return
+      Array.from(res).forEach((result: any) => {
+        if (!result || typeof result[Symbol.iterator] !== 'function') return
+        Array.from(result).forEach((item: any) => {
+          const transcript = item?.transcript?.trim().toLowerCase()
+          if (transcript) {
+            processCommand(transcript)
+          }
+        })
+      })
     }
     recognition.onend = () => setIsListening(false)
     return recognition
@@ -46,7 +53,13 @@ export function useVoiceCommands() {
 
   useEffect(() => {
     return () => {
-      recognitionRef.current?.stop()
+      const recognition = recognitionRef.current
+      if (recognition) {
+        // avoid updating state after unmount
+        recognition.onend = null
+        recognition.onresult = null
+        recognition.stop()
+      }
     }
   }, [])
 

--- a/src/frontend/react_app/src/hooks/useVoiceCommands.ts
+++ b/src/frontend/react_app/src/hooks/useVoiceCommands.ts
@@ -20,12 +20,12 @@ export function useVoiceCommands() {
     recognition.lang = 'pt-BR'
     recognition.interimResults = false
     recognition.onresult = (e: SpeechRecognitionEvent) => {
-      const res: any = e.results
+      const res: SpeechRecognitionResultList = e.results
       if (!res || typeof res[Symbol.iterator] !== 'function') return
-      Array.from(res).forEach((result: any) => {
+      Array.from(res).forEach((result: SpeechRecognitionResult) => {
         if (!result || typeof result[Symbol.iterator] !== 'function') return
-        Array.from(result).forEach((item: any) => {
-          const transcript = item?.transcript?.trim().toLowerCase()
+        Array.from(result).forEach((item: SpeechRecognitionAlternative) => {
+          const transcript = item.transcript?.trim().toLowerCase()
           if (transcript) {
             processCommand(transcript)
           }


### PR DESCRIPTION
## Summary
- clear handlers before stopping speech recognition
- ensure `onresult` processes all transcripts individually
- add cleanup test for `useVoiceCommands`

## Testing
- `pre-commit run --files src/frontend/react_app/src/hooks/useVoiceCommands.ts src/frontend/react_app/src/hooks/__tests__/useVoiceCommands.test.tsx`
- `npm test -- --runTestsByPath src/hooks/__tests__/useVoiceCommands.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68843f981b708320890c5c79e9820dad

## Resumo por Sourcery

Melhora o hook de reconhecimento de voz ao processar transcrições individuais e limpando corretamente os manipuladores de eventos ao desmontar

Correções de Bugs:
- Limpa os manipuladores de reconhecimento de fala antes de parar para evitar atualizações de estado após a desmontagem
- Itera através dos resultados de reconhecimento para processar cada transcrição separadamente

Testes:
- Adiciona um teste para verificar se os manipuladores de reconhecimento são removidos e o reconhecimento é interrompido na desmontagem do hook

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve voice recognition hook by processing individual transcripts and properly cleaning up event handlers on unmount

Bug Fixes:
- Clear speech recognition handlers before stopping to prevent state updates after unmount
- Iterate through recognition results to process each transcript separately

Tests:
- Add a test to verify recognition handlers are removed and recognition is stopped on hook unmount

</details>