### PR TITLE
Improve search results UX

### DIFF
--- a/src/frontend/react_app/src/components/Header.tsx
+++ b/src/frontend/react_app/src/components/Header.tsx
@@ -5,6 +5,8 @@ import { useVoiceCommands } from '../hooks/useVoiceCommands'
 import VoiceIndicator from './VoiceIndicator'
 import SearchResults from './SearchResults'
 
+const SEARCH_BLUR_DELAY = 100
+
 const Header: FC = () => {
   const { theme, setTheme } = useThemeSwitcher()
   const { toggleFilters } = useFilters()
@@ -18,7 +20,10 @@ const Header: FC = () => {
   const [showResults, setShowResults] = useState(false)
 
   const handleFocus = () => setShowResults(true)
-  const handleBlur = () => {
+  const handleBlur = (e: React.FocusEvent<HTMLInputElement>) => {
+    if (e.relatedTarget?.closest('.search-container')) {
+      return
+    }
     setTimeout(() => setShowResults(false), SEARCH_BLUR_DELAY)
   }
 

--- a/src/frontend/react_app/src/components/Header.tsx
+++ b/src/frontend/react_app/src/components/Header.tsx
@@ -5,6 +5,8 @@ import { useVoiceCommands } from '../hooks/useVoiceCommands'
 import VoiceIndicator from './VoiceIndicator'
 import SearchResults from './SearchResults'
 
+// The delay value for the blur handler ensures smooth UI transitions and prevents
+// accidental dismissal of search results when interacting with related elements.
 const SEARCH_BLUR_DELAY = 100
 
 const Header: FC = () => {

--- a/src/frontend/react_app/src/components/SearchResults.tsx
+++ b/src/frontend/react_app/src/components/SearchResults.tsx
@@ -1,5 +1,6 @@
 import type { FC } from 'react'
 import { useSearch } from '../hooks/useSearch'
+import { useDebounce } from '../hooks/useDebounce'
 import { LoadingSpinner } from './LoadingSpinner'
 import { ErrorMessage } from './ErrorMessage'
 
@@ -9,7 +10,8 @@ interface Props {
 }
 
 const SearchResults: FC<Props> = ({ term, visible }) => {
-  const { data, isLoading, isError } = useSearch(term)
+  const debouncedTerm = useDebounce(term, 300)
+  const { data, isLoading, isError } = useSearch(debouncedTerm)
 
   if (!visible) return null
 
@@ -30,11 +32,14 @@ const SearchResults: FC<Props> = ({ term, visible }) => {
   }
 
   if (!data || data.length === 0) {
-    return (
-      <div className="search-results show">
-        <div className="no-results-message">Nenhum resultado encontrado</div>
-      </div>
-    )
+    if (debouncedTerm.trim().length > 0) {
+      return (
+        <div className="search-results show">
+          <div className="search-result-item">Nenhum resultado encontrado</div>
+        </div>
+      )
+    }
+    return null
   }
 
   return (

--- a/src/frontend/react_app/src/components/__tests__/SearchResults.test.tsx
+++ b/src/frontend/react_app/src/components/__tests__/SearchResults.test.tsx
@@ -67,3 +67,31 @@ test('shows no results message', () => {
   render(<SearchResults term="t" visible={true} />)
   expect(screen.getByText('Nenhum resultado encontrado')).toBeInTheDocument()
 })
+
+test("does not show 'Nenhum resultado encontrado' when search term is empty", () => {
+  const result: Partial<UseQueryResult<useSearchHook.SearchResult[], Error>> = {
+    data: [],
+    isLoading: false,
+    isError: false,
+  }
+  mockUseSearch.useSearch.mockReturnValue(
+    result as UseQueryResult<useSearchHook.SearchResult[], Error>,
+  )
+
+  render(<SearchResults term="" visible={true} />)
+  expect(screen.queryByText('Nenhum resultado encontrado')).not.toBeInTheDocument()
+})
+
+test("does not show 'Nenhum resultado encontrado' when search term is whitespace only", () => {
+  const result: Partial<UseQueryResult<useSearchHook.SearchResult[], Error>> = {
+    data: [],
+    isLoading: false,
+    isError: false,
+  }
+  mockUseSearch.useSearch.mockReturnValue(
+    result as UseQueryResult<useSearchHook.SearchResult[], Error>,
+  )
+
+  render(<SearchResults term="   " visible={true} />)
+  expect(screen.queryByText('Nenhum resultado encontrado')).not.toBeInTheDocument()
+})

--- a/src/frontend/react_app/src/components/__tests__/SearchResults.test.tsx
+++ b/src/frontend/react_app/src/components/__tests__/SearchResults.test.tsx
@@ -1,18 +1,69 @@
 import { render, screen } from '@testing-library/react'
 import SearchResults from '../SearchResults'
 import * as useSearchHook from '../../hooks/useSearch'
+import type { UseQueryResult } from '@tanstack/react-query'
 
 jest.mock('../../hooks/useSearch')
 
 const mockUseSearch = useSearchHook as jest.Mocked<typeof useSearchHook>
 
 test('renders results', () => {
-  mockUseSearch.useSearch.mockReturnValue({
-    data: [{ id: 1, name: 'T1' }],
+  const result: Partial<UseQueryResult<useSearchHook.SearchResult[], Error>> = {
+    data: [{ id: 1, name: 'T1', requester: undefined }],
     isLoading: false,
     isError: false,
-  } as any)
+  }
+  mockUseSearch.useSearch.mockReturnValue(
+    result as UseQueryResult<useSearchHook.SearchResult[], Error>,
+  )
 
   render(<SearchResults term="t" visible={true} />)
   expect(screen.getByText('T1')).toBeInTheDocument()
+})
+
+test('shows loading spinner', () => {
+  const result: Partial<UseQueryResult<useSearchHook.SearchResult[], Error>> = {
+    data: undefined,
+    isLoading: true,
+    isError: false,
+  }
+  mockUseSearch.useSearch.mockReturnValue(
+    result as UseQueryResult<useSearchHook.SearchResult[], Error>,
+  )
+
+  render(<SearchResults term="t" visible={true} />)
+  expect(screen.getByRole('status')).toBeInTheDocument()
+})
+
+test('shows error message', () => {
+  const result: Partial<UseQueryResult<useSearchHook.SearchResult[], Error>> = {
+    data: undefined,
+    isLoading: false,
+    isError: true,
+    error: new Error('oops'),
+  }
+  mockUseSearch.useSearch.mockReturnValue(
+    result as UseQueryResult<useSearchHook.SearchResult[], Error>,
+  )
+
+  render(<SearchResults term="t" visible={true} />)
+  expect(
+    screen.getByText(
+      'Erro ao buscar chamados. Tente novamente ou verifique sua conexão.',
+    ),
+  ).toBeInTheDocument()
+})
+
+test('shows no results message', () => {
+  const result: Partial<UseQueryResult<useSearchHook.SearchResult[], Error>> = {
+    data: [],
+    isLoading: false,
+    isError: false,
+  }
+  mockUseSearch.useSearch.mockReturnValue(
+    result as UseQueryResult<useSearchHook.SearchResult[], Error>,
+  )
+
+  render(<SearchResults term="t" visible={true} />)
+  expect(screen.getByText('Nenhum resultado encontrado')).toBeInTheDocument()
 })

--- a/src/frontend/react_app/src/components/__tests__/SearchResults.test.tsx
+++ b/src/frontend/react_app/src/components/__tests__/SearchResults.test.tsx
@@ -35,6 +35,20 @@ test('shows loading spinner', () => {
   expect(screen.getByRole('status')).toBeInTheDocument()
 })
 
+test('renders nothing when visible is false', () => {
+  const result: Partial<UseQueryResult<useSearchHook.SearchResult[], Error>> = {
+    data: [{ id: 1, name: 'T1', requester: undefined }],
+    isLoading: false,
+    isError: false,
+  }
+  mockUseSearch.useSearch.mockReturnValue(
+    result as UseQueryResult<useSearchHook.SearchResult[], Error>,
+  )
+
+  const { container } = render(<SearchResults term="t" visible={false} />)
+  expect(container).toBeEmptyDOMElement()
+})
+
 test('shows error message', () => {
   const result: Partial<UseQueryResult<useSearchHook.SearchResult[], Error>> = {
     data: undefined,

--- a/src/frontend/react_app/src/hooks/__tests__/useSearch.test.tsx
+++ b/src/frontend/react_app/src/hooks/__tests__/useSearch.test.tsx
@@ -9,12 +9,18 @@ afterEach(() => {
   global.fetch = originalFetch
 })
 
-const queryClient = new QueryClient()
-const wrapper = ({ children }: { children: React.ReactNode }) => (
-  <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-)
+let queryClient: QueryClient
+const createWrapper = () => {
+  queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+}
 
 test('fetches search results', async () => {
+  const wrapper = createWrapper()
   ;(global.fetch as jest.Mock).mockResolvedValue({
     ok: true,
     json: () => Promise.resolve([{ id: 1, name: 'ticket' }]),

--- a/src/frontend/react_app/src/hooks/useDebounce.ts
+++ b/src/frontend/react_app/src/hooks/useDebounce.ts
@@ -1,0 +1,14 @@
+import { useState, useEffect } from 'react';
+
+export function useDebounce<T>(value: T, delay: number): T {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    const handler = setTimeout(() => setDebouncedValue(value), delay);
+    return () => {
+      clearTimeout(handler);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+}


### PR DESCRIPTION
## Summary
- debounce search term in `SearchResults`
- guard blur handler using `relatedTarget`
- show "Nenhum resultado" feedback only when applicable
- add `useDebounce` hook
- expand component and hook tests

## Testing
- `pre-commit run --files src/frontend/react_app/src/components/SearchResults.tsx src/frontend/react_app/src/components/Header.tsx src/frontend/react_app/src/hooks/useDebounce.ts src/frontend/react_app/src/components/__tests__/SearchResults.test.tsx src/frontend/react_app/src/hooks/__tests__/useSearch.test.tsx`
- `pytest -p no:cov -o addopts=''` *(fails: ModuleNotFoundError: No module named 'libcst')*
- `npm test --silent` *(fails: SyntaxError: Cannot use 'import.meta' outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68843f9ce1c883208728b25580cc32ad

## Resumo por Sourcery

Melhorar a UX dos resultados de pesquisa aplicando debounce à entrada, prevenindo o fechamento indesejado do dropdown, mostrando feedback de 'sem resultados' condicionalmente, e aprimorando testes relacionados

Novas Funcionalidades:
- Adicionar o hook `useDebounce` para aplicar debounce a valores
- Aplicar debounce a consultas de pesquisa em `SearchResults`

Melhorias:
- Proteger o manipulador de blur do `Header` para prevenir o fechamento prematuro do dropdown de pesquisa
- Exibir ‘Nenhum resultado encontrado’ apenas quando um termo de pesquisa não vazio não retornar resultados

Testes:
- Expandir os testes de `SearchResults` para cobrir os estados de carregamento, erro e sem resultados
- Refatorar os testes do hook `useSearch` com um `QueryClientProvider` personalizado que desabilita as tentativas (retries)

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve search results UX by debouncing input, preventing unwanted dropdown closure, conditionally showing no-results feedback, and enhancing related tests

New Features:
- Add useDebounce hook to debounce values
- Debounce search queries in SearchResults

Enhancements:
- Guard Header blur handler to prevent premature closing of search dropdown
- Display ‘Nenhum resultado encontrado’ only when a non-empty search term yields no results

Tests:
- Expand SearchResults tests to cover loading, error, and no-results states
- Refactor useSearch hook tests with a custom QueryClientProvider that disables retries

</details>