### PR TITLE
Add sidebar toggle

### DIFF
--- a/src/frontend/react_app/src/App.test.tsx
+++ b/src/frontend/react_app/src/App.test.tsx
@@ -36,6 +36,7 @@ jest.mock('./components/Header', () => () => <header>Header Mock</header>)
 jest.mock('./components/FilterPanel', () => () => <div>FilterPanel Mock</div>)
 jest.mock('./components/Sidebar', () => () => <aside>Sidebar Mock</aside>)
 jest.mock('./components/LevelsPanel', () => () => <div>LevelsPanel Mock</div>)
+jest.mock('./components/SidebarToggle', () => () => <button>Toggle</button>)
 
 import { useTickets } from './hooks/useTickets'
 import { useChamadosPorData } from './hooks/useChamadosPorData'

--- a/src/frontend/react_app/src/App.tsx
+++ b/src/frontend/react_app/src/App.tsx
@@ -3,10 +3,12 @@ import Header from './components/Header'
 import { ErrorBoundary } from './components/ErrorBoundary'
 import FilterPanel from './components/FilterPanel'
 import { Sidebar } from './components/Sidebar'
+import SidebarToggle from './components/SidebarToggle'
 import { LevelsPanel } from './components/LevelsPanel'
 import TicketsDisplay from './components/TicketsDisplay'
 import SkeletonChart from './components/SkeletonChart'
 import SkeletonHeatmap from './components/SkeletonHeatmap'
+import { SidebarProvider } from './hooks/useSidebar'
 
 // Lazy load heavy components to split them into separate chunks.
 // This tells Vite/Rollup to create separate .js files for these components.
@@ -16,23 +18,26 @@ const ChamadosHeatmap = lazy(() => import('./components/ChamadosHeatmap'))
 function App() {
   return (
     <ErrorBoundary>
-      <div className="app-container">
-        <Header />
-        <FilterPanel />
-        <main className="main-content">
-          <div className="dashboard-grid">
-            <TicketsDisplay />
-            <Suspense fallback={<SkeletonChart />}>
-              <ChamadosTendencia />
-            </Suspense>
-            <Suspense fallback={<SkeletonHeatmap />}>
-              <ChamadosHeatmap />
-            </Suspense>
-            <LevelsPanel levels={[]} />
-          </div>
-          <Sidebar performance={[]} ranking={[]} alerts={[]} />
-        </main>
-      </div>
+      <SidebarProvider>
+        <div className="app-container">
+          <Header />
+          <FilterPanel />
+          <SidebarToggle />
+          <main className="main-content">
+            <div className="dashboard-grid">
+              <TicketsDisplay />
+              <Suspense fallback={<SkeletonChart />}>
+                <ChamadosTendencia />
+              </Suspense>
+              <Suspense fallback={<SkeletonHeatmap />}>
+                <ChamadosHeatmap />
+              </Suspense>
+              <LevelsPanel levels={[]} />
+            </div>
+            <Sidebar performance={[]} ranking={[]} alerts={[]} />
+          </main>
+        </div>
+      </SidebarProvider>
     </ErrorBoundary>
   )
 }

--- a/src/frontend/react_app/src/components/Sidebar.tsx
+++ b/src/frontend/react_app/src/components/Sidebar.tsx
@@ -1,4 +1,5 @@
 import { memo, type FC } from 'react'
+import { useSidebar } from '../hooks/useSidebar'
 
 export interface PerformanceMetric {
   label: string
@@ -25,8 +26,10 @@ export interface SidebarProps {
   alerts: AlertItem[]
 }
 
-const SidebarComponent: FC<SidebarProps> = ({ performance, ranking, alerts }) => (
-  <aside className="sidebar">
+const SidebarComponent: FC<SidebarProps> = ({ performance, ranking, alerts }) => {
+  const { open } = useSidebar()
+  return (
+  <aside className={`sidebar ${open ? 'open' : ''}`}>
     <div className="sidebar-card">
       <div className="sidebar-header">
         <i className="fas fa-chart-line sidebar-icon" />
@@ -77,6 +80,7 @@ const SidebarComponent: FC<SidebarProps> = ({ performance, ranking, alerts }) =>
       </div>
     </div>
   </aside>
-)
+  )
+}
 
 export const Sidebar = memo(SidebarComponent)

--- a/src/frontend/react_app/src/components/SidebarToggle.tsx
+++ b/src/frontend/react_app/src/components/SidebarToggle.tsx
@@ -5,7 +5,7 @@ const SidebarToggle: FC = () => {
   const { toggle } = useSidebar()
   return (
     <button className="sidebar-toggle" onClick={toggle} aria-label="Toggle sidebar">
-      <i className="fas fa-bars" />
+      <i className="fas fa-bars" aria-hidden="true" />
     </button>
   )
 }

--- a/src/frontend/react_app/src/components/SidebarToggle.tsx
+++ b/src/frontend/react_app/src/components/SidebarToggle.tsx
@@ -1,0 +1,13 @@
+import { type FC } from 'react'
+import { useSidebar } from '../hooks/useSidebar'
+
+const SidebarToggle: FC = () => {
+  const { toggle } = useSidebar()
+  return (
+    <button className="sidebar-toggle" onClick={toggle} aria-label="Toggle sidebar">
+      <i className="fas fa-bars" />
+    </button>
+  )
+}
+
+export default SidebarToggle

--- a/src/frontend/react_app/src/hooks/useSidebar.tsx
+++ b/src/frontend/react_app/src/hooks/useSidebar.tsx
@@ -1,0 +1,26 @@
+import { createContext, useContext, useState, type ReactNode } from 'react'
+
+interface SidebarState {
+  open: boolean
+  toggle: () => void
+}
+
+const SidebarContext = createContext<SidebarState | undefined>(undefined)
+
+export function SidebarProvider({ children }: { children: ReactNode }) {
+  const [open, setOpen] = useState(false)
+  const toggle = () => setOpen((o) => !o)
+  return (
+    <SidebarContext.Provider value={{ open, toggle }}>
+      {children}
+    </SidebarContext.Provider>
+  )
+}
+
+export function useSidebar() {
+  const ctx = useContext(SidebarContext)
+  if (!ctx) {
+    throw new Error('useSidebar must be used within SidebarProvider')
+  }
+  return ctx
+}

--- a/src/frontend/react_app/tests/hooks/useSidebar.test.tsx
+++ b/src/frontend/react_app/tests/hooks/useSidebar.test.tsx
@@ -1,0 +1,11 @@
+import { renderHook, act } from '@testing-library/react'
+import { SidebarProvider, useSidebar } from '@/hooks/useSidebar'
+
+test('toggles sidebar state', () => {
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <SidebarProvider>{children}</SidebarProvider>
+  )
+  const { result } = renderHook(() => useSidebar(), { wrapper })
+  act(() => result.current.toggle())
+  expect(result.current.open).toBe(true)
+})


### PR DESCRIPTION
## Summary
- use context-based hook to manage sidebar state
- add SidebarToggle component
- wrap app in SidebarProvider and apply open state
- apply open CSS class inside Sidebar
- cover new hook with tests and mock toggle in app tests

## Testing
- `npm test --silent -- tests/hooks/useSidebar.test.tsx`
- `pre-commit run --files src/frontend/react_app/src/App.tsx src/frontend/react_app/src/components/Sidebar.tsx src/frontend/react_app/src/components/SidebarToggle.tsx src/frontend/react_app/src/hooks/useSidebar.tsx src/frontend/react_app/tests/hooks/useSidebar.test.tsx src/frontend/react_app/src/App.test.tsx`
- `pytest -k "" -q` *(fails: ModuleNotFoundError: No module named 'fakeredis')*

------
https://chatgpt.com/codex/tasks/task_e_68843ffaa1908320aafc5794be0f98f3

## Resumo por Sourcery

Adiciona recurso de alternância da barra lateral gerenciando o estado de abertura via contexto e integrando um botão de alternância no aplicativo.

Novos Recursos:
- Apresenta SidebarProvider e o hook useSidebar para gerenciamento de estado da barra lateral
- Adiciona o componente SidebarToggle para acionar a abertura/fechamento da barra lateral
- Envolve o App em SidebarProvider e inclui SidebarToggle para integrar a funcionalidade de alternância

Melhorias:
- Aplica a classe CSS 'open' à Sidebar com base no estado do contexto

Testes:
- Adiciona testes unitários para o hook useSidebar
- Simula a alternância (mock) nos testes do componente App para acomodar o novo botão de alternância

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add sidebar toggle feature by managing open state via context and integrating a toggle button in the app.

New Features:
- Introduce SidebarProvider and useSidebar hook for sidebar state management
- Add SidebarToggle component to trigger sidebar open/close
- Wrap App in SidebarProvider and include SidebarToggle to integrate the toggle functionality

Enhancements:
- Apply 'open' CSS class to Sidebar based on context state

Tests:
- Add unit tests for useSidebar hook
- Mock toggle in App component tests to accommodate the new toggle button

</details>