### PR TITLE
Add reusable modal with hook

### DIFF
--- a/src/frontend/react_app/src/components/LevelsPanel.tsx
+++ b/src/frontend/react_app/src/components/LevelsPanel.tsx
@@ -1,4 +1,5 @@
 import { memo, type FC } from 'react'
+import { useModal } from '../hooks/useModal'
 
 export interface LevelData {
   name: string
@@ -10,6 +11,22 @@ export interface LevelsPanelProps {
 }
 
 const LevelsPanelComponent: FC<LevelsPanelProps> = ({ levels }) => {
+  const { openModal, modalElement } = useModal()
+
+  const showDetails = (level: LevelData) => {
+    openModal(
+      <div>
+        <h2 className="text-xl font-bold mb-4">{level.name}</h2>
+        <ul className="space-y-2">
+          <li>Novos: {level.metrics.new}</li>
+          <li>Progresso: {level.metrics.progress}</li>
+          <li>Pendente: {level.metrics.pending}</li>
+          <li>Resolvido: {level.metrics.resolved}</li>
+        </ul>
+      </div>,
+    )
+  }
+
   return (
     <div className="levels-section">
       <div className="levels-header">
@@ -23,6 +40,7 @@ const LevelsPanelComponent: FC<LevelsPanelProps> = ({ levels }) => {
           <div
             key={level.name}
             className={`level-card ${level.name.toLowerCase()}`}
+            onClick={() => showDetails(level)}
           >
             <div className="level-header">
               <div className="level-badge">{level.name}</div>
@@ -54,6 +72,7 @@ const LevelsPanelComponent: FC<LevelsPanelProps> = ({ levels }) => {
           </div>
         ))}
       </div>
+      {modalElement}
     </div>
   )
 }

--- a/src/frontend/react_app/src/components/Modal.tsx
+++ b/src/frontend/react_app/src/components/Modal.tsx
@@ -1,0 +1,77 @@
+import { type FC, useEffect, useRef } from 'react'
+import { createPortal } from 'react-dom'
+
+interface ModalProps {
+  isOpen: boolean
+  onClose: () => void
+  children: React.ReactNode
+}
+
+const FOCUS_SELECTOR =
+  'a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), iframe, object, embed, [tabindex]:not([-1]), [contenteditable=true]'
+
+function useFocusTrap(ref: React.RefObject<HTMLDivElement>, isActive: boolean, onClose: () => void) {
+  useEffect(() => {
+    if (!isActive || !ref.current) return
+    const root = ref.current
+    const focusable = Array.from(root.querySelectorAll<HTMLElement>(FOCUS_SELECTOR))
+    const first = focusable[0]
+    const last = focusable[focusable.length - 1]
+    const previouslyFocused = document.activeElement as HTMLElement | null
+    first?.focus()
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Tab') {
+        if (focusable.length === 0) {
+          e.preventDefault()
+          return
+        }
+        if (e.shiftKey) {
+          if (document.activeElement === first) {
+            e.preventDefault()
+            last?.focus()
+          }
+        } else if (document.activeElement === last) {
+          e.preventDefault()
+          first?.focus()
+        }
+      } else if (e.key === 'Escape') {
+        onClose()
+      }
+    }
+    root.addEventListener('keydown', handleKeyDown)
+    return () => {
+      root.removeEventListener('keydown', handleKeyDown)
+      previouslyFocused?.focus()
+    }
+  }, [isActive, ref, onClose])
+}
+
+export const Modal: FC<ModalProps> = ({ isOpen, onClose, children }) => {
+  const containerRef = useRef<HTMLDivElement>(null)
+  useFocusTrap(containerRef, isOpen, onClose)
+
+  useEffect(() => {
+    if (!isOpen) return
+    const handleClick = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        onClose()
+      }
+    }
+    document.addEventListener('mousedown', handleClick)
+    return () => document.removeEventListener('mousedown', handleClick)
+  }, [isOpen, onClose])
+
+  if (!isOpen) return null
+
+  return createPortal(
+    <div className={"modal-overlay show"}>
+      <div role="dialog" aria-modal="true" ref={containerRef} className="modal">
+        {children}
+        <button className="absolute top-2 right-2" onClick={onClose} aria-label="Fechar">
+          &times;
+        </button>
+      </div>
+    </div>,
+    document.body,
+  )
+}

--- a/src/frontend/react_app/src/hooks/useModal.tsx
+++ b/src/frontend/react_app/src/hooks/useModal.tsx
@@ -1,0 +1,14 @@
+import { useState } from 'react'
+import { Modal } from '../components/Modal'
+
+export function useModal() {
+  const [content, setContent] = useState<React.ReactNode | null>(null)
+  const openModal = (node: React.ReactNode) => setContent(node)
+  const closeModal = () => setContent(null)
+  const modalElement = (
+    <Modal isOpen={content !== null} onClose={closeModal}>
+      {content}
+    </Modal>
+  )
+  return { openModal, closeModal, modalElement }
+}


### PR DESCRIPTION
## Summary
- implement `Modal` component using React portals and focus trap
- add `useModal` hook for managing modal state
- update `LevelsPanel` to open a modal with level details on click

## Testing
- `pytest tests/test_auth.py -q` *(fails: ModuleNotFoundError: 'fakeredis')*
- `npm test -- -w 1 --runTestsByPath src/components/LevelsPanel.tsx` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6884452dab108320a09a1a552d7053a6