### PR TITLE
Improve modal hooks and accessibility

### DIFF
--- a/src/frontend/react_app/src/components/LevelsPanel.tsx
+++ b/src/frontend/react_app/src/components/LevelsPanel.tsx
@@ -1,4 +1,4 @@
-import { memo, type FC } from 'react'
+import { memo, type FC, useCallback } from 'react'
 import { useModal } from '../hooks/useModal'
 
 export interface LevelData {
@@ -13,19 +13,22 @@ export interface LevelsPanelProps {
 const LevelsPanelComponent: FC<LevelsPanelProps> = ({ levels }) => {
   const { openModal, modalElement } = useModal()
 
-  const showDetails = (level: LevelData) => {
-    openModal(
-      <div>
-        <h2 className="text-xl font-bold mb-4">{level.name}</h2>
-        <ul className="space-y-2">
-          <li>Novos: {level.metrics.new}</li>
-          <li>Progresso: {level.metrics.progress}</li>
-          <li>Pendente: {level.metrics.pending}</li>
-          <li>Resolvido: {level.metrics.resolved}</li>
-        </ul>
-      </div>,
-    )
-  }
+  const showDetails = useCallback(
+    (level: LevelData) => {
+      openModal(
+        <div>
+          <h2 className="text-xl font-bold mb-4">{level.name}</h2>
+          <ul className="space-y-2">
+            <li>Novos: {level.metrics.new}</li>
+            <li>Progresso: {level.metrics.progress}</li>
+            <li>Pendente: {level.metrics.pending}</li>
+            <li>Resolvido: {level.metrics.resolved}</li>
+          </ul>
+        </div>,
+      )
+    },
+    [openModal],
+  )
 
   return (
     <div className="levels-section">
@@ -41,6 +44,9 @@ const LevelsPanelComponent: FC<LevelsPanelProps> = ({ levels }) => {
             key={level.name}
             className={`level-card ${level.name.toLowerCase()}`}
             onClick={() => showDetails(level)}
+            role="button"
+            aria-label={`View details for ${level.name}`}
+            type="button"
           >
             <div className="level-header">
               <div className="level-badge">{level.name}</div>
@@ -69,7 +75,7 @@ const LevelsPanelComponent: FC<LevelsPanelProps> = ({ levels }) => {
                 </span>
               </div>
             </div>
-          </div>
+            </button>
         ))}
       </div>
       {modalElement}

--- a/src/frontend/react_app/src/components/LevelsPanel.tsx
+++ b/src/frontend/react_app/src/components/LevelsPanel.tsx
@@ -74,7 +74,7 @@ const LevelsPanelComponent: FC<LevelsPanelProps> = ({ levels }) => {
                   {level.metrics.resolved}
                 </span>
               </div>
-            </div>
+              </button>
             </button>
         ))}
       </div>

--- a/src/frontend/react_app/src/hooks/useModal.tsx
+++ b/src/frontend/react_app/src/hooks/useModal.tsx
@@ -1,14 +1,17 @@
-import { useState } from 'react'
+import { useState, useCallback, useMemo } from 'react'
 import { Modal } from '../components/Modal'
 
 export function useModal() {
   const [content, setContent] = useState<React.ReactNode | null>(null)
-  const openModal = (node: React.ReactNode) => setContent(node)
-  const closeModal = () => setContent(null)
-  const modalElement = (
-    <Modal isOpen={content !== null} onClose={closeModal}>
-      {content}
-    </Modal>
+  const openModal = useCallback((node: React.ReactNode) => setContent(node), [])
+  const closeModal = useCallback(() => setContent(null), [])
+  const modalElement = useMemo(
+    () => (
+      <Modal isOpen={content !== null} onClose={closeModal}>
+        {content}
+      </Modal>
+    ),
+    [content, closeModal],
   )
   return { openModal, closeModal, modalElement }
 }


### PR DESCRIPTION
## Summary
- memoize openModal/closeModal in useModal hook
- memoize modalElement in useModal
- refactor LevelsPanel to use useCallback and add accessibility labels

## Testing
- `pre-commit run --files src/frontend/react_app/src/components/LevelsPanel.tsx src/frontend/react_app/src/hooks/useModal.tsx`
- `pytest tests/test_auth.py -k test_init_session_success -q`

------
https://chatgpt.com/codex/tasks/task_e_68844b6127e0832093bafd13688c1f54

## Resumo por Sourcery

Melhorar o desempenho do hook de modal ao memorizar callbacks e o elemento renderizado, e aprimorar o componente LevelsPanel com callbacks otimizados e atributos de acessibilidade.

Melhorias:
- Memorizar as funções openModal e closeModal e o modalElement usando useCallback e useMemo no hook useModal
- Empacotar a função showDetails do LevelsPanel em useCallback para evitar recriações desnecessárias
- Adicionar atributos role, type e aria-label aos botões de nível para melhor acessibilidade

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve modal hook performance by memoizing callbacks and rendered element, and enhance LevelsPanel component with optimized callbacks and accessibility attributes.

Enhancements:
- Memoize openModal and closeModal functions and the modalElement using useCallback and useMemo in useModal hook
- Wrap LevelsPanel’s showDetails function in useCallback to prevent unnecessary re-creations
- Add role, type, and aria-label attributes to level buttons for better accessibility

</details>