### PR TITLE
Support dashboard filters in query hooks

### DIFF
--- a/src/frontend/react_app/src/hooks/__tests__/useDashboardData.test.tsx
+++ b/src/frontend/react_app/src/hooks/__tests__/useDashboardData.test.tsx
@@ -2,6 +2,7 @@ import { renderHook } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { useDashboardData } from '../useDashboardData'
 import { useApiQuery } from '../useApiQuery'
+import { DEFAULT_FILTERS } from '../useFilters'
 
 jest.mock('../useApiQuery')
 
@@ -31,7 +32,7 @@ describe('useDashboardData refresh interval', () => {
     const wrapper = ({ children }: { children: React.ReactNode }) => (
       <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
     )
-    const { unmount } = renderHook(() => useDashboardData(), { wrapper })
+    const { unmount } = renderHook(() => useDashboardData(DEFAULT_FILTERS), { wrapper })
     unmount()
     expect(clearSpy).toHaveBeenCalledWith(123)
     setSpy.mockRestore()

--- a/src/frontend/react_app/src/hooks/useFilters.ts
+++ b/src/frontend/react_app/src/hooks/useFilters.ts
@@ -8,14 +8,16 @@ export interface FiltersState {
   priority: string[]
 }
 
-export function useFilters() {
-  const [filters, setFilters] = useState<FiltersState>({
-    open: false,
-    period: ['today'],
-    level: ['n1', 'n2', 'n3', 'n4'],
-    status: ['new', 'progress', 'pending', 'resolved'],
-    priority: ['medium', 'low'],
-  })
+export const DEFAULT_FILTERS: FiltersState = {
+  open: false,
+  period: ['today'],
+  level: ['n1', 'n2', 'n3', 'n4'],
+  status: ['new', 'progress', 'pending', 'resolved'],
+  priority: ['medium', 'low'],
+}
+
+export function useFilters(initial: FiltersState = DEFAULT_FILTERS) {
+  const [filters, setFilters] = useState<FiltersState>({ ...initial })
 
   const toggleFilters = () => setFilters((f) => ({ ...f, open: !f.open }))
 

--- a/src/frontend/react_app/src/hooks/useTickets.ts
+++ b/src/frontend/react_app/src/hooks/useTickets.ts
@@ -1,6 +1,9 @@
+import { useEffect, useMemo } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import { useApiQuery } from '../hooks/useApiQuery'
-import { useMemo } from 'react'
+import type { FiltersState } from './useFilters'
+import { buildQueryString } from '../lib/buildQueryString'
+import { stableStringify } from '../lib/stableStringify'
 import type { CleanTicketDTO } from '../types/api'
 import type { Ticket } from '../types/ticket'
 
@@ -17,10 +20,21 @@ function toTicket(dto: CleanTicketDTO): Ticket {
   }
 }
 
-export function useTickets() {
+export function useTickets(filters?: FiltersState) {
   const queryClient = useQueryClient()
-  const query = useApiQuery<CleanTicketDTO[]>(['tickets'], '/tickets')
+  const qs = buildQueryString(filters)
+  const serialized = stableStringify(filters)
+  const query = useApiQuery<CleanTicketDTO[]>(
+    ['tickets', serialized],
+    `/tickets${qs}`,
+  )
   const tickets = useMemo(() => query.data?.map(toTicket), [query.data])
+
+  useEffect(() => {
+    if (filters) {
+      queryClient.invalidateQueries({ queryKey: ['tickets'] })
+    }
+  }, [filters, queryClient])
 
   const refreshTickets = () =>
     queryClient.invalidateQueries({ queryKey: ['tickets'] })

--- a/src/frontend/react_app/src/hooks/useTickets.ts
+++ b/src/frontend/react_app/src/hooks/useTickets.ts
@@ -32,12 +32,12 @@ export function useTickets(filters?: FiltersState) {
 
   useEffect(() => {
     if (filters) {
-      queryClient.invalidateQueries({ queryKey: ['tickets'] })
+      queryClient.invalidateQueries({ queryKey: ['tickets', serialized] })
     }
   }, [filters, queryClient])
 
   const refreshTickets = () =>
-    queryClient.invalidateQueries({ queryKey: ['tickets'] })
+    queryClient.invalidateQueries({ queryKey: ['tickets', serialized] })
 
   return {
     tickets,

--- a/src/frontend/react_app/src/lib/buildQueryString.ts
+++ b/src/frontend/react_app/src/lib/buildQueryString.ts
@@ -1,0 +1,25 @@
+export interface FilterQuery {
+  [key: string]: string[] | boolean | undefined
+}
+
+/**
+ * Convert filter values into a stable query string.
+ * `open` is ignored because it only controls panel visibility.
+ */
+export function buildQueryString(filters?: FilterQuery): string {
+  if (!filters) return ''
+  const entries = Object.entries(filters)
+    .filter(([key]) => key !== 'open')
+    .sort(([a], [b]) => a.localeCompare(b))
+  const params = new URLSearchParams()
+  for (const [key, value] of entries) {
+    if (Array.isArray(value)) {
+      const sortedValues = [...value].sort()
+      for (const v of sortedValues) params.append(key, v)
+    } else if (value != null) {
+      params.append(key, String(value))
+    }
+  }
+  const str = params.toString()
+  return str ? `?${str}` : ''
+}

--- a/src/frontend/react_app/tests/hooks/useDashboardData.test.tsx
+++ b/src/frontend/react_app/tests/hooks/useDashboardData.test.tsx
@@ -1,6 +1,7 @@
 import { renderHook, waitFor } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { useDashboardData } from '@/hooks/useDashboardData'
+import { DEFAULT_FILTERS } from '@/hooks/useFilters'
 
 const queryClient = new QueryClient()
 const wrapper = ({ children }: { children: React.ReactNode }) => (
@@ -14,7 +15,7 @@ test('loads metrics from API', async () => {
       Promise.resolve({ status: { new: 2, pending: 1, progress: 3, resolved: 4 } }),
   }) as jest.Mock
 
-  const { result } = renderHook(() => useDashboardData(), { wrapper })
+  const { result } = renderHook(() => useDashboardData(DEFAULT_FILTERS), { wrapper })
 
   await waitFor(() => expect(result.current.metrics.new).toBe(2))
 
@@ -32,7 +33,7 @@ test('handles API error', async () => {
     text: () => Promise.resolve('fail'),
   }) as jest.Mock
 
-  const { result } = renderHook(() => useDashboardData(), { wrapper })
+  const { result } = renderHook(() => useDashboardData(DEFAULT_FILTERS), { wrapper })
   await waitFor(() => expect(result.current.error).toBeTruthy())
 })
 
@@ -51,7 +52,7 @@ test('refreshMetrics triggers refetch', async () => {
     })
   global.fetch = fetchMock as unknown as typeof fetch
 
-  const { result } = renderHook(() => useDashboardData(), { wrapper })
+  const { result } = renderHook(() => useDashboardData(DEFAULT_FILTERS), { wrapper })
   await waitFor(() => expect(result.current.metrics.new).toBe(1))
 
   await result.current.refreshMetrics()


### PR DESCRIPTION
## Summary
- expose `DEFAULT_FILTERS` from `useFilters`
- add helper `buildQueryString` for filter params
- update `useTickets` and `useDashboardData` to accept filters
- watch filters and invalidate associated React Query caches
- adapt tests for the new hook signatures

## Testing
- `pre-commit run --files src/frontend/react_app/src/hooks/useFilters.ts src/frontend/react_app/src/hooks/useTickets.ts src/frontend/react_app/src/hooks/useDashboardData.ts src/frontend/react_app/src/hooks/__tests__/useDashboardData.test.tsx src/frontend/react_app/tests/hooks/useTickets.test.tsx src/frontend/react_app/tests/hooks/useDashboardData.test.tsx src/frontend/react_app/src/lib/buildQueryString.ts`
- `NEXT_PUBLIC_API_BASE_URL=http://localhost npm test -- -w 1` *(fails: SyntaxError: Cannot use 'import.meta' outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_688457f792208320915c631d25a8f047

## Resumo por Sourcery

Adiciona suporte a hooks de dashboard e tickets para parâmetros de filtro, expondo filtros padrão, construindo query strings e invalidando consultas quando os filtros mudam.

Novos Recursos:
- Expõe a constante `DEFAULT_FILTERS` para inicializar o estado do filtro
- Implementa o helper `buildQueryString` para serializar parâmetros de filtro em consultas de URL
- Atualiza os hooks `useTickets` e `useDashboardData` para aceitar um `FiltersState` opcional, incluir filtros em chaves de consulta e endpoints de API, e invalidar caches do React Query em mudanças de filtro

Testes:
- Adapta testes existentes para fornecer `DEFAULT_FILTERS` aos hooks e verificar o uso da query string de filtro

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add dashboard and ticket hooks support for filter parameters by exposing default filters, building query strings, and invalidating queries when filters change.

New Features:
- Expose DEFAULT_FILTERS constant for initializing filter state
- Implement buildQueryString helper to serialize filter parameters into URL queries
- Update useTickets and useDashboardData hooks to accept optional FiltersState, include filters in query keys and API endpoints, and invalidate React Query caches on filter changes

Tests:
- Adapt existing tests to supply DEFAULT_FILTERS to hooks and verify filter query string usage

</details>