### PR TITLE
Log hydration timing

### DIFF
--- a/src/frontend/react_app/src/main.tsx
+++ b/src/frontend/react_app/src/main.tsx
@@ -7,7 +7,7 @@ import App from './App';
 import './index.css';
 
 // Start measuring from the initial navigation start point
-const navigationStart = performance.timing.navigationStart;
+const navigationStart = performance.getEntriesByType('navigation')[0]?.startTime || performance.timeOrigin;
 
 const queryClient = new QueryClient();
 const faroURL = import.meta.env.NEXT_PUBLIC_FARO_URL;

--- a/src/frontend/react_app/src/main.tsx
+++ b/src/frontend/react_app/src/main.tsx
@@ -6,6 +6,9 @@ import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import App from './App';
 import './index.css';
 
+// Start measuring from the initial navigation start point
+const navigationStart = performance.timing.navigationStart;
+
 const queryClient = new QueryClient();
 const faroURL = import.meta.env.NEXT_PUBLIC_FARO_URL;
 
@@ -31,3 +34,7 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
     </QueryClientProvider>
   </StrictMode>,
 );
+
+// Measure how long it took from navigation start to React hydration
+const hydrationTime = performance.now() - navigationStart;
+console.log(`⚡ React hydrated in ${hydrationTime.toFixed(2)}ms`);


### PR DESCRIPTION
## Summary
- add hydration timing log to frontend

## Testing
- `pre-commit run --files src/frontend/react_app/src/main.tsx`
- `npm run lint --silent` *(fails: React must be in scope etc)*
- `NEXT_PUBLIC_API_BASE_URL=http://localhost:8000 npm test --silent` *(fails to parse ESM modules)*

------
https://chatgpt.com/codex/tasks/task_e_68845c6098688320ad093b68334b5d79

## Resumo por Sourcery

Mede e registra o tempo desde o início da navegação da página até a hidratação do React no ponto de entrada do frontend.

Novos Recursos:
- Registra o tempo de hidratação do React no console do navegador

Melhorias:
- Captura o início da navegação usando performance.timing.navigationStart antes do React renderizar

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Measure and log the time from page navigation start to React hydration in the frontend entrypoint.

New Features:
- Log React hydration time in the browser console

Enhancements:
- Capture navigation start using performance.timing.navigationStart before React renders

</details>