### PR TITLE
Remove unnecessary query invalidations

### DIFF
--- a/src/frontend/react_app/src/hooks/useDashboardData.ts
+++ b/src/frontend/react_app/src/hooks/useDashboardData.ts
@@ -84,13 +84,6 @@ export function useDashboardData(filters?: FiltersState) {
     }
   }, [])
 
-  useEffect(() => {
-    if (filters) {
-      queryClient.invalidateQueries({ queryKey: ['metrics-aggregated'] })
-    }
-  }, [filters, queryClient])
-
-
   const refreshMetrics = () =>
     queryClient.invalidateQueries({ queryKey: ['metrics-aggregated'] })
 

--- a/src/frontend/react_app/src/hooks/useTickets.ts
+++ b/src/frontend/react_app/src/hooks/useTickets.ts
@@ -30,11 +30,6 @@ export function useTickets(filters?: FiltersState) {
   )
   const tickets = useMemo(() => query.data?.map(toTicket), [query.data])
 
-  useEffect(() => {
-    if (filters) {
-      queryClient.invalidateQueries({ queryKey: ['tickets', serialized] })
-    }
-  }, [filters, queryClient])
 
   const refreshTickets = () =>
     queryClient.invalidateQueries({ queryKey: ['tickets', serialized] })


### PR DESCRIPTION
## Summary
- remove effect hooks that were redundantly invalidating queries

## Testing
- `pre-commit run --files src/frontend/react_app/src/hooks/useDashboardData.ts src/frontend/react_app/src/hooks/useTickets.ts`
- `npm test` *(fails: Jest encountered unexpected token due to ESM parsing)*
- `pytest -q` *(fails: missing modules such as `fakeredis`)*

------
https://chatgpt.com/codex/tasks/task_e_68845c4b151483209e4f8dcf08362ece

## Resumo por Sourcery

Remove invalidações automáticas redundantes de query nos hooks de dashboard e tickets

Melhorias:
- Remove hooks useEffect que invalidavam queries em mudanças de filtro em useDashboardData e useTickets
- Confia em funções de atualização explícitas para invalidação de query em vez de hooks de efeito colateral

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove redundant automatic query invalidations in dashboard and tickets hooks

Enhancements:
- Remove useEffect hooks that invalidated queries on filter changes in useDashboardData and useTickets
- Rely on explicit refresh functions for query invalidation instead of side-effect hooks

</details>