### PR TITLE
Add sparkline hook and history tracking

### DIFF
--- a/src/frontend/react_app/src/hooks/useDashboardData.ts
+++ b/src/frontend/react_app/src/hooks/useDashboardData.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import { useApiQuery } from './useApiQuery'
 import type { FiltersState } from './useFilters'
@@ -8,6 +8,7 @@ import { buildQueryString } from '../lib/buildQueryString'
 import { stableStringify } from '../lib/stableStringify'
 import type { Chart as ChartType } from 'chart.js'
 import type { DashboardStats } from '../types/dashboard'
+import { useSparkline } from './useSparkline'
 import {
   scheduleIdleCallback,
   cancelIdleCallback,
@@ -39,6 +40,12 @@ export function useDashboardData(filters?: FiltersState) {
     progress: query.data?.status?.progress ?? 0,
     resolved: query.data?.status?.resolved ?? 0,
   }
+  const [history, setHistory] = useState<Record<keyof Metrics, number[]>>({
+    new: [],
+    pending: [],
+    progress: [],
+    resolved: [],
+  })
   const trendChart = useRef<ChartType | null>(null)
   const sparkRefs = {
     new: useRef<HTMLCanvasElement>(null),
@@ -46,6 +53,21 @@ export function useDashboardData(filters?: FiltersState) {
     progress: useRef<HTMLCanvasElement>(null),
     resolved: useRef<HTMLCanvasElement>(null),
   }
+
+  useSparkline(sparkRefs.new, history.new)
+  useSparkline(sparkRefs.pending, history.pending)
+  useSparkline(sparkRefs.progress, history.progress)
+  useSparkline(sparkRefs.resolved, history.resolved)
+
+  useEffect(() => {
+    if (!query.data) return
+    setHistory((prev) => ({
+      new: [...prev.new.slice(-19), metrics.new],
+      pending: [...prev.pending.slice(-19), metrics.pending],
+      progress: [...prev.progress.slice(-19), metrics.progress],
+      resolved: [...prev.resolved.slice(-19), metrics.resolved],
+    }))
+  }, [query.data])
 
   useEffect(() => {
     let handle: IdleHandle | null = null
@@ -97,6 +119,7 @@ export function useDashboardData(filters?: FiltersState) {
   return {
     metrics,
     sparkRefs,
+    history,
     refreshMetrics,
     isLoading: query.isLoading,
     error: query.error as Error | null,

--- a/src/frontend/react_app/src/hooks/useSparkline.ts
+++ b/src/frontend/react_app/src/hooks/useSparkline.ts
@@ -1,0 +1,51 @@
+import { useEffect, useRef } from 'react'
+import type { Chart as ChartType } from 'chart.js'
+import {
+  scheduleIdleCallback,
+  cancelIdleCallback,
+  type IdleHandle,
+} from '../lib/scheduleIdleCallback'
+
+/**
+ * Draws a tiny sparkline using Chart.js on the provided canvas.
+ * The chart updates whenever the `data` array changes.
+ */
+export function useSparkline(
+  canvasRef: React.RefObject<HTMLCanvasElement>,
+  data: number[],
+) {
+  const chartRef = useRef<ChartType | null>(null)
+
+  useEffect(() => {
+    if (!canvasRef.current) return
+    let handle: IdleHandle | null = null
+    async function render() {
+      const Chart = (await import('chart.js/auto')).default
+      const ctx = canvasRef.current
+      if (!ctx) return
+      if (!chartRef.current) {
+        chartRef.current = new Chart(ctx, {
+          type: 'line',
+          data: { labels: data.map((_, i) => String(i)), datasets: [{ data }] },
+          options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            scales: { x: { display: false }, y: { display: false } },
+            elements: { point: { radius: 0 } },
+            plugins: { legend: { display: false }, tooltip: { enabled: false } },
+          },
+        })
+      } else {
+        chartRef.current.data.labels = data.map((_, i) => String(i))
+        chartRef.current.data.datasets[0].data = data
+        chartRef.current.update()
+      }
+    }
+    handle = scheduleIdleCallback(render)
+    return () => {
+      if (handle !== null) cancelIdleCallback(handle)
+    }
+  }, [canvasRef, data])
+
+  useEffect(() => () => chartRef.current?.destroy(), [])
+}

--- a/src/frontend/react_app/tests/profile.spec.tsx
+++ b/src/frontend/react_app/tests/profile.spec.tsx
@@ -11,6 +11,7 @@ jest.mock('../src/hooks/useDashboardData', () => ({
       progress: { current: null },
       resolved: { current: null },
     },
+    history: { new: [], pending: [], progress: [], resolved: [] },
   }),
 }))
 


### PR DESCRIPTION
## Summary
- create `useSparkline` for small canvas line charts
- track metric history in `useDashboardData`
- draw sparklines for each metric
- update test mocks

## Testing
- `make test-backend` *(fails: TypeError: Can't replace canonical symbol)*

------
https://chatgpt.com/codex/tasks/task_e_68845cc2f04c8320bdbf09c05fe80bd9