### PR TITLE
Improve GLPI pagination mapping

### DIFF
--- a/src/backend/application/glpi_api_client.py
+++ b/src/backend/application/glpi_api_client.py
@@ -62,8 +62,9 @@ class GlpiApiClient:
                 for fid, info in options.items()
                 if isinstance(info, dict) and info.get("field")
             }
-            ids = [field_map[name] for name in BASE_TICKET_FIELDS if name in field_map]
-            if ids:
+            if ids := [
+                field_map[name] for name in BASE_TICKET_FIELDS if name in field_map
+            ]:
                 self._forced_fields[:] = ids
                 return
         except Exception as exc:  # pragma: no cover - defensive

--- a/src/backend/application/glpi_api_client.py
+++ b/src/backend/application/glpi_api_client.py
@@ -98,7 +98,7 @@ class GlpiApiClient:
                 continue
             try:
                 id_to_name[int(fid)] = name
-            except (ValueError, TypeError):  # noqa: BLE001
+            except (ValueError, TypeError):
                 continue
 
         for record in records:

--- a/src/backend/application/glpi_api_client.py
+++ b/src/backend/application/glpi_api_client.py
@@ -106,8 +106,7 @@ class GlpiApiClient:
             for key in list(record.keys()):
                 if isinstance(key, int) or (isinstance(key, str) and key.isdigit()):
                     fid = int(key)
-                    name = id_to_name.get(fid)
-                    if name:
+                    if name := id_to_name.get(fid):
                         record[name] = record.pop(key)
         return records
 

--- a/src/backend/application/glpi_api_client.py
+++ b/src/backend/application/glpi_api_client.py
@@ -56,7 +56,13 @@ class GlpiApiClient:
         if self._forced_fields:
             return
         try:
-            ids = await self._mapper.get_ticket_field_ids(BASE_TICKET_FIELDS)
+            options = await self._session.list_search_options("Ticket")
+            field_map = {
+                info.get("field"): int(fid)
+                for fid, info in options.items()
+                if isinstance(info, dict) and info.get("field")
+            }
+            ids = [field_map[name] for name in BASE_TICKET_FIELDS if name in field_map]
             if ids:
                 self._forced_fields[:] = ids
                 return
@@ -73,6 +79,36 @@ class GlpiApiClient:
         tb: Optional[Any],
     ) -> None:
         await self._session.__aexit__(exc_type, exc, tb)
+
+    async def _map_numeric_fields_to_names(
+        self, itemtype: str, records: List[Dict[str, Any]]
+    ) -> List[Dict[str, Any]]:
+        """Replace numeric keys in ``records`` with field names."""
+        try:
+            options = await self._session.list_search_options(itemtype)
+        except Exception:  # pragma: no cover - best effort
+            return records
+
+        id_to_name: Dict[int, str] = {}
+        for fid, info in options.items():
+            if not isinstance(info, dict):
+                continue
+            name = info.get("field")
+            if not name:
+                continue
+            try:
+                id_to_name[int(fid)] = name
+            except (ValueError, TypeError):  # noqa: BLE001
+                continue
+
+        for record in records:
+            for key in list(record.keys()):
+                if isinstance(key, int) or (isinstance(key, str) and key.isdigit()):
+                    fid = int(key)
+                    name = id_to_name.get(fid)
+                    if name:
+                        record[name] = record.pop(key)
+        return records
 
     async def _resolve_ticket_fields(self) -> None:
         """Discover essential Ticket field IDs dynamically."""
@@ -137,7 +173,8 @@ class GlpiApiClient:
                 endpoint, params=page_params, return_headers=True
             )
 
-        return await paginate_items(itemtype, fetch_page, page_size=page_size)
+        items = await paginate_items(itemtype, fetch_page, page_size=page_size)
+        return await self._map_numeric_fields_to_names(normalized_itemtype, items)
 
     async def fetch_tickets(self) -> List[CleanTicketDTO]:
         """Return translated tickets from the GLPI API."""


### PR DESCRIPTION
## Summary
- look up ticket field IDs directly via `listSearchOptions`
- map numeric search keys to field names when paginating
- test that field IDs are resolved and pagination mapping works

## Testing
- `pre-commit run --files tests/test_glpi_api_client.py src/backend/application/glpi_api_client.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68845c66c8f083208d2990c5a97ec502

## Resumo por Sourcery

Melhora a paginação do cliente da API GLPI resolvendo dinamicamente os IDs dos campos via `list_search_options` e mapeando chaves de campo numéricas para nomes legíveis por humanos nos resultados paginados.

Novas Funcionalidades:
- Introduz `_map_numeric_fields_to_names` para traduzir chaves de registro numéricas em nomes de campo.
- Integra o mapeamento numérico para nome em `get_all_paginated` para dados paginados.

Melhorias:
- Refatora `_populate_forced_fields` para usar `session.list_search_options` em vez de `MappingService.get_ticket_field_ids`.

Testes:
- Atualiza `test_populate_forced_fields` para afirmar o uso de `list_search_options`.
- Adiciona `test_get_all_paginated_maps_fields` para verificar a funcionalidade de mapeamento da paginação.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve GLPI API client pagination by dynamically resolving field IDs via list_search_options and mapping numeric field keys to human-readable names in paginated results.

New Features:
- Introduce _map_numeric_fields_to_names to translate numeric record keys to field names.
- Integrate numeric-to-name mapping into get_all_paginated for paginated data.

Enhancements:
- Refactor _populate_forced_fields to use session.list_search_options instead of MappingService.get_ticket_field_ids.

Tests:
- Update test_populate_forced_fields to assert list_search_options usage.
- Add test_get_all_paginated_maps_fields to verify pagination mapping functionality.

</details>