### PR TITLE
Improve search option caching

### DIFF
--- a/src/backend/application/glpi_api_client.py
+++ b/src/backend/application/glpi_api_client.py
@@ -58,7 +58,7 @@ class GlpiApiClient:
 
         cache_key = "ticket:forced_fields"
         cached = await self._mapper.search_cache.get(cache_key)
-        if isinstance(cached, list) and all(isinstance(x, int) for x in cached):
+        if isinstance(cached, list) and all(isinstance(x, int) for x in cached[:10]):
             self._forced_fields[:] = cached
             return
 

--- a/src/backend/application/glpi_api_client.py
+++ b/src/backend/application/glpi_api_client.py
@@ -52,23 +52,27 @@ class GlpiApiClient:
         return self
 
     async def _populate_forced_fields(self) -> None:
-        """Resolve numeric IDs for ``BASE_TICKET_FIELDS`` once."""
+        """Resolve numeric IDs for ``BASE_TICKET_FIELDS`` once and cache them."""
         if self._forced_fields:
             return
+
+        cache_key = "ticket:forced_fields"
+        cached = await self._mapper.search_cache.get(cache_key)
+        if isinstance(cached, list) and all(isinstance(x, int) for x in cached):
+            self._forced_fields[:] = cached
+            return
+
         try:
-            options = await self._session.list_search_options("Ticket")
-            field_map = {
-                info.get("field"): int(fid)
-                for fid, info in options.items()
-                if isinstance(info, dict) and info.get("field")
-            }
-            if ids := [
-                field_map[name] for name in BASE_TICKET_FIELDS if name in field_map
-            ]:
+            ids = await self._mapper.get_ticket_field_ids(BASE_TICKET_FIELDS)
+            if ids:
                 self._forced_fields[:] = ids
+                await self._mapper.search_cache.set(
+                    cache_key, ids, ttl_seconds=self._mapper.cache_ttl_seconds
+                )
                 return
         except Exception as exc:  # pragma: no cover - defensive
             logger.error("failed to load ticket field IDs: %s", exc)
+
         # Fallback to legacy defaults if lookup fails
         if not self._forced_fields:
             self._forced_fields[:] = [1, 2, 4, 12, 15, 83]
@@ -86,7 +90,7 @@ class GlpiApiClient:
     ) -> List[Dict[str, Any]]:
         """Replace numeric keys in ``records`` with field names."""
         try:
-            options = await self._session.list_search_options(itemtype)
+            options = await self._mapper.get_search_options(itemtype)
         except Exception:  # pragma: no cover - best effort
             return records
 


### PR DESCRIPTION
## Summary
- fetch search option IDs via MappingService instead of hitting the session
- cache forced display IDs in Redis
- update GLPI API client unit tests

## Testing
- `pre-commit run --files src/backend/application/glpi_api_client.py tests/test_glpi_api_client.py`
- `pytest tests/test_glpi_api_client.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68846f4cd4ec83209b4d17b256df8bde

## Resumo por Sourcery

Introduz cache para mapeamentos de opções de busca no cliente da API GLPI, delegando as consultas ao MappingService e armazenando IDs de campos de ticket resolvidos no Redis, e atualiza os testes para cobrir cenários de acerto e falha de cache.

Novas Funcionalidades:
- Armazena em cache os IDs de `BASE_TICKET_FIELDS` resolvidos no Redis via `MappingService.search_cache`
- Busca IDs de campos de ticket e opções de busca através de `MappingService.get_ticket_field_ids` e `get_search_options`

Melhorias:
- Substitui chamadas diretas a `session.list_search_options` por consultas ao `MappingService` e fallback de cache
- Mantém IDs de campos padrão legados se a consulta de mapeamento falhar

Testes:
- Adiciona testes unitários para os caminhos de acerto e falha de cache em `_populate_forced_fields`
- Atualiza os testes do cliente da API GLPI para simular interações do `MappingService` e `BASE_TICKET_FIELDS`

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce caching for search option mappings in the GLPI API client by delegating lookups to the MappingService and storing resolved ticket field IDs in Redis, and update tests to cover cache-hit and cache-miss scenarios.

New Features:
- Cache resolved BASE_TICKET_FIELDS IDs in Redis via MappingService.search_cache
- Fetch ticket field IDs and search options through MappingService.get_ticket_field_ids and get_search_options

Enhancements:
- Replace direct session.list_search_options calls with MappingService lookups and cache fallback
- Retain legacy default field IDs if mapping lookup fails

Tests:
- Add unit tests for cache-hit and cache-miss paths in _populate_forced_fields
- Update GLPI API client tests to mock MappingService interactions and BASE_TICKET_FIELDS

</details>