### PR TITLE
Update docs to reflect Vite setup

### DIFF
--- a/docs/ARCHITECTURE_backup.md
+++ b/docs/ARCHITECTURE_backup.md
@@ -6,7 +6,7 @@ This document provides a quick overview of how the repository is structured, the
 
 - **`src/backend/`** – FastAPI worker that talks to the GLPI API and exposes REST/GraphQL endpoints.
 - **`src/frontend/`** – Dash application composed of callbacks and layout files.
-- **`src/frontend/react_app/`** – Stand‑alone React/Next.js dashboard that consumes the worker API.
+- **`src/frontend/react_app/`** – Stand‑alone Vite + React dashboard that consumes the worker API.
 - **`src/shared/`** – Shared models and utilities reused by both back‑end and front‑end modules.
 - **`scripts/`** – Helper scripts organised into `setup/`, `fetch/` and `etl/` subfolders.
 - **`examples/`** – Reference code and prototypes only.
@@ -38,7 +38,7 @@ Aggregated metrics are computed under `src/backend/application/aggregated_metric
 ## Dependencies
 
 - **Backend**: FastAPI, httpx, pandas, SQLAlchemy, Redis, PostgreSQL.
-- **Frontend**: Dash for the Python UI and React/Next.js with Tailwind for the web dashboard.
+- **Frontend**: Dash for the Python UI and a Vite + React application with Tailwind for the web dashboard.
 
 ## GLPI Integration and Metrics
 

--- a/docs/adr/0001-frontend-stack.md
+++ b/docs/adr/0001-frontend-stack.md
@@ -8,13 +8,13 @@ Accepted
 
 ## Context
 
-The project requires a modern front-end stack capable of delivering high performance and maintainability. The architectural plan recommends React with TypeScript, Next.js for server-side rendering, and a testing toolchain based on Jest and Playwright.
+The project requires a modern front-end stack capable of delivering high performance and maintainability. The architectural plan now recommends React with TypeScript bundled by Vite, and a testing toolchain based on Jest and Playwright.
 
 ## Decision
 
-Adopt **Next.js 14** with React 18 and TypeScript 5 as the baseline. Use Jest for unit tests, Playwright for end-to-end tests, and Storybook for UI development. This combination provides strong typing, fast builds and a rich ecosystem of tools.
+Adopt **Vite** with React 18 and TypeScript 5 as the baseline. Use Jest for unit tests, Playwright for end-to-end tests, and Storybook for UI development. This combination provides strong typing, fast builds and a rich ecosystem of tools.
 
-While the original plan targeted Next.js 15, that version is still in prerelease and several key dependencies do not yet provide stable support. Until the ecosystem catches up, we pin the dashboard to the latest 14.x release for predictable builds and easier upgrades later.
+The switch away from Next.js reduces complexity since server-side rendering is not required for the dashboard. Vite offers faster iteration times and simpler configuration.
 
 ## Consequences
 

--- a/docs/adr/0002-dashboard-architecture.md
+++ b/docs/adr/0002-dashboard-architecture.md
@@ -12,7 +12,7 @@ The first iteration of the dashboard mixed data ingestion and UI logic in a
 single service.  As the scope grew—adding offline mode, GraphQL endpoints and
 background updates—it became clear that the project needed a clearer separation
 between data processing and presentation.  The architecture document proposes a
-dedicated FastAPI worker for GLPI integration and a Dash/Next.js front-end for
+dedicated FastAPI worker for GLPI integration and a Dash/Vite React front-end for
 visualization.
 
 ## Decision

--- a/docs/developer_usage.md
+++ b/docs/developer_usage.md
@@ -15,7 +15,7 @@ Principais módulos do projeto:
 | `src/frontend/layout/layout.py` | Layout e callbacks do dashboard em Dash |
 | `src/backend/services/worker_api.py` | Lógica de cache e métricas usadas pelo `worker.py` |
 | `shared/config/settings.py` | Carrega variáveis de ambiente (GLPI, DB, Redis) |
-| `src/frontend/react_app/` | Projeto Next.js que consome o worker API |
+| `src/frontend/react_app/` | Projeto Vite + React que consome o worker API |
 
 Os módulos da Anti-Corruption Layer residem em `src/backend/adapters`. Importe-os diretamente desse pacote. O antigo `glpi_adapter.py` foi removido durante a refatoração.
 
@@ -161,7 +161,7 @@ Isso sobe PostgreSQL, Redis, o `worker` e o dashboard em portas 8000 e 5174.
 ├── src/
 │   ├── backend/   # serviços FastAPI e integrações GLPI
 │   ├── frontend/  # layout do dashboard em Dash
-│   ├── frontend/react_app/  # projeto React/Next.js
+│   ├── frontend/react_app/  # projeto Vite + React
 │   └── shared/    # modelos e utilidades comuns
 ├── examples/      # códigos de referência e testes
 ├── tests/         # suíte pytest

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -92,7 +92,7 @@ responsible for API calls verifies that `NEXT_PUBLIC_API_BASE_URL` is defined
 
 The React code can read this value using `import.meta.env.NEXT_PUBLIC_API_BASE_URL` to send requests to the worker.
 
-> **Note**: this variable was renamed from `VITE_API_URL` to `NEXT_PUBLIC_API_BASE_URL` to match Next.js conventions. This change ensures compatibility with Next.js, which uses the `NEXT_PUBLIC_` prefix for environment variables exposed to the browser.
+> **Note**: this variable was renamed from `VITE_API_URL` to `NEXT_PUBLIC_API_BASE_URL` for compatibility with existing tooling. The Vite config loads both `VITE_` and `NEXT_PUBLIC_` prefixes via `envPrefix`, so the React app can keep using `import.meta.env.NEXT_PUBLIC_*` variables.
 
 Vite only exposes variables prefixed with `VITE_` by default. The project configures `envPrefix` in `vite.config.ts` so that `NEXT_PUBLIC_*` variables are also loaded.
 

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -4,7 +4,7 @@ Welcome to the GLPI Dashboard project. This guide helps you set up the developme
 
 ## Overview
 
-The dashboard aggregates GLPI service desk metrics using a FastAPI backend and a Next.js frontend. Postgres stores ticket data and Redis caches frequent queries.
+The dashboard aggregates GLPI service desk metrics using a FastAPI backend and a Vite-powered React frontend. Postgres stores ticket data and Redis caches frequent queries.
 
 ## Getting Started
 
@@ -48,7 +48,7 @@ The dashboard aggregates GLPI service desk metrics using a FastAPI backend and a
 ```text
 ├── src/backend/   # worker FastAPI modules
 ├── src/frontend/  # Dash components
-├── src/frontend/react_app/      # Next.js application
+├── src/frontend/react_app/      # Vite + React application
 ├── docs/          # documentation and ADRs
 ├── monitoring/    # Prometheus/Grafana config
 └── tests/         # pytest suite
@@ -66,7 +66,7 @@ flowchart TB
         Cache[(Redis)]
     end
     subgraph Frontend
-        Next[Next.js]
+        React[Vite]
     end
     API -- tickets --> DB
     API -- metrics --> Cache

--- a/docs/research_backlog.md
+++ b/docs/research_backlog.md
@@ -7,6 +7,6 @@ This document lists topics that require additional investigation to strengthen t
 - **ESM vs. CommonJS**: Gather best practices for migrating Node.js scripts to native ES Modules. Document how to use the `.cjs` extension for legacy files and how to replace `require` with `import` using `fileURLToPath` to emulate `__dirname`.
 - **Least-Privilege Database Roles**: Explore strategies for creating PostgreSQL users with minimal permissions. Document how to avoid running the application as a superuser inside Docker.
 - **Secure Docker Initialization**: Review techniques for deterministic container setup using environment variables and seed scripts. Ensure the database initializes with the correct roles and passwords.
-- **Next.js Environment Variables**: Confirm recommended prefixes (`NEXT_PUBLIC_*`) and loading order when running under Vite or Next.js. Provide guidelines for check-env scripts.
+- **Front-End Environment Variables**: Confirm recommended prefixes (`NEXT_PUBLIC_*`) and loading order when running under Vite. Provide guidelines for check-env scripts.
 
 Update this backlog as new issues arise or existing ones are resolved.

--- a/src/frontend/react_app/AGENTS.md
+++ b/src/frontend/react_app/AGENTS.md
@@ -1,8 +1,8 @@
-# frontend_agents.md — Pipeline de Agentes para o Frontend React/Next.js
+# frontend_agents.md — Pipeline de Agentes para o Frontend React/Vite
 
 > **Contexto**
 > Este arquivo expande o `AGENTS.md` original, adicionando seis agentes especializados
-> na geração, composição, validação e testes de componentes Front‑End (React/Next.js)
+> na geração, composição, validação e testes de componentes Front‑End (Vite + React)
 > do projeto **GLPI Dashboard MVP**. Todos os prompts seguem o padrão formal
 > **Identidade → Instruções → Contexto → Exemplos → Pergunta (CoT)** e usam
 > *temperature = 0* para saídas reprodutíveis.
@@ -13,7 +13,7 @@
 
 ```text
 # Identidade
-Você é um engenheiro Front‑End sênior especializado em React 18 + Next.js 14.
+Você é um engenheiro Front‑End sênior especializado em React 18 com Vite.
 
 # Instruções
 * Gere **um único** arquivo `<component>.tsx`.
@@ -66,7 +66,7 @@ Gere o `tailwind.config.ts` completo e utilitário `cn`.
 
 ```text
 # Identidade
-Você é um engenheiro Full‑Stack Next.js + tRPC.
+Você é um engenheiro Full‑Stack React + tRPC usando Vite.
 
 # Instruções
 * Gere hooks em `src/hooks/useTickets.ts`.


### PR DESCRIPTION
## Summary
- update architecture docs for Vite + React
- clarify front-end stack change in ADRs
- revise onboarding and developer docs
- tweak front-end AGENTS pipeline

## Testing
- `make lint` *(fails: F821 undefined name, mypy errors)*

------
https://chatgpt.com/codex/tasks/task_e_688474c172a483209b2fa7accdd68c40

## Resumo por Sourcery

Atualizar a documentação para refletir a migração do front-end de Next.js para uma configuração React empacotada com Vite e ajustar as convenções de variáveis de ambiente.

Documentação:
- Revisar os ADRs para recomendar Vite com React 18 e TypeScript 5 em vez de Next.js
- Atualizar os guias de integração, backup de arquitetura e uso do desenvolvedor para fazer referência a um front-end React baseado em Vite
- Ajustar a documentação do pipeline AGENTS para mencionar agentes Vite + React
- Esclarecer o tratamento de variáveis de ambiente do front-end, renomeando VITE_API_URL para NEXT_PUBLIC_API_BASE_URL e carregando prefixos via vite.config.ts
- Refinar o backlog de pesquisa para cobrir diretrizes gerais de variáveis de ambiente do front-end sob Vite

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update documentation to reflect migration of the front-end from Next.js to a Vite‐bundled React setup and adjust environment variable conventions

Documentation:
- Revise ADRs to recommend Vite with React 18 and TypeScript 5 in place of Next.js
- Update onboarding, architecture backup, and developer usage guides to reference a Vite-powered React frontend
- Adjust AGENTS pipeline documentation to mention Vite + React agents
- Clarify front-end environment variable handling by renaming VITE_API_URL to NEXT_PUBLIC_API_BASE_URL and loading prefixes via vite.config.ts
- Refine research backlog to cover general front‐end environment variable guidelines under Vite

</details>