### PR TITLE
Improve FilterPanel accessibility

### DIFF
--- a/src/frontend/react_app/src/components/FilterPanel.tsx
+++ b/src/frontend/react_app/src/components/FilterPanel.tsx
@@ -1,43 +1,20 @@
 import { type FC, useCallback, useEffect, useRef } from 'react'
 import { useFilters } from '../hooks/useFilters'
+import { useFocusTrap } from '../hooks/useFocusTrap'
 
 const FilterPanel: FC = () => {
   const { filters, toggleFilters, toggleValue } = useFilters()
 
   const panelRef = useRef<HTMLDivElement>(null)
+  const toggleRef = useRef<HTMLButtonElement>(null)
+
+  useFocusTrap(panelRef, filters.open, toggleFilters)
 
   useEffect(() => {
-    if (!filters.open || !panelRef.current) return
-
-    const focusable = panelRef.current.querySelectorAll<HTMLElement>(
-      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
-    )
-    const first = focusable[0]
-    const last = focusable[focusable.length - 1]
-    first?.focus()
-
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Tab') {
-        if (focusable.length === 0) return
-        if (e.shiftKey) {
-          if (document.activeElement === first) {
-            e.preventDefault()
-            last.focus()
-          }
-        } else if (document.activeElement === last) {
-          e.preventDefault()
-          first.focus()
-        }
-      } else if (e.key === 'Escape') {
-        toggleFilters()
-      }
+    if (!filters.open) {
+      toggleRef.current?.focus()
     }
-
-    panelElement.addEventListener('keydown', handleKeyDown)
-    return () => {
-      panelElement.removeEventListener('keydown', handleKeyDown)
-    }
-  }, [filters.open, toggleFilters])
+  }, [filters.open])
 
   const renderOptions = useCallback(
     (category: keyof Omit<typeof filters, 'open'>) => {
@@ -61,13 +38,25 @@ const FilterPanel: FC = () => {
   )
 
   return (
-    <div
-      className={`filter-panel ${filters.open ? 'open' : ''}`}
-      id="filterPanel"
-      role="dialog"
-      aria-modal="true"
-      ref={panelRef}
-    >
+    <>
+      <button
+        ref={toggleRef}
+        onClick={toggleFilters}
+        className="filter-toggle"
+        aria-controls="filterPanel"
+        aria-expanded={filters.open}
+        aria-haspopup="dialog"
+      >
+        <i className="fas fa-filter" aria-hidden="true" />
+        <span className="sr-only">Abrir filtros</span>
+      </button>
+      <div
+        className={`filter-panel ${filters.open ? 'open' : ''}`}
+        id="filterPanel"
+        role="dialog"
+        aria-modal="true"
+        ref={panelRef}
+      >
       <div className="filter-header">
         <div className="filter-title">Filtros Avançados</div>
         <button className="filter-close" onClick={toggleFilters} title='Fechar filtros'>
@@ -91,6 +80,7 @@ const FilterPanel: FC = () => {
         <div className="filter-options">{renderOptions('priority')}</div>
       </div>
     </div>
+    </>
   )
 }
 

--- a/src/frontend/react_app/src/hooks/useFocusTrap.ts
+++ b/src/frontend/react_app/src/hooks/useFocusTrap.ts
@@ -1,0 +1,44 @@
+import { useEffect } from 'react'
+
+const FOCUS_SELECTOR =
+  'a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), iframe, object, embed, [tabindex]:not([-1]), [contenteditable=true]'
+
+export function useFocusTrap(
+  ref: React.RefObject<HTMLElement>,
+  active: boolean,
+  onClose: () => void,
+) {
+  useEffect(() => {
+    if (!active || !ref.current) return
+    const root = ref.current
+    const focusable = Array.from(root.querySelectorAll<HTMLElement>(FOCUS_SELECTOR))
+    const first = focusable[0]
+    const last = focusable[focusable.length - 1]
+    const previouslyFocused = document.activeElement as HTMLElement | null
+    first?.focus()
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Tab') {
+        if (focusable.length === 0) {
+          e.preventDefault()
+          return
+        }
+        if (e.shiftKey) {
+          if (document.activeElement === first) {
+            e.preventDefault()
+            last?.focus()
+          }
+        } else if (document.activeElement === last) {
+          e.preventDefault()
+          first?.focus()
+        }
+      } else if (e.key === 'Escape') {
+        onClose()
+      }
+    }
+    document.addEventListener('keydown', handleKeyDown)
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown)
+      previouslyFocused?.focus()
+    }
+  }, [active, ref, onClose])
+}

--- a/src/frontend/react_app/tests/components/FilterPanel.test.tsx
+++ b/src/frontend/react_app/tests/components/FilterPanel.test.tsx
@@ -24,9 +24,13 @@ jest.mock('@/hooks/useFilters', () => {
   }
 })
 
-test('toggles panel visibility', () => {
+test('aria-expanded toggles and focus returns to trigger', () => {
   render(<FilterPanel />)
   const btn = screen.getByRole('button')
+  expect(btn).toHaveAttribute('aria-expanded', 'false')
   fireEvent.click(btn)
-  expect(btn).toBeInTheDocument()
+  expect(btn).toHaveAttribute('aria-expanded', 'true')
+  fireEvent.click(screen.getByLabelText('Fechar filtros'))
+  expect(btn).toHaveAttribute('aria-expanded', 'false')
+  expect(document.activeElement).toBe(btn)
 })


### PR DESCRIPTION
## Summary
- add focus trap hook
- update `FilterPanel` to trap focus and toggle `aria-expanded`
- test the new a11y behavior

## Testing
- `pre-commit run --files src/frontend/react_app/src/components/FilterPanel.tsx src/frontend/react_app/tests/components/FilterPanel.test.tsx src/frontend/react_app/src/hooks/useFocusTrap.ts`
- `npm test --prefix src/frontend/react_app` *(fails: SyntaxError: Cannot use 'import.meta' outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_688488dee2188320926b4133d1664c9e