### PR TITLE
Clean up unused file_map.json reference

### DIFF
--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -123,18 +123,18 @@ Jest and Playwright tests rely on this same URL when exercising real API calls, 
 
 ### Refactoring TypeScript imports
 
-When the front-end files were reorganised into `src/frontend/react_app`, existing TypeScript imports pointing to the old `frontend/src` paths needed adjustment. The script `scripts/refactor/update_ts_imports.js` automates this process using jscodeshift. It reads `file_map.json` to map old locations to the new `@/` alias and updates all matching `import` statements.
+When the front-end files were reorganised into `src/frontend/react_app`, existing TypeScript imports pointing to the old `frontend/src` paths needed adjustment. The script `scripts/refactor/update_ts_imports.js` automates this process using jscodeshift. It reads `scripts/refactor/file_map.json` to map old locations to the new `@/` alias and updates all matching `import` statements.
 
 Run it from the repository root after moving files:
 
 ```bash
-jscodeshift -t scripts/refactor/update_ts_imports.js <paths> --map file_map.json
+jscodeshift -t scripts/refactor/update_ts_imports.js <paths> --map scripts/refactor/file_map.json
 ```
 
 Pass one or more files or directories as `<paths>` to transform.
 
 For small moves you can also invoke the helper script `scripts/run_ts_codemod.sh`.
-It reads `file_map.json`, moves each file with `git mv` and runs the codemod
+It reads `scripts/refactor/file_map.json`, moves each file with `git mv` and runs the codemod
 `scripts/update-imports.js` with the appropriate `--oldPath` and `--newPath`
 options to update import statements automatically.
 

--- a/file_map.json
+++ b/file_map.json
@@ -1,4 +1,0 @@
-{
-    "glpi_dashboard.acl.normalization": "backend.adapters.normalization",
-    "glpi_dashboard.acl": "backend.adapters"
-}

--- a/scripts/refactor/move_files.py
+++ b/scripts/refactor/move_files.py
@@ -28,7 +28,11 @@ def git_mv(src: Path, dest: Path) -> None:
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="Move files according to a map")
-    parser.add_argument("--map", default="file_map.json", help="Mapping JSON path")
+    parser.add_argument(
+        "--map",
+        default="scripts/refactor/file_map.json",
+        help="Mapping JSON path",
+    )
     args = parser.parse_args()
 
     mapping = json.loads(Path(args.map).read_text())

--- a/scripts/refactor/update_ts_imports.js
+++ b/scripts/refactor/update_ts_imports.js
@@ -1,12 +1,12 @@
 const fs = require('fs');
 
 /**
- * Transform TypeScript import paths based on mapping from file_map.json.
- * Usage: jscodeshift -t scripts/refactor/update_ts_imports.js <paths> --map path/to/file_map.json
+ * Transform TypeScript import paths based on mapping from scripts/refactor/file_map.json.
+ * Usage: jscodeshift -t scripts/refactor/update_ts_imports.js <paths> --map scripts/refactor/file_map.json
  */
 module.exports = function transformer(fileInfo, api, options) {
   const j = api.jscodeshift;
-  const mappingPath = options.map || 'file_map.json';
+  const mappingPath = options.map || 'scripts/refactor/file_map.json';
   const raw = JSON.parse(fs.readFileSync(mappingPath, 'utf8'));
 
   const aliasMap = buildAliasMap(raw);

--- a/scripts/refactor/update_ts_imports.js
+++ b/scripts/refactor/update_ts_imports.js
@@ -6,7 +6,8 @@ const fs = require('fs');
  */
 module.exports = function transformer(fileInfo, api, options) {
   const j = api.jscodeshift;
-  const mappingPath = options.map || 'scripts/refactor/file_map.json';
+const DEFAULT_MAPPING_PATH = 'scripts/refactor/file_map.json';
+const mappingPath = options.map || DEFAULT_MAPPING_PATH;
   const raw = JSON.parse(fs.readFileSync(mappingPath, 'utf8'));
 
   const aliasMap = buildAliasMap(raw);


### PR DESCRIPTION
## Summary
- remove unused `file_map.json`
- point docs and refactor scripts at `scripts/refactor/file_map.json`

## Testing
- `pre-commit run --files docs/frontend_architecture.md scripts/refactor/move_files.py scripts/refactor/update_ts_imports.js`
- `pytest -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6884928065b4832088a9f7140c2466e0

## Resumo por Sourcery

Atualizar referências de arquivo de mapeamento para scripts/refactor/file_map.json e remover o obsoleto root file_map.json

Melhorias:
- Alterar o caminho de mapeamento padrão em move_files.py e update_ts_imports.js para scripts/refactor/file_map.json

Documentação:
- Atualizar frontend_architecture.md para referenciar scripts/refactor/file_map.json

Tarefas:
- Remover root-level file_map.json não utilizado

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update mapping file references to scripts/refactor/file_map.json and remove obsolete root file_map.json

Enhancements:
- Change default mapping path in move_files.py and update_ts_imports.js to scripts/refactor/file_map.json

Documentation:
- Update frontend_architecture.md to reference scripts/refactor/file_map.json

Chores:
- Remove unused root-level file_map.json

</details>