### PR TITLE
Add /tickets/search endpoint

### DIFF
--- a/src/shared/__init__.py
+++ b/src/shared/__init__.py
@@ -6,7 +6,7 @@ from shared.utils.resilience import (
     retry_api_call,
 )
 
-from .dto import CleanTicketDTO, TicketTranslator
+from .dto import CleanTicketDTO, TicketSearchResult, TicketTranslator
 from .models import (
     Impact,
     Priority,
@@ -21,6 +21,7 @@ __all__ = [
     "init_logging",
     "set_correlation_id",
     "CleanTicketDTO",
+    "TicketSearchResult",
     "TicketTranslator",
     "TicketStatus",
     "Priority",

--- a/src/shared/dto.py
+++ b/src/shared/dto.py
@@ -111,6 +111,14 @@ class CleanTicketDTO(BaseModel):
         return "Unknown"
 
 
+class TicketSearchResult(BaseModel):
+    """Simplified ticket info returned by the search endpoint."""
+
+    id: int
+    name: str
+    requester: Optional[str] = None
+
+
 class TicketTranslator:
     """Translate raw GLPI ticket dictionaries into :class:`CleanTicketDTO`."""
 

--- a/tests/test_worker_api.py
+++ b/tests/test_worker_api.py
@@ -105,6 +105,12 @@ def test_rest_endpoints(test_app: TestClient):
     assert tickets and "id" in tickets[0]
     assert tickets[0]["requester"] == "Alice"
 
+    resp = test_app.get("/tickets/search", params={"query": "A", "limit": 1})
+    assert resp.status_code == 200
+    results = resp.json()
+    assert results[0]["name"] == "A"
+    assert len(results) <= 1
+
     resp = test_app.get("/metrics/summary")
     assert resp.status_code == 200
     metrics = resp.json()


### PR DESCRIPTION
## Summary
- implement ticket search results class for reuse
- expose `TicketSearchResult` through shared package
- refine `/tickets/search` endpoint with limit parameter
- cover limit logic in worker API tests

## Testing
- `pre-commit run --files src/backend/api/worker_api.py src/shared/dto.py src/shared/__init__.py tests/test_worker_api.py`
- `pytest -q tests/test_worker_api.py` *(fails: multiple GLPI API errors)*

------
https://chatgpt.com/codex/tasks/task_e_6884974a51708320911f92302d56053f

## Resumo por Sourcery

Adiciona um novo endpoint de busca de tickets que realiza a correspondência de nomes sem distinção entre maiúsculas e minúsculas, retorna resultados limitados por um limite configurável e usa um DTO dedicado para consistência da resposta.

Novas Funcionalidades:
- Adiciona o endpoint `/tickets/search` para permitir a consulta de tickets por nome com um limite opcional
- Introduz o DTO `TicketSearchResult` para padronizar o payload do resultado da busca

Melhorias:
- Expõe `TicketSearchResult` na API do pacote compartilhado

Testes:
- Adiciona teste de integração para o endpoint `/tickets/search` verificando a filtragem da consulta e o comportamento do limite

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a new ticket search endpoint that performs case-insensitive name matching, returns results capped by a configurable limit, and uses a dedicated DTO for response consistency.

New Features:
- Add /tickets/search endpoint to allow querying tickets by name with an optional limit
- Introduce TicketSearchResult DTO to standardize search result payload

Enhancements:
- Expose TicketSearchResult in the shared package API

Tests:
- Add integration test for the /tickets/search endpoint verifying query filtering and limit behavior

</details>