### PR TITLE
Update API endpoint documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,8 +494,11 @@ When the FastAPI service starts it primes the Redis cache by calling
 
  - `/tickets` – full list of tickets in JSON format. The payload includes the
    ticket `priority` label and the `requester` name when available.
-- `/tickets/stream` – Server‑Sent Events (SSE) stream of progress followed by the JSON payload.
-- `/metrics` – summary with `total`, `opened` and `closed` counts.
+ - `/tickets/search` – search tickets by name. Accepts `query` and optional
+   `limit` parameters.
+ - `/tickets/stream` – Server‑Sent Events (SSE) stream of progress followed by the JSON payload.
+ - `/metrics` – summary with `total`, `opened` and `closed` counts.
+ - `/metrics/summary` – on‑demand summary built from the current cache.
 - `/metrics/aggregated` – counts grouped by status and technician, pre-computed by the worker.
 - `/chamados/por-data` – tickets per creation date, refreshed every 10 minutes.
 - `/chamados/por-dia` – totals for calendar heatmaps, refreshed every 10 minutes.

--- a/docs/developer_usage.md
+++ b/docs/developer_usage.md
@@ -75,7 +75,9 @@ Endpoints relevantes:
 
 - `/tickets` – lista completa de chamados
 - A resposta inclui os campos `priority` e `requester` em formato textual.
+- `/tickets/search` – busca tickets por nome. Recebe `query` e `limit` opcional.
 - `/metrics` – contagem de abertos/fechados
+- `/metrics/summary` – resumo calculado sob demanda a partir do cache.
 - `/graphql/` – versão GraphQL
 - `/cache/stats` – estatísticas de cache
 


### PR DESCRIPTION
## Summary
- document `/tickets/search` and `/metrics/summary` endpoints in the README
- add the same endpoints to developer usage docs

## Testing
- `pre-commit run --files README.md docs/developer_usage.md`

------
https://chatgpt.com/codex/tasks/task_e_6884a4a13a188320842e169c419be24f

## Resumo por Sourcery

Adiciona documentação para os endpoints da API `/tickets/search` e `/metrics/summary`.

Documentação:
- Documenta o endpoint `/tickets/search` com os parâmetros `query` e `limit` (opcional) tanto no README.md quanto na documentação de uso para desenvolvedores
- Documenta o endpoint `/metrics/summary` como um resumo sob demanda construído a partir do cache atual tanto no README.md quanto na documentação de uso para desenvolvedores

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add documentation for the `/tickets/search` and `/metrics/summary` API endpoints.

Documentation:
- Document `/tickets/search` endpoint with `query` and optional `limit` parameters in both README.md and developer usage docs
- Document `/metrics/summary` endpoint as an on-demand summary built from the current cache in both README.md and developer usage docs

</details>