### PR TITLE
Update docs for ticket search endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,8 +492,10 @@ When the FastAPI service starts it primes the Redis cache by calling
 
 - The service exposes several endpoints:
 
- - `/tickets` – full list of tickets in JSON format. The payload includes the
+- `/tickets` – full list of tickets in JSON format. The payload includes the
    ticket `priority` label and the `requester` name when available.
+- `/tickets/search` – returns tickets whose names contain the given query. Use
+  `?query=<term>&limit=<n>` to filter results.
 - `/tickets/stream` – Server‑Sent Events (SSE) stream of progress followed by the JSON payload.
 - `/metrics` – summary with `total`, `opened` and `closed` counts.
 - `/metrics/aggregated` – counts grouped by status and technician, pre-computed by the worker.

--- a/docs/developer_usage.md
+++ b/docs/developer_usage.md
@@ -76,6 +76,7 @@ Endpoints relevantes:
 - `/tickets` – lista completa de chamados
 - A resposta inclui os campos `priority` e `requester` em formato textual.
 - `/metrics` – contagem de abertos/fechados
+- `/tickets/search` – busca tickets pelo nome com `?query=<termo>&limit=<n>`
 - `/graphql/` – versão GraphQL
 - `/cache/stats` – estatísticas de cache
 


### PR DESCRIPTION
## Summary
- document `/tickets/search` endpoint in README and developer usage guide

## Testing
- `pytest tests/test_auth.py -k 'not get_session_token_cache' -q`


------
https://chatgpt.com/codex/tasks/task_e_6884a4a13a188320842e169c419be24f