### PR TITLE
Ensure ticket priority mapping uses Portuguese labels

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,4 +51,4 @@ lint: ## Run all linters
 
 gen-types: ## Generate TypeScript types from Pydantic models
 	@echo "🔄 Generating TypeScript types from Pydantic models..."
-	$(VENV_ACTIVATE) pydantic-to-typescript --input src/backend/models/ts_models.py --output $(FRONTEND_DIR)/src/types/api.ts
+	$(VENV_ACTIVATE) pydantic2ts --module shared.models.ts_models --output $(FRONTEND_DIR)/src/types/api.ts

--- a/src/shared/dto.py
+++ b/src/shared/dto.py
@@ -23,6 +23,7 @@ STATUS_MAP = {
 # Map textual statuses (e.g., "closed") to the same canonical labels
 TEXT_STATUS_MAP = {label.lower(): label for label in STATUS_MAP.values()}
 
+# Priority labels in English (legacy) and Portuguese used in the dashboard.
 PRIORITY_MAP = {
     1: "Very Low",
     2: "Low",
@@ -30,6 +31,15 @@ PRIORITY_MAP = {
     4: "High",
     5: "Very High",
     6: "Major",
+}
+
+PRIORITY_MAP_PT = {
+    1: "Muito Baixa",
+    2: "Baixa",
+    3: "Média",
+    4: "Alta",
+    5: "Muito Alta",
+    6: "Maior",
 }
 
 # Fallback title assigned when a ticket comes with an empty or null name
@@ -102,8 +112,11 @@ class CleanTicketDTO(BaseModel):
         if isinstance(v, str) and not v.isdigit():
             return v
         if isinstance(v, int):
-            return PRIORITY_MAP.get(v, "Unknown")
-        return PRIORITY_MAP.get(int(v), "Unknown") if str(v).isdigit() else "Unknown"
+            return PRIORITY_MAP_PT.get(v, PRIORITY_MAP.get(v, "Unknown"))
+        if str(v).isdigit():
+            num = int(v)
+            return PRIORITY_MAP_PT.get(num, PRIORITY_MAP.get(num, "Unknown"))
+        return "Unknown"
 
 
 class TicketTranslator:


### PR DESCRIPTION
## Summary
- map numeric priority values to Portuguese labels in `CleanTicketDTO`
- regenerate TypeScript types using new Makefile target
- update Makefile to use pydantic2ts for type generation

## Testing
- `pre-commit run --files src/shared/dto.py Makefile`
- `make gen-types`

------
https://chatgpt.com/codex/tasks/task_e_68873411decc83208467cc563acefb79