### PR TITLE
Enhance Dash app styles

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1,0 +1,9 @@
+/* Custom styles for Dash DataTable */
+#ticket-table .dash-header {
+    background-color: #f8f9fa;
+    font-weight: bold;
+}
+#ticket-table .dash-cell {
+    padding: 8px;
+    font-size: 14px;
+}

--- a/dashboard_app.py
+++ b/dashboard_app.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 import os
 
+import dash_bootstrap_components as dbc
 import pandas as pd
 from dash import Dash
 from flask import Flask
@@ -119,7 +120,7 @@ def create_app(df: pd.DataFrame | None) -> Dash:
     #     """Simple health check endpoint."""
     #     return "OK", 200
 
-    app = Dash(__name__, server=server)
+    app = Dash(__name__, server=server, external_stylesheets=[dbc.themes.BOOTSTRAP])
     app.layout = build_layout(df)
     if df is not None:
         register_callbacks(app, load_data)


### PR DESCRIPTION
## Summary
- load Dash Bootstrap theme in `create_app`
- add initial custom DataTable CSS

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for fakeredis)*
- `flake8` *(fails: AttributeError 'EntryPoints' object has no attribute 'get')*
- `scripts/check_merge_conflicts.py` *(fails: KeyboardInterrupt)*
- `python scripts/generate_bug_prompt.py --output bug_prompt.md` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_688742deb3a4832080c64290ddbdf724