### PR TITLE
Add levels metrics hook

### DIFF
--- a/src/frontend/react_app/src/App.test.tsx
+++ b/src/frontend/react_app/src/App.test.tsx
@@ -31,6 +31,9 @@ jest.mock('./hooks/useChamadosPorData', () => ({
 jest.mock('./hooks/useChamadosPorDia', () => ({
   useChamadosPorDia: jest.fn(),
 }))
+jest.mock('./hooks/useLevelsMetrics', () => ({
+  useLevelsMetrics: jest.fn(),
+}))
 
 jest.mock('./components/Header', () => () => <header>Header Mock</header>)
 jest.mock('./components/FilterPanel', () => () => <div>FilterPanel Mock</div>)
@@ -41,10 +44,12 @@ jest.mock('./components/SidebarToggle', () => () => <button>Toggle</button>)
 import { useTickets } from './hooks/useTickets'
 import { useChamadosPorData } from './hooks/useChamadosPorData'
 import { useChamadosPorDia } from './hooks/useChamadosPorDia'
+import { useLevelsMetrics } from './hooks/useLevelsMetrics'
 
 const useTicketsMock = useTickets as jest.Mock
 const useChamadosPorDataMock = useChamadosPorData as jest.Mock
 const useChamadosPorDiaMock = useChamadosPorDia as jest.Mock
+const useLevelsMetricsMock = useLevelsMetrics as jest.Mock
 
 const mockTickets = [
   {
@@ -65,6 +70,7 @@ describe('App Integration', () => {
     useTicketsMock.mockClear()
     useChamadosPorDataMock.mockClear()
     useChamadosPorDiaMock.mockClear()
+    useLevelsMetricsMock.mockClear()
   })
 
   it('renders loading state initially', () => {
@@ -76,6 +82,7 @@ describe('App Integration', () => {
     })
     useChamadosPorDataMock.mockReturnValue({ data: [], isLoading: true })
     useChamadosPorDiaMock.mockReturnValue({ data: [], isLoading: true })
+    useLevelsMetricsMock.mockReturnValue({ levels: [], isLoading: true })
 
     renderWithClient(<App />)
 
@@ -99,6 +106,7 @@ describe('App Integration', () => {
       data: mockChamadosPorDia,
       isLoading: false,
     })
+    useLevelsMetricsMock.mockReturnValue({ levels: [], isLoading: false })
 
     renderWithClient(<App />)
 
@@ -123,6 +131,7 @@ describe('App Integration', () => {
     })
     useChamadosPorDataMock.mockReturnValue({ data: [], isLoading: false, isError: true })
     useChamadosPorDiaMock.mockReturnValue({ data: [], isLoading: false, error: true })
+    useLevelsMetricsMock.mockReturnValue({ levels: [], isLoading: false, error: true })
 
     renderWithClient(<App />)
 

--- a/src/frontend/react_app/src/App.tsx
+++ b/src/frontend/react_app/src/App.tsx
@@ -12,6 +12,7 @@ import { SidebarProvider } from './hooks/useSidebar'
 import { NotificationProvider } from './context/notification'
 import NotificationToast from './components/NotificationToast'
 import { useHotkeys } from './hooks/useHotkeys'
+import { useLevelsMetrics } from './hooks/useLevelsMetrics'
 
 // Lazy load heavy components to split them into separate chunks.
 // This tells Vite/Rollup to create separate .js files for these components.
@@ -20,6 +21,7 @@ const ChamadosHeatmap = lazy(() => import('./components/ChamadosHeatmap'))
 
 function App() {
   useHotkeys()
+  const { levels } = useLevelsMetrics()
   return (
     <ErrorBoundary>
       <NotificationProvider>
@@ -37,7 +39,7 @@ function App() {
                 <Suspense fallback={<SkeletonHeatmap />}>
                   <ChamadosHeatmap />
                 </Suspense>
-                <LevelsPanel levels={[]} />
+                <LevelsPanel levels={levels} />
               </div>
               <Sidebar performance={[]} ranking={[]} alerts={[]} />
             </main>

--- a/src/frontend/react_app/src/hooks/__tests__/useLevelsMetrics.test.tsx
+++ b/src/frontend/react_app/src/hooks/__tests__/useLevelsMetrics.test.tsx
@@ -1,0 +1,39 @@
+import { renderHook } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { useLevelsMetrics } from '../useLevelsMetrics'
+import { useApiQuery } from '../useApiQuery'
+
+jest.mock('../useApiQuery')
+
+const createWrapper = () => {
+  const queryClient = new QueryClient()
+  return {
+    queryClient,
+    wrapper: ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    ),
+  }
+}
+
+test('maps API record to levels array', () => {
+  ;(useApiQuery as jest.Mock).mockReturnValue({
+    data: { N1: { new: 1, progress: 2, pending: 3, resolved: 4 } },
+    isLoading: false,
+    isError: false,
+    error: null,
+  })
+  const { wrapper } = createWrapper()
+  const { result } = renderHook(() => useLevelsMetrics(), { wrapper })
+  expect(result.current.levels).toEqual([
+    { name: 'N1', metrics: { new: 1, progress: 2, pending: 3, resolved: 4 } },
+  ])
+})
+
+test('refreshLevels invalidates query', () => {
+  ;(useApiQuery as jest.Mock).mockReturnValue({ data: {}, isLoading: false })
+  const { queryClient, wrapper } = createWrapper()
+  const invalidate = jest.spyOn(queryClient, 'invalidateQueries')
+  const { result } = renderHook(() => useLevelsMetrics(), { wrapper })
+  result.current.refreshLevels()
+  expect(invalidate).toHaveBeenCalledWith({ queryKey: ['levels-metrics'] })
+})

--- a/src/frontend/react_app/src/hooks/useLevelsMetrics.ts
+++ b/src/frontend/react_app/src/hooks/useLevelsMetrics.ts
@@ -1,0 +1,40 @@
+import { useCallback, useMemo } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
+import { useApiQuery } from './useApiQuery'
+
+export interface LevelMetrics {
+  new: number
+  progress: number
+  pending: number
+  resolved: number
+}
+
+export interface LevelEntry {
+  name: string
+  metrics: LevelMetrics
+}
+
+const LEVELS_QUERY_KEY = ['levels-metrics'] as const
+
+export function useLevelsMetrics() {
+  const queryClient = useQueryClient()
+  const query = useApiQuery<Record<string, LevelMetrics>>(LEVELS_QUERY_KEY, '/metrics/levels')
+
+  const levels = useMemo<LevelEntry[]>(() => {
+    if (!query.data) return []
+    return Object.entries(query.data).map(([name, metrics]) => ({ name, metrics }))
+  }, [query.data])
+
+  const refreshLevels = useCallback(
+    () => queryClient.invalidateQueries({ queryKey: LEVELS_QUERY_KEY }),
+    [queryClient],
+  )
+
+  return {
+    levels,
+    refreshLevels,
+    isLoading: query.isLoading,
+    isError: query.isError,
+    error: query.error,
+  }
+}


### PR DESCRIPTION
## Summary
- add `useLevelsMetrics` hook using `useApiQuery`
- wire the hook into `App`
- adjust App tests to mock the new hook
- include unit tests for `useLevelsMetrics`

## Testing
- `pre-commit run --files src/frontend/react_app/src/hooks/useLevelsMetrics.ts src/frontend/react_app/src/App.tsx src/frontend/react_app/src/App.test.tsx src/frontend/react_app/src/hooks/__tests__/useLevelsMetrics.test.tsx`
- `NEXT_PUBLIC_API_BASE_URL=http://localhost:8000 npm test` *(fails: SyntaxError Cannot use 'import.meta' outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_688748e5cf2c8320865a238c1482325e