### PR TITLE
Fix priority label handling

### DIFF
--- a/src/backend/adapters/mapping_service.py
+++ b/src/backend/adapters/mapping_service.py
@@ -179,7 +179,7 @@ class MappingService:
 
     def normalize_ticket(self, raw_ticket: dict[str, Any]) -> dict[str, Any]:
         raw_priority = raw_ticket.get("priority")
-        pid = int(raw_priority) if raw_priority is not None else -1
+        pid = int(raw_priority) if raw_priority is not None else MISSING_PRIORITY
         return {
             # ...
             "priority": PRIORITY_MAPPING.get(pid, "Unknown"),

--- a/src/backend/adapters/mapping_service.py
+++ b/src/backend/adapters/mapping_service.py
@@ -178,9 +178,9 @@ class MappingService:
         return result
 
     def normalize_ticket(self, raw_ticket: dict[str, Any]) -> dict[str, Any]:
+        raw_priority = raw_ticket.get("priority")
+        pid = int(raw_priority) if raw_priority is not None else -1
         return {
             # ...
-            "priority": PRIORITY_MAPPING.get(
-                int(raw_ticket.get("priority", 0)), "Unknown"
-            ),
+            "priority": PRIORITY_MAPPING.get(pid, "Unknown"),
         }

--- a/src/shared/dto.py
+++ b/src/shared/dto.py
@@ -139,7 +139,7 @@ class TicketTranslator:
             requester = await self.mapper.get_username(validated_raw.users_id_requester)
 
         priority_value = (
-            validated_raw.priority if validated_raw.priority is not None else -1
+            validated_raw.priority if validated_raw.priority is not None else MISSING_PRIORITY
         )
         priority_label = self.mapper.priority_label(priority_value)
 

--- a/src/shared/dto.py
+++ b/src/shared/dto.py
@@ -138,11 +138,10 @@ class TicketTranslator:
         if validated_raw.users_id_requester:
             requester = await self.mapper.get_username(validated_raw.users_id_requester)
 
-        priority_label = (
-            self.mapper.priority_label(validated_raw.priority)
-            if validated_raw.priority is not None
-            else None
+        priority_value = (
+            validated_raw.priority if validated_raw.priority is not None else -1
         )
+        priority_label = self.mapper.priority_label(priority_value)
 
         clean_data: Dict[str, Any] = {
             "id": validated_raw.id,


### PR DESCRIPTION
## Summary
- always resolve priority label even when missing
- guard int conversion when normalizing tickets

## Testing
- `pre-commit run --files src/shared/dto.py src/backend/adapters/mapping_service.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fakeredis')*

------
https://chatgpt.com/codex/tasks/task_e_68875a3d66c8832085f265777b4e34c8