### PR TITLE
Add missing priority handling in ticket translator

### DIFF
--- a/src/shared/dto.py
+++ b/src/shared/dto.py
@@ -138,11 +138,10 @@ class TicketTranslator:
         if validated_raw.users_id_requester:
             requester = await self.mapper.get_username(validated_raw.users_id_requester)
 
-        priority_label = (
-            self.mapper.priority_label(validated_raw.priority)
-            if validated_raw.priority is not None
-            else None
+        priority_value = (
+            validated_raw.priority if validated_raw.priority is not None else -1
         )
+        priority_label = self.mapper.priority_label(priority_value)
 
         clean_data: Dict[str, Any] = {
             "id": validated_raw.id,

--- a/tests/test_ticket_translator.py
+++ b/tests/test_ticket_translator.py
@@ -80,3 +80,23 @@ async def test_translate_ticket_uses_priority_label(mocker):
     assert ticket.priority == "Alta"
     assert ticket.requester == "Bob"
     mapper.get_username.assert_awaited_once_with(7)
+
+
+@pytest.mark.asyncio
+async def test_translate_ticket_missing_priority_defaults_unknown(mocker):
+    mapper = mocker.Mock(spec=MappingService)
+    mapper.get_username = mocker.AsyncMock(return_value="Bob")
+    mapper.priority_label = mocker.Mock(return_value="Unknown")
+
+    translator = TicketTranslator(mapper)
+    raw = {
+        "id": 4,
+        "name": "No priority",
+        "status": 1,
+        "date_creation": "2024-01-04T00:00:00",
+    }
+
+    ticket = await translator.translate_ticket(raw)
+
+    mapper.priority_label.assert_called_once_with(-1)
+    assert ticket.priority == "Unknown"


### PR DESCRIPTION
## Summary
- handle missing priority by mapping service with default -1
- add test for missing priority

## Testing
- `pre-commit` *(from git commit)*
- `pytest -q` *(failed: environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_68875a4272e083208b27bcf08bac8e11