### PR TITLE
Handle unknown priority without mapping lookup

### DIFF
--- a/src/shared/dto.py
+++ b/src/shared/dto.py
@@ -7,6 +7,11 @@ from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
+try:  # Avoid runtime import cycle during initialization
+    from backend.adapters.mapping_service import MISSING_PRIORITY
+except Exception:  # pragma: no cover - fallback if import fails
+    MISSING_PRIORITY = -1
+
 if TYPE_CHECKING:  # Avoid runtime import cycle
     from backend.adapters.mapping_service import MappingService
 
@@ -138,10 +143,10 @@ class TicketTranslator:
         if validated_raw.users_id_requester:
             requester = await self.mapper.get_username(validated_raw.users_id_requester)
 
-        priority_value = (
-            validated_raw.priority if validated_raw.priority is not None else MISSING_PRIORITY
-        )
-        priority_label = self.mapper.priority_label(priority_value)
+        if validated_raw.priority is not None:
+            priority_label = self.mapper.priority_label(validated_raw.priority)
+        else:
+            priority_label = "Unknown"
 
         clean_data: Dict[str, Any] = {
             "id": validated_raw.id,

--- a/src/shared/dto.py
+++ b/src/shared/dto.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator, model_valida
 
 try:  # Avoid runtime import cycle during initialization
     from backend.adapters.mapping_service import MISSING_PRIORITY
-except Exception:  # pragma: no cover - fallback if import fails
+except (ImportError, ModuleNotFoundError):  # pragma: no cover - fallback if import fails
     MISSING_PRIORITY = -1
 
 if TYPE_CHECKING:  # Avoid runtime import cycle


### PR DESCRIPTION
## Summary
- ensure dto imports `MISSING_PRIORITY`
- avoid calling `priority_label` when priority is missing
- keep fallback label as `"Unknown"`

## Testing
- `pytest tests/test_ticket_translator.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6887d4c6be50832091d576ca6f207b15