### PR TITLE
Update ticket priority default

### DIFF
--- a/src/backend/domain/ticket_models.py
+++ b/src/backend/domain/ticket_models.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime
-from typing import Any, Optional, Type, TypeVar
+from typing import Any, Type, TypeVar
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
@@ -60,7 +60,10 @@ class CleanTicketDTO(BaseModel):
     )
     content: str | None = Field(None, description="Detailed description")
     status: TicketStatus = Field(TicketStatus.UNKNOWN, description="Status")
-    priority: Optional[str] = Field(None, description="Prioridade do ticket")
+    priority: str = Field(
+        "Unknown",
+        description="Prioridade do ticket",
+    )
     urgency: Urgency = Field(Urgency.UNKNOWN, description="Urgency")
     impact: Impact = Field(Impact.UNKNOWN, description="Impact")
     type: TicketType = Field(TicketType.UNKNOWN, description="Ticket type")

--- a/src/frontend/react_app/src/types/api.ts
+++ b/src/frontend/react_app/src/types/api.ts
@@ -42,7 +42,7 @@ export interface CleanTicketDTO {
   /**
    * Priority
    */
-  priority?: string | null;
+  priority?: string;
   urgency?: Urgency;
   impact?: Impact;
   type?: TicketType;

--- a/src/shared/dto.py
+++ b/src/shared/dto.py
@@ -7,6 +7,8 @@ from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
+from backend.adapters.mapping_service import MISSING_PRIORITY
+
 if TYPE_CHECKING:  # Avoid runtime import cycle
     from backend.adapters.mapping_service import MappingService
 
@@ -139,7 +141,9 @@ class TicketTranslator:
             requester = await self.mapper.get_username(validated_raw.users_id_requester)
 
         priority_value = (
-            validated_raw.priority if validated_raw.priority is not None else MISSING_PRIORITY
+            validated_raw.priority
+            if validated_raw.priority is not None
+            else MISSING_PRIORITY
         )
         priority_label = self.mapper.priority_label(priority_value)
 

--- a/src/shared/models/ts_models.py
+++ b/src/shared/models/ts_models.py
@@ -21,7 +21,10 @@ class CleanTicketDTO(BaseModel):
     name: str = Field("", description="Short summary")
     content: str | None = Field(None, description="Detailed description")
     status: TicketStatus = Field(TicketStatus.UNKNOWN, description="Status")
-    priority: str | None = Field(None, description="Priority")
+    priority: str = Field(
+        "Unknown",
+        description="Priority",
+    )
     urgency: Urgency = Field(Urgency.UNKNOWN, description="Urgency")
     impact: Impact = Field(Impact.UNKNOWN, description="Impact")
     type: TicketType = Field(TicketType.UNKNOWN, description="Ticket type")


### PR DESCRIPTION
## Summary
- ensure CleanTicketDTO returns `'Unknown'` when priority is missing
- synchronize TS models and regenerate `api.ts`
- fix MISSING_PRIORITY import

## Testing
- `pre-commit run --files src/backend/domain/ticket_models.py src/shared/models/ts_models.py src/frontend/react_app/src/types/api.ts src/shared/dto.py`
- `pytest -c /dev/null` *(fails: ModuleNotFoundError for many dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6887d4c6d2648320a0e149516e0e888c