### PR TITLE
Add level metrics API endpoint

### DIFF
--- a/app/api/metrics.py
+++ b/app/api/metrics.py
@@ -182,3 +182,15 @@ async def metrics_overview() -> MetricsOverview:
         raise HTTPException(
             status_code=500, detail="Failed to compute metrics"
         ) from exc
+
+
+@router.get("/metrics/level/{level}", response_model=LevelMetrics)
+async def metrics_by_level(level: str) -> LevelMetrics:
+    """Return metrics for a specific support level."""
+    try:
+        return await compute_level_metrics(level)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.exception("Error computing metrics for level %s", level)
+        raise HTTPException(
+            status_code=500, detail="Failed to compute level metrics"
+        ) from exc

--- a/app/api/metrics.py
+++ b/app/api/metrics.py
@@ -187,6 +187,11 @@ async def metrics_overview() -> MetricsOverview:
 @router.get("/metrics/level/{level}", response_model=LevelMetrics)
 async def metrics_by_level(level: str) -> LevelMetrics:
     """Return metrics for a specific support level."""
+    VALID_LEVELS = {"level1", "level2", "level3"}  # Define valid levels
+    if level not in VALID_LEVELS:
+        raise HTTPException(
+            status_code=400, detail=f"Invalid level: {level}. Valid levels are: {', '.join(VALID_LEVELS)}"
+        )
     try:
         return await compute_level_metrics(level)
     except Exception as exc:  # pragma: no cover - defensive

--- a/app/api/metrics.py
+++ b/app/api/metrics.py
@@ -185,7 +185,7 @@ async def metrics_overview() -> MetricsOverview:
 
 
 @router.get("/metrics/level/{level}", response_model=LevelMetrics)
-async def metrics_by_level(level: str) -> LevelMetrics:
+async def metrics_by_level(level: str = Path(..., min_length=1, max_length=50, regex="^[A-Z0-9]+$")) -> LevelMetrics:
     """Return metrics for a specific support level."""
     VALID_LEVELS = {"level1", "level2", "level3"}  # Define valid levels
     if level not in VALID_LEVELS:


### PR DESCRIPTION
## Summary
- add `/metrics/level/{level}` route for per-level metrics

## Testing
- `pre-commit run --files app/api/metrics.py`
- `pytest -k test_level_endpoint tests/test_metrics_api.py --no-cov` *(fails: KeyboardInterrupt and missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_6887de52c084832092315fd43e24b543

## Resumo por Sourcery

Novas Funcionalidades:
- Adiciona o endpoint GET /metrics/level/{level} para expor métricas por nível

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Add GET /metrics/level/{level} endpoint to expose per-level metrics

</details>