### PR TITLE
Fix metrics overview mapping

### DIFF
--- a/src/frontend/react_app/src/components/__tests__/Dashboard.test.tsx
+++ b/src/frontend/react_app/src/components/__tests__/Dashboard.test.tsx
@@ -43,6 +43,8 @@ describe('Dashboard component', () => {
     expect(screen.getByTestId('card-N1')).toBeInTheDocument()
     expect(screen.getByText('Abertos: 5')).toBeInTheDocument()
     expect(screen.getByText('Fechados: 2')).toBeInTheDocument()
+    const cards = screen.getAllByTestId(/card-/)
+    expect(cards).toHaveLength(Object.keys(mockMetrics).length)
   })
 
   it('shows error message on failure', () => {

--- a/src/frontend/react_app/src/hooks/__tests__/useMetricsOverview.test.tsx
+++ b/src/frontend/react_app/src/hooks/__tests__/useMetricsOverview.test.tsx
@@ -1,0 +1,46 @@
+import { renderHook } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { useMetricsOverview } from '../useMetricsOverview'
+import { useApiQuery } from '../useApiQuery'
+
+jest.mock('../useApiQuery')
+
+const createWrapper = () => {
+  const queryClient = new QueryClient()
+  return {
+    queryClient,
+    wrapper: ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    ),
+  }
+}
+
+test('builds metrics from API data', () => {
+  ;(useApiQuery as jest.Mock).mockReturnValue({
+    data: {
+      open_tickets: { N1: 5, N2: 2 },
+      tickets_closed_this_month: { N1: 1, N2: 0 },
+    },
+    isLoading: false,
+    isError: false,
+    error: null,
+  })
+  const { wrapper } = createWrapper()
+  const { result } = renderHook(() => useMetricsOverview(), { wrapper })
+  expect(result.current.metrics).toEqual({
+    N1: { open: 5, closed: 1 },
+    N2: { open: 2, closed: 0 },
+  })
+})
+
+test('refreshMetrics invalidates query', () => {
+  ;(useApiQuery as jest.Mock).mockReturnValue({
+    data: { open_tickets: {}, tickets_closed_this_month: {} },
+    isLoading: false,
+  })
+  const { queryClient, wrapper } = createWrapper()
+  const invalidate = jest.spyOn(queryClient, 'invalidateQueries')
+  const { result } = renderHook(() => useMetricsOverview(), { wrapper })
+  result.current.refreshMetrics()
+  expect(invalidate).toHaveBeenCalledWith({ queryKey: ['metrics-overview'] })
+})

--- a/src/frontend/react_app/src/hooks/useMetricsOverview.ts
+++ b/src/frontend/react_app/src/hooks/useMetricsOverview.ts
@@ -26,13 +26,16 @@ export function useMetricsOverview() {
 
   const metrics = useMemo(() => {
     if (!query.data) return undefined
-    return Object.keys(query.data.open_tickets).reduce((acc, level) => {
+    const openLevels = Object.keys(query.data.open_tickets);
+    const closedLevels = Object.keys(query.data.tickets_closed_this_month);
+    const allLevels = Array.from(new Set([...openLevels, ...closedLevels]));
+    return allLevels.reduce((acc, level) => {
       acc[level] = {
         open: query.data.open_tickets[level] ?? 0,
         closed: query.data.tickets_closed_this_month[level] ?? 0,
-      }
-      return acc
-    }, {} as MetricsOverview)
+      };
+      return acc;
+    }, {} as MetricsOverview);
   }, [query.data])
 
   const refreshMetrics = useCallback(


### PR DESCRIPTION
## Summary
- build metrics object from open_tickets keys
- verify dashboard shows card per level
- add unit tests for useMetricsOverview

## Testing
- `pre-commit run --files src/frontend/react_app/src/hooks/useMetricsOverview.ts src/frontend/react_app/src/components/__tests__/Dashboard.test.tsx src/frontend/react_app/src/hooks/__tests__/useMetricsOverview.test.tsx`
- `cd src/frontend/react_app && NEXT_PUBLIC_API_BASE_URL=http://localhost npx jest src/hooks/__tests__/useMetricsOverview.test.tsx --runInBand` *(fails: SyntaxError Cannot use 'import.meta' outside a module)*
- `pytest -k Dashboard` *(fails: ModuleNotFoundError: No module named 'libcst')*

------
https://chatgpt.com/codex/tasks/task_e_68881c471af4832094b3b579e56a97e5

## Resumo por Sourcery

Corrige o hook de visão geral de métricas para construir métricas a partir do formato de resposta da API atualizado e melhorar a cobertura de testes.

Correções de Bugs:
- Corrige o mapeamento da visão geral de métricas para iterar sobre as chaves `open_tickets` e definir valores ausentes como zero por padrão

Melhorias:
- Atualiza o hook `useMetricsOverview` para usar registros separados de `open_tickets` e `tickets_closed_this_month` em vez de objetos de entrada por nível

Testes:
- Adiciona testes unitários para `useMetricsOverview` para verificar a construção de métricas e a invalidação de consultas
- Aprimora o teste do componente `Dashboard` para afirmar que um cartão é renderizado para cada nível de métricas

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix the metrics overview hook to build metrics from the updated API response shape and improve test coverage.

Bug Fixes:
- Correct metrics overview mapping to iterate over open_tickets keys and default missing values to zero

Enhancements:
- Update useMetricsOverview hook to use separate open_tickets and tickets_closed_this_month records instead of per-level entry objects

Tests:
- Add unit tests for useMetricsOverview to verify metrics construction and query invalidation
- Enhance Dashboard component test to assert that a card is rendered for each metrics level

</details>