### PR TITLE
Add metrics levels test

### DIFF
--- a/tests/test_worker_api.py
+++ b/tests/test_worker_api.py
@@ -467,15 +467,30 @@ def test_metrics_aggregated_cache(dummy_cache: DummyCache):
     "cache_data, expected_status, expected_response",
     [
         # Test case for cache hit
-        ({"metrics_levels": {"N1": {"new": 1, "pending": 0, "solved": 2}}}, 200, {"N1": {"new": 1, "pending": 0, "solved": 2}}),
+        (
+            {"metrics_levels": {"N1": {"new": 1, "pending": 0, "solved": 2}}},
+            200,
+            {"N1": {"new": 1, "pending": 0, "solved": 2}},
+        ),
         # Test case for cache miss
         ({}, 503, {"detail": "metrics not available"}),
     ],
 )
-def test_metrics_levels_endpoint(dummy_cache: DummyCache, cache_data, expected_status, expected_response) -> None:
+def test_metrics_levels_endpoint(
+    dummy_cache: DummyCache, cache_data, expected_status, expected_response
+) -> None:
     """Return cached status counts grouped by ticket level."""
     dummy_cache.data = cache_data
     client = TestClient(create_app(client=FakeClient(), cache=dummy_cache))
     resp = client.get("/metrics/levels")
     assert resp.status_code == expected_status
     assert resp.json() == expected_response
+
+
+def test_metrics_levels(dummy_cache: DummyCache) -> None:
+    """Return cached status counts grouped by ticket level."""
+    dummy_cache.data["metrics_levels"] = {"N1": {"new": 1, "pending": 2, "solved": 0}}
+    client = TestClient(create_app(client=FakeClient(), cache=dummy_cache))
+    resp = client.get("/metrics/levels")
+    assert resp.status_code == 200
+    assert resp.json() == {"N1": {"new": 1, "pending": 2, "solved": 0}}


### PR DESCRIPTION
## Summary
- test `/metrics/levels` endpoint when cache is primed

## Testing
- `pytest -c /dev/null tests/test_worker_api.py::test_metrics_levels -q`

------
https://chatgpt.com/codex/tasks/task_e_688825a5b0448320b007a5ac8c233362

## Resumo por Sourcery

Estender e aprimorar os testes para o endpoint /metrics/levels.

Testes:
- Adiciona um novo teste (test_metrics_levels) para verificar se o endpoint /metrics/levels retorna dados corretos quando o cache está populado
- Reformatar a assinatura de test_metrics_levels_endpoint para melhor legibilidade

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Extend and tidy up tests for the /metrics/levels endpoint.

Tests:
- Add a new test (test_metrics_levels) to verify the /metrics/levels endpoint returns correct data when the cache is primed
- Reformat the signature of test_metrics_levels_endpoint for improved readability

</details>