### PR TITLE
Add levels metrics hook

### DIFF
--- a/src/frontend/react_app/src/components/LevelsPanel.tsx
+++ b/src/frontend/react_app/src/components/LevelsPanel.tsx
@@ -1,6 +1,6 @@
 import { memo, type FC, useCallback } from 'react'
 import { useModal } from '../hooks/useModal'
-import { useMetricsLevels } from '../hooks/useMetricsLevels'
+import { useLevelsMetrics } from '../hooks/useLevelsMetrics'
 
 export interface LevelData {
   name: string
@@ -8,7 +8,7 @@ export interface LevelData {
 }
 
 const LevelsPanelComponent: FC = () => {
-  const { levels, isLoading, isError } = useMetricsLevels()
+  const { levels, isLoading, isError } = useLevelsMetrics()
   const { openModal, modalElement } = useModal()
 
   const showDetails = useCallback(

--- a/src/frontend/react_app/src/hooks/useLevelsMetrics.ts
+++ b/src/frontend/react_app/src/hooks/useLevelsMetrics.ts
@@ -27,5 +27,6 @@ export function useLevelsMetrics() {
     levels,
     isLoading: query.isLoading,
     isError: query.isError,
+    error: query.error,
   }
 }

--- a/src/frontend/react_app/src/hooks/useLevelsMetrics.ts
+++ b/src/frontend/react_app/src/hooks/useLevelsMetrics.ts
@@ -1,5 +1,4 @@
-import { useCallback, useMemo } from 'react'
-import { useQueryClient } from '@tanstack/react-query'
+import { useMemo } from 'react'
 import { useApiQuery } from './useApiQuery'
 
 export interface LevelMetrics {
@@ -17,7 +16,6 @@ export interface LevelEntry {
 const LEVELS_QUERY_KEY = ['levels-metrics'] as const
 
 export function useLevelsMetrics() {
-  const queryClient = useQueryClient()
   const query = useApiQuery<Record<string, LevelMetrics>>(LEVELS_QUERY_KEY, '/metrics/levels')
 
   const levels = useMemo<LevelEntry[]>(() => {
@@ -25,16 +23,9 @@ export function useLevelsMetrics() {
     return Object.entries(query.data).map(([name, metrics]) => ({ name, metrics }))
   }, [query.data])
 
-  const refreshLevels = useCallback(
-    () => queryClient.invalidateQueries({ queryKey: LEVELS_QUERY_KEY }),
-    [queryClient],
-  )
-
   return {
     levels,
-    refreshLevels,
     isLoading: query.isLoading,
     isError: query.isError,
-    error: query.error,
   }
 }

--- a/src/frontend/react_app/tests/hooks/useLevelsMetrics.test.tsx
+++ b/src/frontend/react_app/tests/hooks/useLevelsMetrics.test.tsx
@@ -1,0 +1,30 @@
+import { renderHook } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { useLevelsMetrics } from '@/hooks/useLevelsMetrics'
+import { useApiQuery } from '@/hooks/useApiQuery'
+
+jest.mock('@/hooks/useApiQuery')
+
+const createWrapper = () => {
+  const queryClient = new QueryClient()
+  return {
+    queryClient,
+    wrapper: ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    ),
+  }
+}
+
+test('maps API record to levels array', () => {
+  ;(useApiQuery as jest.Mock).mockReturnValue({
+    data: { N1: { new: 1, progress: 2, pending: 3, resolved: 4 } },
+    isLoading: false,
+    isError: false,
+    error: null,
+  })
+  const { wrapper } = createWrapper()
+  const { result } = renderHook(() => useLevelsMetrics(), { wrapper })
+  expect(result.current.levels).toEqual([
+    { name: 'N1', metrics: { new: 1, progress: 2, pending: 3, resolved: 4 } },
+  ])
+})


### PR DESCRIPTION
## Summary
- implement `useLevelsMetrics` hook
- update `LevelsPanel` to consume new hook
- add hook unit test under `tests/hooks`

## Testing
- `npm test -- tests/hooks/useLevelsMetrics.test.tsx` *(fails: Cannot use 'import.meta' outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_688825a656688320b6d70c8f49e3b363

## Resumo pelo Sourcery

Implementa o hook `useLevelsMetrics` para buscar e mapear métricas de nível, integra-o no `LevelsPanel` e adiciona um teste unitário para o novo hook

Novas Funcionalidades:
- Adiciona o hook `useLevelsMetrics` para recuperar e transformar métricas de nível

Melhorias:
- Atualiza o `LevelsPanel` para usar o novo hook e remove as propriedades não utilizadas `refreshLevels` e `error`

Testes:
- Adiciona teste unitário para `useLevelsMetrics` para verificar o mapeamento correto dos dados da API para o array `levels`

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement useLevelsMetrics hook to fetch and map level metrics, integrate it into LevelsPanel, and add a unit test for the new hook

New Features:
- Add useLevelsMetrics hook to retrieve and transform level metrics

Enhancements:
- Update LevelsPanel to use the new hook and remove unused refreshLevels and error properties

Tests:
- Add unit test for useLevelsMetrics to verify correct mapping of API data to levels array

</details>