### PR TITLE
Fix slug generation for LevelsPanel buttons

### DIFF
--- a/src/frontend/react_app/src/components/LevelsPanel.tsx
+++ b/src/frontend/react_app/src/components/LevelsPanel.tsx
@@ -45,9 +45,7 @@ const LevelsPanelComponent: FC = () => {
         {levels?.map((level) => (
           <button
             key={level.name}
-            className={`level-card ${level.name
-              .toLowerCase()
-              .replace(/\s+/g, '-')}`}
+            className={`level-card ${slugify(level.name)}`}
             onClick={() => showDetails(level)}
             role="button"
             aria-label={`View details for ${level.name}`}

--- a/src/frontend/react_app/src/components/LevelsPanel.tsx
+++ b/src/frontend/react_app/src/components/LevelsPanel.tsx
@@ -45,7 +45,9 @@ const LevelsPanelComponent: FC = () => {
         {levels?.map((level) => (
           <button
             key={level.name}
-            className={`level-card ${level.name.toLowerCase()}`}
+            className={`level-card ${level.name
+              .toLowerCase()
+              .replace(/\s+/g, '-')}`}
             onClick={() => showDetails(level)}
             role="button"
             aria-label={`View details for ${level.name}`}


### PR DESCRIPTION
## Summary
- slugify level names in class generation in `LevelsPanel`

## Testing
- `NODE_ENV=test make test-frontend` *(fails: Cannot use 'import.meta' outside a module)*
- `make test-backend` *(fails: TypeError in SQLAlchemy)*

------
https://chatgpt.com/codex/tasks/task_e_688825a6e444832087e4172d14bad260

## Resumo por Sourcery

Correções de Bugs:
- Substituir espaços por hífens nos slugs das classes de nomes de nível para gerar classes CSS válidas

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Replace spaces with hyphens in level name class slugs to generate valid CSS classes

</details>