### PR TITLE
Fix jest ESM config and dynamic import-meta

### DIFF
--- a/src/frontend/react_app/jest.config.ts
+++ b/src/frontend/react_app/jest.config.ts
@@ -1,13 +1,25 @@
 import type { Config } from 'jest'
 
+// Jest requires additional configuration to handle ES modules produced by
+// ts-jest.  Without this, constructs like `import.meta` fail to parse during
+// tests.  Enabling the `default-esm` preset and `useESM` option allows ts-jest
+// to output native ESM which Node can execute.
+
 const config: Config = {
+  preset: 'ts-jest/presets/default-esm',
+  extensionsToTreatAsEsm: ['.ts', '.tsx'],
   coverageProvider: 'v8',
   testEnvironment: 'jsdom',
   transform: {
     '^.+\\.(ts|tsx)$': [
       'ts-jest',
-      { tsconfig: 'tsconfig.test.json' },
+      { tsconfig: 'tsconfig.test.json', useESM: true },
     ],
+  },
+  globals: {
+    'ts-jest': {
+      useESM: true,
+    },
   },
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
   testMatch: [

--- a/src/frontend/react_app/src/hooks/useApiQuery.ts
+++ b/src/frontend/react_app/src/hooks/useApiQuery.ts
@@ -28,10 +28,18 @@ export function useApiQuery<T, E = Error>(
   endpoint: string,
   options?: Omit<UseQueryOptions<T, E, T, QueryKey>, 'queryKey' | 'queryFn'>,
 ): UseQueryResult<T, E> {
-  const metaEnv: Record<string, string | undefined> | undefined =
-    typeof import.meta !== 'undefined' && import.meta.env
-      ? import.meta.env
-      : undefined;
+  // Access `import.meta.env` dynamically to avoid syntax errors in environments
+  // that do not support the `import.meta` construct (e.g. Jest running in CJS
+  // mode).  When executed in such environments the `eval` call will throw and
+  // we gracefully fall back to `process.env`.
+  const metaEnv: Record<string, string | undefined> | undefined = (() => {
+    try {
+      // eslint-disable-next-line no-eval
+      return (0, eval)('import.meta.env') as Record<string, string | undefined>;
+    } catch {
+      return undefined;
+    }
+  })();
 
   const baseUrl =
     metaEnv?.NEXT_PUBLIC_API_BASE_URL ??


### PR DESCRIPTION
## Summary
- update Jest config to handle ESM
- avoid direct `import.meta` usage in API hook

## Testing
- `pre-commit run --files src/frontend/react_app/jest.config.ts src/frontend/react_app/src/hooks/useApiQuery.ts`
- `cd src/frontend/react_app && NEXT_PUBLIC_API_BASE_URL=http://localhost npx jest src/hooks/__tests__/useMetricsOverview.test.tsx --runInBand`
- `pytest tests/integration/test_dashboard.py -vv`

------
https://chatgpt.com/codex/tasks/task_e_688823cff9e8832098759ad2160c0025

## Resumo por Sourcery

Corrigir o suporte a ESM no Jest e evitar erros de sintaxe de `import.meta` no hook `useApiQuery` durante os testes.

Correções de Bug:
- Atualizar `jest.config.ts` para habilitar o suporte a ESM através dos flags `ts-jest default-esm preset`, `extensionsToTreatAsEsm` e `useESM`.
- Refatorar `useApiQuery` para avaliar dinamicamente `import.meta.env` via `eval` com fallback para `process.env` para evitar erros de sintaxe em ambientes CJS.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix ESM support in Jest and prevent import.meta syntax errors in the useApiQuery hook during tests.

Bug Fixes:
- Update jest.config.ts to enable ESM support via ts-jest default-esm preset, extensionsToTreatAsEsm, and useESM flags.
- Refactor useApiQuery to dynamically evaluate import.meta.env via eval with fallback to process.env to avoid syntax errors in CJS environments.

</details>