### PR TITLE
Update metrics API test

### DIFF
--- a/tests/test_metrics_api.py
+++ b/tests/test_metrics_api.py
@@ -131,7 +131,7 @@ def test_overview_endpoint(test_client, monkeypatch):
     assert resp.status_code == 200
     data = resp.json()
     assert data["open_tickets"] == {"N1": 1, "N2": 1}
-    assert data["created_and_resolved_this_month"] == {"N1": 1, "N2": 1}
+    assert data["tickets_closed_this_month"] == {"N1": 1, "N2": 1}
     assert data["status_distribution"] == {"new": 1, "closed": 2, "pending": 1}
     # call again should hit cache
     resp = client.get("/metrics/overview")


### PR DESCRIPTION
## Summary
- align overview metrics test with updated field name

## Testing
- `pre-commit run --files tests/test_metrics_api.py`
- `pytest tests/test_metrics_api.py::test_level_endpoint --no-cov -vv -s` *(fails: ModuleNotFoundError: No module named 'fakeredis')*

------
https://chatgpt.com/codex/tasks/task_e_6888208251c88320aa6254a8ce2baebe

## Resumo por Sourcery

Testes:
- Atualizar o teste da API de métricas de visão geral para verificar `tickets_closed_this_month` em vez de `created_and_resolved_this_month`

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Tests:
- Update overview metrics API test to assert tickets_closed_this_month instead of created_and_resolved_this_month

</details>