### PR TITLE
docs: trust mise after cloning

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,9 +141,10 @@ This starts PostgreSQL, Redis, the FastAPI worker and the Dash app. Access the d
 - Node.js >=20.19.0 is required to run the React frontend locally. The required
   version is stored in the `.nvmrc` file at the repository root. This version is
   picked up automatically by [mise](https://github.com/jdx/mise) thanks to the
-  `.mise.toml` configuration, so no manual settings are needed. Run `mise trust`
-  after cloning to silence the untrusted file warning, then install the same
-  version with [nvm](https://github.com/nvm-sh/nvm) if you prefer:
+This version is picked up automatically by [mise](https://github.com/jdx/mise) thanks to the
+  `.mise.toml` configuration. If you use `mise`, run `mise trust` once after cloning to trust the project's configuration.
+
+Alternatively, if you prefer to use [nvm](https://github.com/nvm-sh/nvm), you can install the version with:
 
   ```bash
   nvm install

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ manual steps in [docs/run_local.md](docs/run_local.md).
 ```bash
 bash scripts/setup/setup_env.sh
 ```
+Run `mise trust` once after cloning to silence warnings about the `.mise.toml`
+configuration.
 
 If a `wheels/` directory is available run the script with `OFFLINE_INSTALL=true`
 to avoid contacting PyPI:
@@ -139,7 +141,8 @@ This starts PostgreSQL, Redis, the FastAPI worker and the Dash app. Access the d
 - Node.js >=20.19.0 is required to run the React frontend locally. The required
   version is stored in the `.nvmrc` file at the repository root. This version is
   picked up automatically by [mise](https://github.com/jdx/mise) thanks to the
-  `.mise.toml` configuration, so no manual settings are needed. Install the same
+  `.mise.toml` configuration, so no manual settings are needed. Run `mise trust`
+  after cloning to silence the untrusted file warning, then install the same
   version with [nvm](https://github.com/nvm-sh/nvm) if you prefer:
 
   ```bash

--- a/docs/install_quickstart.md
+++ b/docs/install_quickstart.md
@@ -15,6 +15,8 @@ This document condenses the main steps from the README to get the dashboard runn
 ```bash
   bash scripts/setup/setup_env.sh
 ```
+Run `mise trust` once after cloning to silence warnings about the `.mise.toml`
+configuration.
   This command creates the `.venv` directory, installs packages from
   `requirements.txt` and the dev dependencies defined in `pyproject.toml`
   (compiled into `requirements-dev.txt`), and sets up `pre-commit`.
@@ -85,6 +87,7 @@ npm install         # installs dotenv, @eslint/js and other dev dependencies
 npm run dev
 npm run storybook   # optional: preview UI components locally
 ```
+Run `mise trust` once to silence the untrusted `.mise.toml` warning.
 The exact Node version is pinned in `.nvmrc` at the repository root.
 Docker Compose automatically loads `.env` when present.
 Docker can be used if you cannot install the required Node version.

--- a/docs/install_quickstart.md
+++ b/docs/install_quickstart.md
@@ -87,8 +87,7 @@ npm install         # installs dotenv, @eslint/js and other dev dependencies
 npm run dev
 npm run storybook   # optional: preview UI components locally
 ```
-Run `mise trust` once to silence the untrusted `.mise.toml` warning.
-The exact Node version is pinned in `.nvmrc` at the repository root.
+The exact Node version is pinned in `.nvmrc` at the repository root. If you use `mise`, it will be picked up automatically; run `mise trust` once to silence the untrusted `.mise.toml` warning.
 Docker Compose automatically loads `.env` when present.
 Docker can be used if you cannot install the required Node version.
 


### PR DESCRIPTION
## Summary
- mention `mise trust` near Python and Node setup steps in the docs

## Testing
- `python scripts/generate_bug_prompt.py --output bug_prompt.md`

------
https://chatgpt.com/codex/tasks/task_e_68883ddaed5083209b6ae207d04da2fc

## Resumo por Sourcery

Documentação:
- Mencionar a execução de `mise trust` uma vez após clonar para silenciar avisos de `.mise.toml` não confiáveis no README e nos documentos de início rápido de instalação

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Mention running `mise trust` once after cloning to silence untrusted `.mise.toml` warnings in the README and install quickstart docs

</details>