### PR TITLE
Add GLPI ticket counts by level

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,12 @@ Query a list of fields for a GLPI item:
 python -m glpi_tools list-fields Ticket
 ```
 
+Count ticket statuses for multiple levels:
+
+```bash
+python -m glpi_tools count-by-level N1 N2
+```
+
 ### Generating components and modules
 
 Use [Plop](https://plopjs.com) to scaffold new React components or Dash modules.

--- a/docs/developer_usage.md
+++ b/docs/developer_usage.md
@@ -85,6 +85,12 @@ Endpoints relevantes:
 - `/graphql/` – versão GraphQL
 - `/cache/stats` – estatísticas de cache
 
+Utilize o CLI para consultar esses números diretamente pela API:
+
+```bash
+python -m glpi_tools count-by-level N1 N2
+```
+
 O comando `load_tickets()` executado na inicialização preenche os
 redis-keys `metrics_aggregated`, `metrics_levels` e `metrics:overview`
 para que esses endpoints respondam rapidamente já no primeiro acesso.

--- a/src/backend/application/glpi_api_client.py
+++ b/src/backend/application/glpi_api_client.py
@@ -200,6 +200,20 @@ class GlpiApiClient:
                 logger.error("failed to translate ticket %s: %s", item.get("id"), exc)
         return translated
 
+    async def get_status_counts_by_levels(
+        self, levels: List[str]
+    ) -> Dict[str, Dict[str, int]]:
+        """Return status counts for each level in ``levels``."""
+
+        results: Dict[str, Dict[str, int]] = {}
+        for level in levels:
+            try:
+                results[level] = await self._session.get_ticket_counts_by_level(level)
+            except Exception as exc:  # pragma: no cover - network failures
+                logger.error("failed to fetch counts for level %s: %s", level, exc)
+                results[level] = {"new": 0, "pending": 0, "solved": 0}
+        return results
+
 
 def create_glpi_api_client() -> Optional[GlpiApiClient]:
     try:

--- a/src/backend/infrastructure/glpi/glpi_session.py
+++ b/src/backend/infrastructure/glpi/glpi_session.py
@@ -916,7 +916,7 @@ class GLPISession:
                 "count": 1,
             }
             data = await self.get("search/Ticket", params=params)
-            totalcount = data.get("totalcount") or data.get("count")
+            totalcount = data.get("totalcount", data.get("count", 0))
             try:
                 return int(totalcount)
             except Exception:

--- a/src/backend/infrastructure/glpi/glpi_session.py
+++ b/src/backend/infrastructure/glpi/glpi_session.py
@@ -922,10 +922,9 @@ class GLPISession:
             except (ValueError, TypeError):
                 return 0
 
-        results = {}
-        for label, sid in STATUS_CODES.items():
-            results[label] = await _query(sid)
-        return results
+        tasks = [_query(sid) for sid in STATUS_CODES.values()]
+        counts = await asyncio.gather(*tasks)
+        return dict(zip(STATUS_CODES.keys(), counts))
 
 
 async def open_session_tool(params: SessionParams) -> str:

--- a/src/backend/infrastructure/glpi/glpi_session.py
+++ b/src/backend/infrastructure/glpi/glpi_session.py
@@ -919,7 +919,7 @@ class GLPISession:
             totalcount = data.get("totalcount", data.get("count", 0))
             try:
                 return int(totalcount)
-            except Exception:
+            except (ValueError, TypeError):
                 return 0
 
         results = {}

--- a/src/glpi_tools/__main__.py
+++ b/src/glpi_tools/__main__.py
@@ -78,13 +78,15 @@ def list_fields(itemtype: str, csv_path: Path | None) -> None:
         Console().print(f"Saved CSV to {csv_path}")
 
 
+import click
+
 @cli.command("count-by-level")
 @click.argument("levels", nargs=-1)
 def count_by_level(levels: tuple[str]) -> None:
     """Show ticket status counts for one or more ``LEVELS``."""
 
     if not levels:
-        raise SystemExit("Specify at least one level")
+        raise click.UsageError("Specify at least one level")
 
     load_dotenv()
 

--- a/tests/test_glpi_api_client.py
+++ b/tests/test_glpi_api_client.py
@@ -96,3 +96,24 @@ async def test_get_all_paginated_maps_fields(monkeypatch):
         {"id": 2, "name": "b"},
         {"id": 3, "name": "c"},
     ]
+
+
+@pytest.mark.asyncio
+async def test_get_status_counts_by_levels(monkeypatch):
+    session = MagicMock()
+    session.get_ticket_counts_by_level = AsyncMock(
+        side_effect=lambda lvl: {"new": 1, "pending": 0, "solved": 2}
+    )
+    monkeypatch.setattr(
+        "backend.application.glpi_api_client.MappingService",
+        lambda *a, **k: MagicMock(),
+    )
+    client = GlpiApiClient(session=session)
+
+    counts = await client.get_status_counts_by_levels(["N1", "N2"])
+
+    assert counts == {
+        "N1": {"new": 1, "pending": 0, "solved": 2},
+        "N2": {"new": 1, "pending": 0, "solved": 2},
+    }
+    assert session.get_ticket_counts_by_level.await_count == 2


### PR DESCRIPTION
## Summary
- query GLPI search API for per-level ticket counts
- add wrapper method to `GlpiApiClient`
- expose `count-by-level` in `glpi_tools`
- document command usage
- test new helpers

## Testing
- `pytest tests/test_glpi_client.py::test_get_ticket_counts_by_level tests/test_glpi_api_client.py::test_get_status_counts_by_levels -q`

------
https://chatgpt.com/codex/tasks/task_e_68883dcf330c8320b82ab8fe081bea5a

## Resumo por Sourcery

Fornecer funcionalidade de contagem de tickets por nível, estendendo a lógica de sessão e cliente, adicionando um comando CLI, documentação e testes

Novas Funcionalidades:
- Implementar `get_ticket_counts_by_level` em `GLPISession` para consultar as contagens de tickets novos, pendentes e resolvidos para um dado nível
- Adicionar `get_status_counts_by_levels` em `GlpiApiClient` para recuperar as contagens de tickets para múltiplos níveis
- Introduzir o comando CLI `count-by-level` em `glpi_tools` para exibir as contagens de status de tickets por nível

Documentação:
- Atualizar a documentação `README` e de uso do desenvolvedor com exemplos para o comando `count-by-level`

Testes:
- Adicionar testes para `GLPISession.get_ticket_counts_by_level`
- Adicionar testes para `GlpiApiClient.get_status_counts_by_levels`

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Provide ticket count functionality per level by extending session and client logic, adding a CLI command, documentation, and tests

New Features:
- Implement get_ticket_counts_by_level in GLPISession to query counts of new, pending, and solved tickets for a given level
- Add get_status_counts_by_levels in GlpiApiClient to retrieve ticket counts for multiple levels
- Introduce count-by-level CLI command in glpi_tools for displaying ticket status counts by level

Documentation:
- Update README and developer usage documentation with examples for the count-by-level command

Tests:
- Add tests for GLPISession.get_ticket_counts_by_level
- Add tests for GlpiApiClient.get_status_counts_by_levels

</details>