### PR TITLE
Add tests for py_glpi SDK counts

### DIFF
--- a/src/glpi_sdk.py
+++ b/src/glpi_sdk.py
@@ -5,7 +5,8 @@ from collections.abc import Iterable
 from py_glpi.connection import GLPISession
 from py_glpi.resources.tickets import Tickets
 
-STATUS_CODES = {"new": 1, "pending": 4, "solved": 5}
+#: Mapping of ticket status names to their corresponding numeric codes in the GLPI system.
+STATUS_CODES: Dict[str, int] = {"new": 1, "pending": 4, "solved": 5}
 
 
 def count_by_levels(

--- a/src/glpi_sdk.py
+++ b/src/glpi_sdk.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Dict, Iterable
+from collections.abc import Iterable
 
 from py_glpi.connection import GLPISession
 from py_glpi.resources.tickets import Tickets

--- a/src/glpi_sdk.py
+++ b/src/glpi_sdk.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from typing import Dict, Iterable
+
+from py_glpi.connection import GLPISession
+from py_glpi.resources.tickets import Tickets
+
+STATUS_CODES = {"new": 1, "pending": 4, "solved": 5}
+
+
+def count_by_levels(
+    session: GLPISession, levels: Iterable[str]
+) -> Dict[str, Dict[str, int]]:
+    """Return status counts for each level using ``py_glpi``.
+
+    Parameters
+    ----------
+    session:
+        Established ``GLPISession``.
+    levels:
+        Iterable of level identifiers (e.g. N1, N2).
+    """
+    tickets = Tickets(session)
+    results: Dict[str, Dict[str, int]] = {}
+
+    for level in levels:
+        level_counts: Dict[str, int] = {}
+        for status_name, status_id in STATUS_CODES.items():
+            criteria = [
+                {"field": "groups_id_assign", "searchtype": "equals", "value": level},
+                {"link": "AND"},
+                {"field": "status", "searchtype": "equals", "value": status_id},
+            ]
+            level_counts[status_name] = tickets.count(criteria=criteria)
+        results[level] = level_counts
+
+    return results

--- a/tests/test_glpi_sdk.py
+++ b/tests/test_glpi_sdk.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+pytest.importorskip("py_glpi")
+
+from glpi_sdk import count_by_levels  # noqa: E402
+
+
+@pytest.fixture()
+def fake_session():
+    return MagicMock(name="GLPISession")
+
+
+def test_count_by_levels_calls_tickets_count(fake_session):
+    levels = ["N1", "N2"]
+    ticket_mock = MagicMock()
+    ticket_mock.count.side_effect = [1, 2, 3, 4, 5, 6]
+
+    with patch("glpi_sdk.Tickets", return_value=ticket_mock) as tickets_cls:
+        result = count_by_levels(fake_session, levels)
+
+    tickets_cls.assert_called_once_with(fake_session)
+    expected_calls = [
+        call(
+            criteria=[
+                {"field": "groups_id_assign", "searchtype": "equals", "value": "N1"},
+                {"link": "AND"},
+                {"field": "status", "searchtype": "equals", "value": 1},
+            ]
+        ),
+        call(
+            criteria=[
+                {"field": "groups_id_assign", "searchtype": "equals", "value": "N1"},
+                {"link": "AND"},
+                {"field": "status", "searchtype": "equals", "value": 4},
+            ]
+        ),
+        call(
+            criteria=[
+                {"field": "groups_id_assign", "searchtype": "equals", "value": "N1"},
+                {"link": "AND"},
+                {"field": "status", "searchtype": "equals", "value": 5},
+            ]
+        ),
+        call(
+            criteria=[
+                {"field": "groups_id_assign", "searchtype": "equals", "value": "N2"},
+                {"link": "AND"},
+                {"field": "status", "searchtype": "equals", "value": 1},
+            ]
+        ),
+        call(
+            criteria=[
+                {"field": "groups_id_assign", "searchtype": "equals", "value": "N2"},
+                {"link": "AND"},
+                {"field": "status", "searchtype": "equals", "value": 4},
+            ]
+        ),
+        call(
+            criteria=[
+                {"field": "groups_id_assign", "searchtype": "equals", "value": "N2"},
+                {"link": "AND"},
+                {"field": "status", "searchtype": "equals", "value": 5},
+            ]
+        ),
+    ]
+    ticket_mock.count.assert_has_calls(expected_calls)
+
+    assert result == {
+        "N1": {"new": 1, "pending": 2, "solved": 3},
+        "N2": {"new": 4, "pending": 5, "solved": 6},
+    }


### PR DESCRIPTION
## Summary
- add a helper module `glpi_sdk.py` implementing `count_by_levels`
- test the helper using mocked `py_glpi` Tickets resource

## Testing
- `pytest -p no:cov -o addopts='' tests/test_glpi_sdk.py`

------
https://chatgpt.com/codex/tasks/task_e_68884a0fbe4883209849398bc607c998

## Resumo por Sourcery

Adiciona uma nova função auxiliar para resumir contagens de tickets por nível usando `py_glpi` e cobri-la com testes de unidade direcionados

Novos Recursos:
- Adiciona o auxiliar `count_by_levels` em `glpi_sdk` para agregar contagens de status de tickets por nível

Melhorias:
- Apresenta o mapeamento `STATUS_CODES` para identificadores de status de ticket

Testes:
- Adiciona testes de unidade para `count_by_levels` usando `py_glpi.Tickets` mockado para verificar os critérios e resultados da consulta

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a new helper function to summarize ticket counts per level using py_glpi and cover it with targeted unit tests

New Features:
- Add count_by_levels helper in glpi_sdk to aggregate ticket status counts by level

Enhancements:
- Introduce STATUS_CODES mapping for ticket status identifiers

Tests:
- Add unit tests for count_by_levels using mocked py_glpi.Tickets to verify query criteria and results

</details>