### PR TITLE
Update docs for SSL inspection with pact-python

### DIFF
--- a/docs/DEV_SETUP.md
+++ b/docs/DEV_SETUP.md
@@ -40,3 +40,17 @@ pip install -r requirements-dev.txt --break-system-packages
 ```bash
 python -m venv venv
 source venv/bin/activate  # On Windows, use `venv\Scripts\activate`
+pip install -r requirements.txt -r requirements-dev.txt
+```
+
+### SSL inspection and `pact-python`
+
+Corporate proxies that inspect TLS traffic may cause `pip install pact-python` to fail with `CERTIFICATE_VERIFY_FAILED`. Provide the company's root certificate bundle and reuse it for Node scripts that invoke Pact:
+
+```bash
+export REQUESTS_CA_BUNDLE=/path/to/company-ca.pem
+export NODE_EXTRA_CA_CERTS=$REQUESTS_CA_BUNDLE
+pip install pact-python
+```
+
+Refer to the [Installing Dependencies Behind a Proxy or Offline](../README.md#installing-dependencies-behind-a-proxy-or-offline) section in the README for additional proxy configuration.


### PR DESCRIPTION
## Summary
- document installing `pact-python` behind corporate SSL inspection

## Testing
- `pre-commit run --files docs/DEV_SETUP.md README.md`

------
https://chatgpt.com/codex/tasks/task_e_68886d8fa8d88320a48fa384b9f9adcd

## Resumo por Sourcery

Atualizar a documentação DEV_SETUP para incluir a instalação combinada de requisitos e instruções para inspeção SSL ao instalar pact-python atrás de proxies corporativos

Documentação:
- Adicionar comando `pip install` combinado para requisitos e requisitos de desenvolvimento em DEV_SETUP.md
- Introduzir seção de inspeção SSL detalhando a configuração de REQUESTS_CA_BUNDLE e NODE_EXTRA_CA_CERTS para instalação de pact-python sob proxies corporativos

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update DEV_SETUP documentation to include combined requirements installation and instructions for SSL inspection when installing pact-python behind corporate proxies

Documentation:
- Add combined pip install command for requirements and development requirements in DEV_SETUP.md
- Introduce SSL inspection section detailing setting REQUESTS_CA_BUNDLE and NODE_EXTRA_CA_CERTS for pact-python installation under corporate proxies

</details>