### PR TITLE
Expose /ping endpoint

### DIFF
--- a/dashboard_app.py
+++ b/dashboard_app.py
@@ -115,10 +115,10 @@ def create_app(df: pd.DataFrame | None) -> Dash:
     server = Flask(__name__)
     cache.init_app(server)
 
-    # @server.route("/ping")
-    # def ping() -> tuple[str, int]:
-    #     """Simple health check endpoint."""
-    #     return "OK", 200
+    @server.route("/ping")
+    def ping() -> tuple[str, int]:
+        """Simple health check endpoint."""
+        return "OK", 200
 
     app = Dash(__name__, server=server, external_stylesheets=[dbc.themes.BOOTSTRAP])
     app.layout = build_layout(df)

--- a/docs/solucoes_problemas.md
+++ b/docs/solucoes_problemas.md
@@ -18,6 +18,7 @@ Este documento reúne estratégias para lidar com falhas de inicialização, inc
 ## 3. Configurações de Saúde do Serviço Dash
 
 - Adicione um endpoint simples de health check via `@app.server.route("/ping")`.
+  O caminho `/ping` retorna `OK` quando o servidor está operacional.
 - Desative o reloader em produção (`app.run_server(use_reloader=False)`).
 - Utilize monitoramento externo (Docker `HEALTHCHECK` ou probes do Kubernetes).
 

--- a/docs/solucoes_problemas.md
+++ b/docs/solucoes_problemas.md
@@ -17,8 +17,7 @@ Este documento reúne estratégias para lidar com falhas de inicialização, inc
 
 ## 3. Configurações de Saúde do Serviço Dash
 
-- Adicione um endpoint simples de health check via `@app.server.route("/ping")`.
-  O caminho `/ping` retorna `OK` quando o servidor está operacional.
+- Para monitoramento, o serviço Dash expõe um endpoint de saúde em `/ping` que retorna `OK` quando está operacional.
 - Desative o reloader em produção (`app.run_server(use_reloader=False)`).
 - Utilize monitoramento externo (Docker `HEALTHCHECK` ou probes do Kubernetes).
 


### PR DESCRIPTION
## Summary
- add simple /ping Flask route in `dashboard_app.py`
- explain the endpoint in the troubleshooting docs

## Testing
- `pre-commit run --files dashboard_app.py docs/solucoes_problemas.md`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'py_glpi.resources.users')*

------
https://chatgpt.com/codex/tasks/task_e_6888fff29c7c8320abab27792119a4c8

## Resumo por Sourcery

Disponibilizar um endpoint simples /ping para verificação de saúde e atualizar a documentação para explicar seu uso

Novas Funcionalidades:
- Adicionar endpoint de verificação de saúde /ping ao servidor Flask

Documentação:
- Documentar o endpoint /ping no guia de solução de problemas

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Expose a simple /ping endpoint for health checking and update documentation to explain its usage

New Features:
- Add /ping health check endpoint to Flask server

Documentation:
- Document the /ping endpoint in the troubleshooting guide

</details>