### PR TITLE
Add GLPISDK factory and metrics worker update

### DIFF
--- a/src/backend/adapters/factory.py
+++ b/src/backend/adapters/factory.py
@@ -13,6 +13,7 @@ from backend.core.settings import (
     USE_MOCK_DATA,
     VERIFY_SSL,
 )
+from backend.infrastructure.glpi.glpi_sdk import GLPISDK
 from backend.infrastructure.glpi.glpi_session import Credentials, GLPISession
 from shared.dto import TicketTranslator
 
@@ -39,6 +40,22 @@ def create_glpi_session() -> Optional[GLPISession]:
         )
     except Exception as exc:  # pragma: no cover - init failures
         logger.exception("GLPI session init failed: %s", exc)
+        return None
+
+
+def create_glpi_sdk() -> Optional[GLPISDK]:
+    """Instantiate :class:`GLPISDK` using settings."""
+
+    try:
+        return GLPISDK(
+            GLPI_BASE_URL,
+            GLPI_APP_TOKEN,
+            user_token=GLPI_USER_TOKEN,
+            username=GLPI_USERNAME,
+            password=GLPI_PASSWORD,
+        )
+    except Exception as exc:  # pragma: no cover - init failures
+        logger.exception("GLPI SDK init failed: %s", exc)
         return None
 
 

--- a/src/backend/adapters/factory.py
+++ b/src/backend/adapters/factory.py
@@ -54,7 +54,7 @@ def create_glpi_sdk() -> Optional[GLPISDK]:
             username=GLPI_USERNAME,
             password=GLPI_PASSWORD,
         )
-    except Exception as exc:  # pragma: no cover - init failures
+    except (ValueError, ConnectionError) as exc:  # pragma: no cover - init failures
         logger.exception("GLPI SDK init failed: %s", exc)
         return None
 

--- a/src/backend/application/metrics_worker.py
+++ b/src/backend/application/metrics_worker.py
@@ -62,7 +62,7 @@ async def update_metrics(ctx: Dict[str, Any], ticket: Dict[str, Any]) -> None:
             levels = {lvl: lvl for lvl in level_values}
             counts = sdk.get_ticket_counts_by_level("groups_id_assign", levels)
             await cache.set("metrics_levels", counts)
-        except Exception as exc:  # pragma: no cover - network failures
+        except (ConnectionError, TimeoutError, sdk.SDKException) as exc:  # pragma: no cover - network failures
             logging.error("failed to fetch counts via SDK: %s", exc)
             await cache.set("metrics_levels", status_by_group(df))
     else:

--- a/tests/test_event_consumer.py
+++ b/tests/test_event_consumer.py
@@ -1,5 +1,6 @@
 import pytest
 
+from backend.application import metrics_worker
 from backend.application.events_consumer import TicketEventConsumer
 from backend.application.metrics_worker import update_metrics
 from shared.utils.redis_client import RedisClient
@@ -27,7 +28,8 @@ class DummyCache(RedisClient):
 
 
 @pytest.mark.asyncio
-async def test_update_metrics_writes_cache():
+async def test_update_metrics_writes_cache(monkeypatch):
+    monkeypatch.setattr(metrics_worker, "create_glpi_sdk", lambda: None)
     cache = DummyCache()
     ticket = {"id": 1, "status": 1, "priority": 2, "date_creation": "2024-06-01"}
     await update_metrics({"cache": cache}, ticket)
@@ -36,7 +38,8 @@ async def test_update_metrics_writes_cache():
 
 
 @pytest.mark.asyncio
-async def test_consumer_processes_events():
+async def test_consumer_processes_events(monkeypatch):
+    monkeypatch.setattr(metrics_worker, "create_glpi_sdk", lambda: None)
     events = [
         {
             "type": "TicketCreated",


### PR DESCRIPTION
## Summary
- create a `create_glpi_sdk` helper in adapters factory
- fetch ticket status counts through the new SDK in `metrics_worker`
- patch event consumer tests to mock `create_glpi_sdk`

## Testing
- `pre-commit run --files src/backend/adapters/factory.py src/backend/application/metrics_worker.py tests/test_event_consumer.py`
- `pytest` *(fails: 52 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6888fffc2fe88320bfb25c3f26ac6c25

## Resumo por Sourcery

Integrar um helper de fábrica do SDK GLPI e atualizar o worker de métricas para usar o SDK para agregação de contagem de tickets, adicionando log de erros e preservando o comportamento de fallback original, e ajustar os testes para simular a nova função de fábrica.

Novas Funcionalidades:
- Adicionar o helper de fábrica `create_glpi_sdk` para instanciar o `GLPISDK`

Melhorias:
- Atualizar o `metrics_worker` para buscar contagens de status de tickets via SDK GLPI com tratamento de erros e fallback para a lógica de agregação existente

Testes:
- Aplicar patch nos testes do consumidor de eventos para simular `create_glpi_sdk`

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Integrate a GLPI SDK factory helper and update the metrics worker to use the SDK for ticket count aggregation, adding error logging and preserving the original fallback behavior, and adjust tests to mock the new factory function.

New Features:
- Add create_glpi_sdk factory helper for instantiating GLPISDK

Enhancements:
- Update metrics_worker to fetch ticket status counts via the GLPI SDK with error handling and fallback to existing aggregation logic

Tests:
- Patch event consumer tests to mock create_glpi_sdk

</details>