### PR TITLE
Add pact-python SSL inspection instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,13 +363,9 @@ strategies to pre-build Docker images and cache Python wheels.
 
 Corporate proxies that inspect TLS traffic may cause `pip install pact-python`
 to fail with `CERTIFICATE_VERIFY_FAILED`. Provide the company's root certificate
-bundle and reuse it for Node scripts that invoke Pact:
-
-```bash
 export REQUESTS_CA_BUNDLE=/path/to/company-ca.pem
-export NODE_EXTRA_CA_CERTS=$REQUESTS_CA_BUNDLE
+export SSL_CERT_FILE=$REQUESTS_CA_BUNDLE
 pip install pact-python
-```
 
 Refer back to the
 [Installing Dependencies Behind a Proxy or Offline](#installing-dependencies-behind-a-proxy-or-offline)

--- a/README.md
+++ b/README.md
@@ -343,6 +343,22 @@ More setup tips—including offline usage with mock data—are documented in
 [docs/dev_performance_guide.md](docs/dev_performance_guide.md) for
 strategies to pre-build Docker images and cache Python wheels.
 
+### SSL inspection and `pact-python`
+
+Corporate proxies that inspect TLS traffic may cause `pip install pact-python`
+to fail with `CERTIFICATE_VERIFY_FAILED`. Provide the company's root certificate
+bundle and reuse it for Node scripts that invoke Pact:
+
+```bash
+export REQUESTS_CA_BUNDLE=/path/to/company-ca.pem
+export NODE_EXTRA_CA_CERTS=$REQUESTS_CA_BUNDLE
+pip install pact-python
+```
+
+Refer back to the
+[Installing Dependencies Behind a Proxy or Offline](#installing-dependencies-behind-a-proxy-or-offline)
+section for more proxy configuration tips.
+
 ## Instalação em rede restrita
 
 Caso o ambiente tenha acesso limitado à internet ou exija proxy corporativo,

--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ More setup tips—including offline usage with mock data—are documented in
 [docs/dev_performance_guide.md](docs/dev_performance_guide.md) for
 strategies to pre-build Docker images and cache Python wheels.
 
-### SSL inspection and `pact-python`
+### SSL Certificate Issues with pact-python Installation
 
 Corporate proxies that inspect TLS traffic may cause `pip install pact-python`
 to fail with `CERTIFICATE_VERIFY_FAILED`. Provide the company's root certificate


### PR DESCRIPTION
## Summary
- document how to use corporate CA bundles when installing pact-python
- provide NODE_EXTRA_CA_CERTS and REQUESTS_CA_BUNDLE example
- link back to proxy instructions for consistency

## Testing
- `pre-commit run --files README.md docs/DEV_SETUP.md`
- `pytest tests/test_auth.py --no-cov -k init_session_success -vv` *(fails: ModuleNotFoundError: No module named 'py_glpi.resources.users')*

------
https://chatgpt.com/codex/tasks/task_e_688902a946008320ac41eb010f0fdfa7

## Resumo por Sourcery

Documentação:
- Adiciona uma seção no README para orientação sobre inspeção SSL ao instalar `pact-python` atrás de proxies corporativos, com exemplos de configurações `REQUESTS_CA_BUNDLE` e `NODE_EXTRA_CA_CERTS`, e um link para a configuração de proxy existente.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Add README section for SSL inspection guidance when installing pact-python behind corporate proxies with example REQUESTS_CA_BUNDLE and NODE_EXTRA_CA_CERTS settings and a link to existing proxy configuration

</details>