### PR TITLE
Add corporate CA environment variable instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,22 @@ pip install --no-index --find-links=wheels/ -r requirements.txt
 O front-end já executa `npm ci --prefer-offline`, reutilizando o cache de
 dependências sempre que possível.
 
+### Confiar no certificado corporativo
+
+Se a rede utiliza inspeção TLS, tanto o `pip` quanto o `npm` precisam confiar no
+mesmo certificado raiz da empresa. Defina `REQUESTS_CA_BUNDLE` apontando para o
+arquivo `.pem` e reutilize esse caminho em `NODE_EXTRA_CA_CERTS`:
+
+```bash
+export REQUESTS_CA_BUNDLE=/path/to/corp-ca.pem
+export NODE_EXTRA_CA_CERTS=$REQUESTS_CA_BUNDLE
+```
+
+Essas variáveis garantem que as ferramentas Python e Node validem os servidores
+HTTPS com a mesma autoridade certificadora. Para entender por que desativar a
+verificação TLS com `NODE_TLS_REJECT_UNAUTHORIZED=0` não é seguro, consulte a
+[seção 11.2 de docs/solucoes_problemas.md](docs/solucoes_problemas.md#112-node_tls_reject_unauthorized0).
+
 ## GitHub access
 
 Repositórios privados ou actions personalizadas exigem autenticação. Defina


### PR DESCRIPTION
## Summary
- document how to set `REQUESTS_CA_BUNDLE` and `NODE_EXTRA_CA_CERTS`
- link to troubleshooting note about `NODE_TLS_REJECT_UNAUTHORIZED` for more details

## Testing
- `python -m pre_commit run --files README.md`

------
https://chatgpt.com/codex/tasks/task_e_688902b42308832082ba397eb912d80c