### PR TITLE
Fix unused vars in update imports test

### DIFF
--- a/tests/refactor/test_update_imports.py
+++ b/tests/refactor/test_update_imports.py
@@ -28,7 +28,8 @@ def test_no_match():
 def test_partial_match():
     src = "from glpi_dashboard.acl import something_else"
     expected = "from backend.adapters import something_else"
-    assert rewrite_imports(src, MAPPING).strip() == expected, f"Expected '{expected}', but got '{rewrite_imports(src, MAPPING).strip()}'"
+    result = rewrite_imports(src, MAPPING).strip()
+    assert result == expected, f"{result!r} != {expected!r}"
 
 
 def test_validate_mapping():
@@ -56,9 +57,13 @@ def test_from_import_rewritten():
 def test_from_submodule_import_rewritten():
     src = "from glpi_dashboard.acl.normalization import sanitize_status_column"
     expected = "from backend.adapters.normalization import sanitize_status_column"
+    assert rewrite_imports(src, MAPPING).strip() == expected
+
+
 def test_string_literal_not_rewritten():
     """Verify that string literals containing module names are not rewritten."""
-    src = 'variable = "import glpi_dashboard.acl.normalization"'  # Should not be rewritten
+    # Should not be rewritten
+    src = 'variable = "import glpi_dashboard.acl.normalization"'
     assert rewrite_imports(src, MAPPING).strip() == src
 
 


### PR DESCRIPTION
## Summary
- remove F841 warnings in tests/refactor/test_update_imports.py
- shorten assertion message and fix long comment line

## Testing
- `pytest tests/refactor/test_update_imports.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68890ff0ad748320922266dc123e2a5a

## Resumo por Sourcery

Refatorar test_update_imports para remover avisos de variáveis não utilizadas, simplificar asserções e melhorar a formatação dos comentários

Testes:
- Extrair a chamada de `rewrite_imports` para uma variável de resultado antes das asserções para remover avisos F841 e evitar chamadas duplicadas
- Substituir mensagens de asserção verbosas de f-string por comparações concisas baseadas em repr
- Mover comentários inline para linhas separadas para evitar linhas de comentário longas
- Adicionar linha em branco ausente em um teste para melhor legibilidade

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor test_update_imports to remove unused variable warnings, simplify assertions, and improve comment formatting

Tests:
- Extract rewrite_imports call into a result variable before assertions to remove F841 warnings and avoid duplicate calls
- Replace verbose f-string assertion messages with concise repr-based comparisons
- Move inline comments to standalone lines to prevent long comment lines
- Add missing blank line in one test for improved readability

</details>