### PR TITLE
Run ruff and sort imports

### DIFF
--- a/dashboard_app.py
+++ b/dashboard_app.py
@@ -9,8 +9,6 @@ import pandas as pd
 from dash import Dash
 from flask import Flask
 from flask_caching import Cache
-from frontend.callbacks.callbacks import register_callbacks
-from frontend.layout.layout import build_layout
 
 from backend.core.settings import (
     DASH_PORT,
@@ -25,6 +23,8 @@ from backend.domain.exceptions import GLPIAPIError
 from backend.infrastructure.glpi import glpi_client_logging
 from backend.infrastructure.glpi.glpi_session import Credentials, GLPISession
 from backend.utils import process_raw
+from frontend.callbacks.callbacks import register_callbacks
+from frontend.layout.layout import build_layout
 
 __all__ = ["create_app", "main"]
 

--- a/src/frontend/callbacks/callbacks.py
+++ b/src/frontend/callbacks/callbacks.py
@@ -5,6 +5,7 @@ from typing import Any, Callable, Dict, List, Optional
 import dash_bootstrap_components as dbc  # type: ignore
 import pandas as pd
 from dash import Dash, Input, Output, callback
+
 from frontend.components.components import _status_fig, compute_ticket_stats
 
 

--- a/tests/test_dashboard_components.py
+++ b/tests/test_dashboard_components.py
@@ -2,6 +2,7 @@ import pandas as pd
 import plotly.graph_objs as go
 import pytest
 from dash import html
+
 from frontend.components.components import _status_fig, compute_ticket_stats
 
 pytest.importorskip("pandas")

--- a/tests/test_dashboard_layout.py
+++ b/tests/test_dashboard_layout.py
@@ -5,6 +5,7 @@ import dash_bootstrap_components as dbc
 import pandas as pd
 import pytest
 from dash import Dash
+
 from frontend.layout.layout import build_layout
 
 _chromedriver = shutil.which("chromedriver")


### PR DESCRIPTION
## Summary
- run `ruff --fix` and reorder imports

## Testing
- `pytest tests/test_dashboard_components.py tests/test_dashboard_layout.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68890fefffc08320bde66995c605ff95