### PR TITLE
Fix GLPI SDK import and status mapping

### DIFF
--- a/tests/test_glpi_sdk.py
+++ b/tests/test_glpi_sdk.py
@@ -96,6 +96,7 @@ def test_count_by_levels_calls_tickets_count(fake_session):
         "N2": {"new": 4, "pending": 5, "solved": 6},
     }
 
+
 def test_get_ticket_counts_by_level_empty_levels(monkeypatch: pytest.MonkeyPatch):
     """Returns empty dict if levels is empty."""
     monkeypatch.setattr(glpi_sdk_impl, "GLPISession", MagicMock())
@@ -103,6 +104,7 @@ def test_get_ticket_counts_by_level_empty_levels(monkeypatch: pytest.MonkeyPatch
     sdk.list_tickets_by_level = MagicMock()
     result = sdk.get_ticket_counts_by_level("lvl", {})
     assert result == {}
+
 
 def test_get_ticket_counts_by_level_empty_tickets(monkeypatch: pytest.MonkeyPatch):
     """Returns all status counts as 0 if list_tickets_by_level returns empty list."""
@@ -113,6 +115,7 @@ def test_get_ticket_counts_by_level_empty_tickets(monkeypatch: pytest.MonkeyPatc
     assert result == {
         "A": {"new": 0, "processing": 0, "waiting": 0, "solved": 0, "closed": 0},
     }
+
 
 def test_list_tickets_by_level_handles_not_found(monkeypatch: pytest.MonkeyPatch):
     """``list_tickets_by_level`` returns an empty list on ``ResourceNotFound``."""


### PR DESCRIPTION
## Summary
- handle missing `py_glpi.resources.users` by falling back to `auth.Users`
- adjust `STATUS_MAP` to support legacy codes
- run `pre-commit` and `pytest`

## Testing
- `pre-commit run --files src/backend/infrastructure/glpi/glpi_sdk.py tests/test_glpi_sdk.py`
- `pytest tests/test_glpi_sdk.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68892188859c83208de8f977dde47fe7

## Resumo por Sourcery

Lidar com a importação de usuários GLPI ausentes, recorrendo a auth.Users, atualizar o mapeamento de status para suportar códigos legados para tickets resolvidos e fechados, e aplicar correções de formatação aos testes.

Melhorias:
- Recorrer a auth.Users quando py_glpi.resources.users estiver indisponível
- Estender STATUS_MAP com valores de fallback para códigos legados 'solved' e 'closed'

CI:
- Garantir as execuções de pre-commit e pytest

Testes:
- Inserir linhas em branco entre as funções de teste para satisfazer a formatação do pre-commit

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle missing GLPI users import by falling back to auth.Users, update status mapping to support legacy codes for solved and closed tickets, and apply formatting fixes to tests

Enhancements:
- Fallback to auth.Users when py_glpi.resources.users is unavailable
- Extend STATUS_MAP with fallback values for legacy 'solved' and 'closed' codes

CI:
- Enforce pre-commit and pytest runs

Tests:
- Insert blank lines between test functions to satisfy pre-commit formatting

</details>