### PR TITLE
Add missing test deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,8 @@ full-tests = [
     "dash[testing]",
     "pact-python",
     "fakeredis",
+    "libcst",
+    "pytest-asyncio",
 ]
 
 

--- a/requirements-full-tests.txt
+++ b/requirements-full-tests.txt
@@ -86,6 +86,10 @@ exceptiongroup==1.2.2
     # via py-glpi
 fakeredis==2.30.2
     # via glpi-dashboard-cau (pyproject.toml)
+libcst==1.8.2
+    # via glpi-dashboard-cau (pyproject.toml)
+pytest-asyncio==1.0.0
+    # via glpi-dashboard-cau (pyproject.toml)
 fastapi==0.116.1
     # via
     #   glpi-dashboard-cau (pyproject.toml)


### PR DESCRIPTION
## Summary
- include `libcst` and `pytest-asyncio` in optional `full-tests` deps
- update compiled requirements

## Testing
- `pip install -r requirements-full-tests.txt`
- `pytest tests/test_health_endpoint.py -q -p no:cov --override-ini addopts=''` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68893a97c6f0832085765549662361c4

## Resumo por Sourcery

Adiciona dependências de teste ausentes ao extra 'full-tests' e atualiza seu arquivo de requisitos compilado

Melhorias:
- Adiciona libcst e pytest-asyncio às dependências opcionais de full-tests
- Regenera requirements-full-tests.txt para refletir as novas dependências

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add missing test dependencies to the 'full-tests' extra and update its compiled requirements file

Enhancements:
- Add libcst and pytest-asyncio to the optional full-tests dependencies
- Regenerate requirements-full-tests.txt to reflect the new dependencies

</details>