### PR TITLE
Document graceful shutdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,11 @@ docker compose up
 
 This starts PostgreSQL, Redis, the FastAPI worker and the Dash app. Access the dashboard at `http://localhost:5174` when the build finishes.
 
+The Compose files configure the backend service with `stop_signal: SIGINT` and a
+`stop_grace_period` of `60s`. When you stop the stack with `CTRL+C` or `docker
+compose down` the worker receives `SIGINT` and has one minute to shut down
+gracefully before the container is killed.
+
 ## Dependencies
 
 - Python 3.10\u20133.12

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ This starts PostgreSQL, Redis, the FastAPI worker and the Dash app. Access the d
 
 The Compose files configure the backend service with `stop_signal: SIGINT` and a
 `stop_grace_period` of `60s`. When you stop the stack with `CTRL+C` or `docker
-compose down` the worker receives `SIGINT` and has one minute to shut down
+compose down` the worker receives `SIGINT` and has 60 seconds to shut down
 gracefully before the container is killed.
 
 ## Dependencies

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -11,6 +11,8 @@ services:
     volumes:
       - ./src:/app/src
       - ./tests:/app/tests
+    stop_signal: SIGINT
+    stop_grace_period: 60s
 
   frontend:
     build:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -24,6 +24,8 @@ services:
       - db_password
     depends_on:
       - db
+    stop_signal: SIGINT
+    stop_grace_period: 60s
 
   frontend:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,8 @@ services:
       timeout: 5s
       start_period: 60s
       retries: 3
+    stop_signal: SIGINT
+    stop_grace_period: 60s
     ports:
       # Map API for host access
       - "8000:8000"


### PR DESCRIPTION
## Summary
- configure backend container to stop with SIGINT and wait 60s
- mention graceful shutdown in README

## Testing
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ac7288c7883209dac321af4f6eabe

## Resumo por Sourcery

Configurar o Docker Compose para habilitar o desligamento elegante do serviço de backend e atualizar a documentação de acordo.

Melhorias:
- Definir stop_signal como SIGINT e stop_grace_period para 60s para o serviço de backend em todos os arquivos Docker Compose

Documentação:
- Documentar o comportamento de desligamento elegante e as configurações de sinal no README

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Configure Docker Compose to enable graceful shutdown of the backend service and update documentation accordingly.

Enhancements:
- Set stop_signal to SIGINT and stop_grace_period to 60s for the backend service in all Docker Compose files

Documentation:
- Document the graceful shutdown behavior and signal settings in the README

</details>