### PR TITLE
Introduce app readiness state

### DIFF
--- a/docs/glpi_tokens_guide.md
+++ b/docs/glpi_tokens_guide.md
@@ -132,8 +132,9 @@ Cobertura mínima de 85 % garantida no CI (GitHub Actions).
 ## 10 ▪️ Monitoramento de produção
 
 O contêiner **worker** possui `HEALTHCHECK` interno que executa `curl -I` no␊
-endpoint `/health` (método **HEAD**). A rota `GET` continua disponível para
-verificações manuais. Use:
+endpoint `/health` (método **HEAD**). O endpoint retorna **503** enquanto
+`app.state.ready` for `False` e **200** quando estiver pronto. A rota `GET`
+continua disponível para verificações manuais. Use:
 
 ```bash
 docker events --filter 'event=health_status' --since 30m

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -21,8 +21,8 @@ The dashboard aggregates GLPI service desk metrics using a FastAPI backend and a
    ```
 
    The command prints `✅ Conexão com GLPI bem-sucedida!` when the API accepts
-   the tokens. If the variables are missing or invalid the worker's␊
-   `/health` endpoint will return **HTTP 500**.
+   the tokens. The worker's `/health` endpoint now reports **503** until
+   `app.state.ready` becomes `True`.
 
    Example snippet:
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -3,5 +3,5 @@
 This directory contains unit and integration tests for the GLPI dashboard.
 
 - `test_health_endpoint.py` verifies the `/health` endpoint.
-  - A `HEAD /health` request should return `200` when GLPI is reachable.
-  - When GLPI is unavailable (simulated via the `glpi_unavailable` fixture) the endpoint responds with `500`.
+  - A `HEAD /health` request returns `200` once the app reports it is ready.
+  - Before readiness (`app.state.ready` is `False`) the endpoint responds with `503`.

--- a/tests/test_health_endpoint.py
+++ b/tests/test_health_endpoint.py
@@ -10,20 +10,18 @@ def dummy_cache() -> DummyCache:
     return DummyCache()
 
 
-def test_head_health_ok(
-    monkeypatch: pytest.MonkeyPatch, dummy_cache: DummyCache
-) -> None:
-    async def ok() -> int:
-        return 200
-
-    monkeypatch.setattr("src.backend.api.worker_api.check_glpi_connection", ok)
-    client = TestClient(create_app(cache=dummy_cache))
+def test_head_health_ok(dummy_cache: DummyCache) -> None:
+    app = create_app(cache=dummy_cache)
+    app.state.ready = True
+    client = TestClient(app)
     resp = client.head("/health")
     assert resp.status_code == 200
     assert resp.text == ""
 
 
-def test_health_unavailable(glpi_unavailable, dummy_cache: DummyCache) -> None:
-    client = TestClient(create_app(cache=dummy_cache))
+def test_health_unavailable(dummy_cache: DummyCache) -> None:
+    app = create_app(cache=dummy_cache)
+    app.state.ready = False
+    client = TestClient(app)
     resp = client.get("/health")
-    assert resp.status_code == 500
+    assert resp.status_code == 503


### PR DESCRIPTION
## Summary
- add `app.state.ready` to `create_app`
- adjust `/health` endpoints to rely on readiness flag
- document new `/health` behavior
- update health endpoint tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fakeredis' and TypeError in SQLAlchemy)*

------
https://chatgpt.com/codex/tasks/task_e_688acdb6add8832081d69c1cdafc01c5

## Resumo por Sourcery

Introduzir um *flag* de prontidão para controlar o comportamento do *healthcheck* do serviço com base no estado de inicialização da aplicação

Novas Funcionalidades:
- Adicionar o *flag* `app.state.ready` inicializado como `false` e definido como `true` assim que as tarefas de inicialização forem concluídas

Melhorias:
- Simplificar os *endpoints* `/health` GET e HEAD para retornar 503 até que esteja pronto e 200 com a resposta JSON apropriada "ready"/"starting"

Documentação:
- Atualizar o guia de integração, o guia de *tokens* GLPI e o README de teste para descrever o novo comportamento do *healthcheck* baseado em prontidão

Testes:
- Modificar os testes do *endpoint* de saúde para definir `app.state.ready` explicitamente e verificar os códigos de status e corpos de resposta atualizados

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a readiness flag to control the service’s healthcheck behavior based on application startup state

New Features:
- Add `app.state.ready` flag initialized to false and set to true once startup tasks complete

Enhancements:
- Simplify `/health` GET and HEAD endpoints to return 503 until ready and 200 with appropriate "ready"/"starting" JSON response

Documentation:
- Update onboarding guide, GLPI tokens guide, and test README to describe new readiness-based healthcheck behavior

Tests:
- Modify health endpoint tests to set `app.state.ready` explicitly and assert updated status codes and response bodies

</details>