### PR TITLE
Implement async ticket preload task and update tests

### DIFF
--- a/tests/test_health_endpoint.py
+++ b/tests/test_health_endpoint.py
@@ -1,6 +1,8 @@
+import pandas as pd
 import pytest
 from fastapi.testclient import TestClient
 
+from backend.application import ticket_loader
 from tests.test_worker_api import DummyCache
 from worker import create_app
 
@@ -10,18 +12,26 @@ def dummy_cache() -> DummyCache:
     return DummyCache()
 
 
-def test_head_health_ok(dummy_cache: DummyCache) -> None:
-    app = create_app(cache=dummy_cache)
-    app.state.ready = True
-    client = TestClient(app)
-    resp = client.head("/health")
-    assert resp.status_code == 200
-    assert resp.text == ""
+def test_head_health_ok(
+    monkeypatch: pytest.MonkeyPatch, dummy_cache: DummyCache
+) -> None:
+    async def fake_load(*args: object, **kwargs: object) -> pd.DataFrame:
+        return pd.DataFrame()
+
+    monkeypatch.setattr(ticket_loader, "load_tickets", fake_load)
+    with TestClient(create_app(cache=dummy_cache)) as client:
+        resp = client.head("/health")
+        assert resp.status_code == 200
+        assert resp.text == ""
 
 
-def test_health_unavailable(dummy_cache: DummyCache) -> None:
-    app = create_app(cache=dummy_cache)
-    app.state.ready = False
-    client = TestClient(app)
-    resp = client.get("/health")
-    assert resp.status_code == 503
+def test_health_unavailable(
+    monkeypatch: pytest.MonkeyPatch, dummy_cache: DummyCache
+) -> None:
+    async def raise_error(*args: object, **kwargs: object) -> pd.DataFrame:
+        raise RuntimeError("fail")
+
+    monkeypatch.setattr(ticket_loader, "load_tickets", raise_error)
+    with TestClient(create_app(cache=dummy_cache)) as client:
+        resp = client.get("/health")
+        assert resp.status_code == 503


### PR DESCRIPTION
## Summary
- create background task for ticket preload in `create_app`
- cancel preload task on shutdown
- update health tests to reflect new readiness handling

## Testing
- `pre-commit`

------
https://chatgpt.com/codex/tasks/task_e_688ad3da8b5c8320a4742ac2e32a8df9