### PR TITLE
Clarify health endpoint purpose in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -570,7 +570,8 @@ endpoints are responsive immediately.
 - `/chamados/por-dia` – totals for calendar heatmaps, refreshed every 10 minutes.
 - `/graphql/` – GraphQL API providing the same information.
 - `/cache/stats` – returns cache hit/miss metrics.
-- `/health` – quick check that the worker can reach the GLPI API.
+- `/health` – indicates only that the worker API is ready. Monitor GLPI
+  connectivity separately using metrics or a dedicated endpoint.
 
 Example `/metrics/overview` payload:
 

--- a/docs/glpi_tokens_guide.md
+++ b/docs/glpi_tokens_guide.md
@@ -132,9 +132,12 @@ Cobertura mínima de 85 % garantida no CI (GitHub Actions).
 ## 10 ▪️ Monitoramento de produção
 
 O contêiner **worker** possui `HEALTHCHECK` interno que executa `curl -I` no␊
-endpoint `/health` (método **HEAD**). O endpoint retorna **503** enquanto
-`app.state.ready` for `False` e **200** quando estiver pronto. A rota `GET`
-continua disponível para verificações manuais. Use:
+endpoint `/health` (método **HEAD**). Esse endpoint **não** verifica a
+conectividade com o GLPI: ele apenas informa se a API está pronta para receber
+requisições. Por isso, ele retorna **503** enquanto `app.state.ready` for
+`False` e **200** quando estiver pronto. A rota `GET` continua disponível para
+verificações manuais. Monitore a conectividade do GLPI separadamente, via
+métricas ou endpoint dedicado. Use:
 
 ```bash
 docker events --filter 'event=health_status' --since 30m

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -21,8 +21,10 @@ The dashboard aggregates GLPI service desk metrics using a FastAPI backend and a
    ```
 
    The command prints `✅ Conexão com GLPI bem-sucedida!` when the API accepts
-   the tokens. The worker's `/health` endpoint now reports **503** until
-   `app.state.ready` becomes `True`.
+   the tokens. The worker's `/health` endpoint only signals when the API is
+   ready to serve requests. It returns **503** while `app.state.ready` remains
+   `False`. Monitor GLPI connectivity separately using metrics or a dedicated
+   endpoint.
 
    Example snippet:
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -2,6 +2,10 @@
 
 This directory contains unit and integration tests for the GLPI dashboard.
 
-- `test_health_endpoint.py` verifies the `/health` endpoint.
+- `test_health_endpoint.py` verifies the `/health` endpoint. This route only
+  signals API readiness and does **not** guarantee connectivity with the GLPI
+  server.
   - A `HEAD /health` request returns `200` once the app reports it is ready.
-  - Before readiness (`app.state.ready` is `False`) the endpoint responds with `503`.
+  - Before readiness (`app.state.ready` is `False`) the endpoint responds with
+    `503`.
+  - Monitor the actual GLPI connection through metrics or a dedicated check.


### PR DESCRIPTION
## Summary
- clarify that `/health` only reports API readiness in onboarding docs
- explain separate GLPI connectivity monitoring in tokens guide
- update README and tests documentation with the same note

## Testing
- `pre-commit run --files docs/onboarding.md docs/glpi_tokens_guide.md README.md tests/README.md`
- `make test-backend` *(fails: TypeError in SQLAlchemy)*

------
https://chatgpt.com/codex/tasks/task_e_688ad66084c083209199907a70543c39

## Resumo por Sourcery

Esclarecer na documentação que o endpoint `/health` indica apenas a prontidão da API, e não a conectividade com o GLPI, e aconselhar o monitoramento separado das conexões GLPI em todos os guias e READMEs relevantes.

Documentação:
- Esclarecer que o endpoint `/health` apenas sinaliza a prontidão da API e não verifica a conectividade com o GLPI
- Recomendar o monitoramento da conectividade com o GLPI separadamente via métricas ou um endpoint dedicado
- Aplicar estes esclarecimentos no guia de integração, guia de tokens GLPI, README principal e documentação de teste

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clarify in documentation that the `/health` endpoint indicates only API readiness, not GLPI connectivity, and advise separate monitoring of GLPI connections across all relevant guides and READMEs

Documentation:
- Clarify that the `/health` endpoint only signals API readiness and does not verify GLPI connectivity
- Recommend monitoring GLPI connectivity separately via metrics or a dedicated endpoint
- Apply these clarifications across the onboarding guide, GLPI tokens guide, main README, and test documentation

</details>