### PR TITLE
Fix health check patch target in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,7 +44,7 @@ def glpi_unavailable(monkeypatch: pytest.MonkeyPatch):
         return 500
 
     monkeypatch.setattr(
-        "src.backend.api.worker_api.check_glpi_connection",
+        "backend.application.ticket_loader.check_glpi_connection",
         _fail,
     )
     yield

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -26,7 +26,7 @@ def test_api_token_required(monkeypatch, dummy_cache):
     async def ok():
         return 200
 
-    monkeypatch.setattr("src.backend.api.worker_api.check_glpi_connection", ok)
+    monkeypatch.setattr("backend.application.ticket_loader.check_glpi_connection", ok)
     app = create_app(cache=dummy_cache)
     client = TestClient(app)
 


### PR DESCRIPTION
## Summary
- point health check patches to `backend.application.ticket_loader.check_glpi_connection`

## Testing
- `pre-commit run --files tests/test_security.py tests/conftest.py`
- `pytest tests/test_security.py -q` *(fails: ModuleNotFoundError: No module named 'opentelemetry.exporter')*

------
https://chatgpt.com/codex/tasks/task_e_688add6929cc8320b2dee73e58c2a1ae

## Resumo por Sourcery

Corrige o caminho do módulo usado para patches de verificação de saúde nos testes para apontar para backend.application.ticket_loader.check_glpi_connection.

Correções de Bugs:
- Atualiza o alvo do monkeypatch em tests/conftest.py para backend.application.ticket_loader.check_glpi_connection
- Atualiza o alvo do monkeypatch em tests/test_security.py para backend.application.ticket_loader.check_glpi_connection

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix the module path used for health check patches in tests to point to backend.application.ticket_loader.check_glpi_connection.

Bug Fixes:
- Update monkeypatch target in tests/conftest.py to backend.application.ticket_loader.check_glpi_connection
- Update monkeypatch target in tests/test_security.py to backend.application.ticket_loader.check_glpi_connection

</details>