### PR TITLE
Fix health checks for async preload

### DIFF
--- a/tests/test_health_endpoint.py
+++ b/tests/test_health_endpoint.py
@@ -1,8 +1,6 @@
-import pandas as pd
 import pytest
 from fastapi.testclient import TestClient
 
-from backend.application import ticket_loader
 from tests.test_worker_api import DummyCache
 from worker import create_app
 
@@ -15,11 +13,12 @@ def dummy_cache() -> DummyCache:
 def test_head_health_ok(
     monkeypatch: pytest.MonkeyPatch, dummy_cache: DummyCache
 ) -> None:
-    async def fake_load(*args: object, **kwargs: object) -> pd.DataFrame:
-        return pd.DataFrame()
+    async def noop(*args: object, **kwargs: object) -> None:
+        return None
 
-    monkeypatch.setattr(ticket_loader, "load_tickets", fake_load)
+    monkeypatch.setattr("backend.application.ticket_loader.load_tickets", noop)
     with TestClient(create_app(cache=dummy_cache)) as client:
+        client.app.state.ready = True
         resp = client.head("/health")
         assert resp.status_code == 200
         assert resp.text == ""
@@ -28,10 +27,11 @@ def test_head_health_ok(
 def test_health_unavailable(
     monkeypatch: pytest.MonkeyPatch, dummy_cache: DummyCache
 ) -> None:
-    async def raise_error(*args: object, **kwargs: object) -> pd.DataFrame:
-        raise RuntimeError("fail")
+    async def noop(*args: object, **kwargs: object) -> None:
+        return None
 
-    monkeypatch.setattr(ticket_loader, "load_tickets", raise_error)
+    monkeypatch.setattr("backend.application.ticket_loader.load_tickets", noop)
     with TestClient(create_app(cache=dummy_cache)) as client:
+        client.app.state.ready = False
         resp = client.get("/health")
         assert resp.status_code == 503


### PR DESCRIPTION
## Summary
- adjust unit tests for new async preload behavior

## Testing
- `ruff check tests/test_health_endpoint.py tests/test_worker_api.py`
- `pytest --collect-only -k test_head_health_ok -vv` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_688add6842408320a904f6020f30db9d