### PR TITLE
Remove unused GLPI connectivity check

### DIFF
--- a/src/backend/application/ticket_loader.py
+++ b/src/backend/application/ticket_loader.py
@@ -9,7 +9,6 @@ import pandas as pd
 from fastapi import HTTPException
 from fastapi.responses import Response
 
-from backend.adapters.factory import create_glpi_session
 from backend.application.aggregated_metrics import (
     cache_aggregated_metrics,
     compute_aggregated,
@@ -175,21 +174,3 @@ async def stream_tickets(
     yield b"processing...\n"
     data = df.astype(object).where(pd.notna(df), None).to_dict(orient="records")
     yield json.dumps(data).encode()
-
-
-async def check_glpi_connection() -> int:
-    """Return HTTP status based on GLPI connectivity."""
-
-    if USE_MOCK_DATA:
-        return 200
-
-    session = create_glpi_session()
-    if session is None:
-        return 500
-
-    try:
-        async with session:
-            pass
-    except Exception:
-        return 500
-    return 200

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,17 +34,3 @@ def valid_tokens_env(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("GLPI_APP_TOKEN", "a" * 40)
     monkeypatch.setenv("GLPI_USER_TOKEN", "b" * 40)
     yield
-
-
-@pytest.fixture()
-def glpi_unavailable(monkeypatch: pytest.MonkeyPatch):
-    """Simulate an unreachable GLPI API for health checks."""
-
-    async def _fail() -> int:
-        return 500
-
-    monkeypatch.setattr(
-        "src.backend.api.worker_api.check_glpi_connection",
-        _fail,
-    )
-    yield

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -23,10 +23,6 @@ def test_sensitive_filter_masks_token(caplog):
 def test_api_token_required(monkeypatch, dummy_cache):
     monkeypatch.setenv("DASHBOARD_API_TOKEN", "secret" * 8)
 
-    async def ok():
-        return 200
-
-    monkeypatch.setattr("src.backend.api.worker_api.check_glpi_connection", ok)
     app = create_app(cache=dummy_cache)
     client = TestClient(app)
 

--- a/tests/test_ticket_loader.py
+++ b/tests/test_ticket_loader.py
@@ -28,7 +28,7 @@ async def test_load_and_translate_tickets_cache_hit(mocker):
 
     assert isinstance(result, list)
     assert all(isinstance(t, CleanTicketDTO) for t in result)
-    assert result[0].priority == "Low"
+    assert result[0].priority == "Baixa"
     cache.get.assert_awaited_once_with("tickets_clean")
 
 
@@ -63,22 +63,3 @@ async def test_load_and_translate_tickets_missing_fields(mocker):
     assert result[0].created_at is None
     assert result[1].priority is None
     assert result[1].created_at is None
-
-
-@pytest.mark.asyncio
-async def test_check_glpi_connection_mock(monkeypatch):
-    """Return 200 without session when mock data is enabled."""
-
-    called = False
-
-    def fake_create_session():
-        nonlocal called
-        called = True
-        raise RuntimeError("should not be called")
-
-    monkeypatch.setattr(ticket_loader, "USE_MOCK_DATA", True)
-    monkeypatch.setattr(ticket_loader, "create_glpi_session", fake_create_session)
-
-    status = await ticket_loader.check_glpi_connection()
-    assert status == 200
-    assert not called


### PR DESCRIPTION
## Summary
- drop deprecated `check_glpi_connection` helper
- update tests to stop patching the old helper
- expect Portuguese label "Baixa" in ticket loader test

## Testing
- `python -m pytest tests/test_ticket_loader.py::test_load_and_translate_tickets_cache_hit -q`
- `python -m pytest tests/test_ticket_loader.py::test_load_and_translate_tickets_missing_fields -q`

------
https://chatgpt.com/codex/tasks/task_e_688add6ad394832082676f89d765a999

## Resumo por Sourcery

Remover o auxiliar de conectividade GLPI não utilizado e limpar testes relacionados, enquanto atualiza os testes do carregador de tickets para esperar um rótulo de prioridade em português.

Melhorias:
- Remover o auxiliar `check_glpi_connection` obsoleto do código da aplicação

Testes:
- Remover testes e fixtures que mockavam ou aplicavam patch em `check_glpi_connection`
- Atualizar o teste de cache-hit do carregador de tickets para esperar "Baixa" em vez de "Low"
- Remover a mockagem redundante de `check_glpi_connection` em testes de segurança

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove the unused GLPI connectivity helper and clean up related tests, while updating ticket loader tests to expect a Portuguese priority label

Enhancements:
- Remove deprecated check_glpi_connection helper from the application code

Tests:
- Remove tests and fixtures that mocked or patched check_glpi_connection
- Update ticket loader cache-hit test to expect "Baixa" instead of "Low"
- Remove redundant check_glpi_connection mocking in security tests

</details>