### PR TITLE
Fix GLPI SDK imports

### DIFF
--- a/src/backend/infrastructure/glpi/glpi_sdk.py
+++ b/src/backend/infrastructure/glpi/glpi_sdk.py
@@ -5,16 +5,12 @@ from typing import Dict, List, Mapping, Optional
 from py_glpi.connection import GLPISession  # type: ignore
 from py_glpi.models import FilterCriteria, ResourceNotFound  # type: ignore
 from py_glpi.resources.tickets import Ticket, Tickets  # type: ignore
+from py_glpi.resources.users import Users  # type: ignore
 
-try:
-    from py_glpi.resources.users import Users  # type: ignore
-except ModuleNotFoundError:  # pragma: no cover - older py-glpi uses auth module
-    from py_glpi.resources.auth import Users  # type: ignore
-
-from shared.dto import STATUS_MAP as STATUS_LABEL_MAP
+from shared.dto import STATUS_MAP as STATUS_LABELS
 
 # Map ticket status names to their numeric codes used by the GLPI API.
-_STATUS_INV = {label.lower(): code for code, label in STATUS_LABEL_MAP.items()}
+_STATUS_INV = {label.lower(): code for code, label in STATUS_LABELS.items()}
 STATUS_MAP: Dict[str, int] = {
     "new": _STATUS_INV.get("new", 1),
     # The GLPI API uses "processing (assigned)" to represent tickets in the


### PR DESCRIPTION
## Summary
- import Users directly from `py_glpi.resources.users`
- align status mapping import with `shared.dto`

## Testing
- `ruff check src/backend/infrastructure/glpi/glpi_sdk.py`

------
https://chatgpt.com/codex/tasks/task_e_688afbd628608320a86c7785f55b5ae0

## Resumo por Sourcery

Corrige importações do SDK do GLPI e alinha a importação do mapeamento de status com shared.dto

Correções de Bugs:
- Importa Users diretamente de py_glpi.resources.users em vez de usar um módulo de autenticação de fallback

Melhorias:
- Renomeia o alias importado STATUS_MAP para STATUS_LABELS
- Atualiza o mapeamento de status interno para usar o novo alias STATUS_LABELS

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix GLPI SDK imports and align status mapping import with shared.dto

Bug Fixes:
- Import Users directly from py_glpi.resources.users instead of using a fallback auth module

Enhancements:
- Rename the imported STATUS_MAP alias to STATUS_LABELS
- Update the internal status mapping to use the new STATUS_LABELS alias

</details>