### PR TITLE
Run ruff and sort imports

### DIFF
--- a/dashboard_app.py
+++ b/dashboard_app.py
@@ -9,6 +9,8 @@ import pandas as pd
 from dash import Dash
 from flask import Flask
 from flask_caching import Cache
+from frontend.callbacks.callbacks import register_callbacks
+from frontend.layout.layout import build_layout
 
 from backend.core.settings import (
     DASH_PORT,
@@ -23,8 +25,6 @@ from backend.domain.exceptions import GLPIAPIError
 from backend.infrastructure.glpi import glpi_client_logging
 from backend.infrastructure.glpi.glpi_session import Credentials, GLPISession
 from backend.utils import process_raw
-from frontend.callbacks.callbacks import register_callbacks
-from frontend.layout.layout import build_layout
 
 __all__ = ["create_app", "main"]
 

--- a/src/frontend/callbacks/callbacks.py
+++ b/src/frontend/callbacks/callbacks.py
@@ -5,7 +5,6 @@ from typing import Any, Callable, Dict, List, Optional
 import dash_bootstrap_components as dbc  # type: ignore
 import pandas as pd
 from dash import Dash, Input, Output, callback
-
 from frontend.components.components import _status_fig, compute_ticket_stats
 
 

--- a/src/glpi_tools/__main__.py
+++ b/src/glpi_tools/__main__.py
@@ -78,8 +78,6 @@ def list_fields(itemtype: str, csv_path: Path | None) -> None:
         Console().print(f"Saved CSV to {csv_path}")
 
 
-import click
-
 @cli.command("count-by-level")
 @click.argument("levels", nargs=-1)
 def count_by_level(levels: tuple[str]) -> None:

--- a/tests/test_dashboard_components.py
+++ b/tests/test_dashboard_components.py
@@ -2,7 +2,6 @@ import pandas as pd
 import plotly.graph_objs as go
 import pytest
 from dash import html
-
 from frontend.components.components import _status_fig, compute_ticket_stats
 
 pytest.importorskip("pandas")


### PR DESCRIPTION
## Summary
- apply ruff --fix to several modules
- resort imports

## Testing
- `pre-commit run --files dashboard_app.py src/frontend/callbacks/callbacks.py src/glpi_tools/__main__.py tests/test_dashboard_components.py tests/test_glpi_sdk.py tests/test_sanitization.py`
- `pytest tests/test_dashboard_components.py tests/test_glpi_sdk.py tests/test_sanitization.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688afbd8835c832096d8fc5daeb6d3e7