### PR TITLE
Fix tests lint warnings and update import rewriting

### DIFF
--- a/scripts/refactor/update_imports.py
+++ b/scripts/refactor/update_imports.py
@@ -10,10 +10,10 @@ logging.basicConfig(level=logging.DEBUG)
 
 
 def rewrite_imports(src: str, mapping: dict[str, str]) -> str:
-    return next(
-        (src.replace(old, new) for old, new in mapping.items() if old in src),
-        src,
-    )
+    """Rewrite import statements according to a mapping."""
+    module = cst.parse_module(src)
+    transformed = module.visit(_ImportTransformer(mapping))
+    return transformed.code
 
 
 class _ImportTransformer(cst.CSTTransformer):

--- a/tests/refactor/test_update_imports.py
+++ b/tests/refactor/test_update_imports.py
@@ -21,8 +21,7 @@ class Example:
 
 def test_no_match():
     src = "import some_other_module"
-    expected = "import some_other_module"
-    assert rewrite_imports(src, MAPPING).strip() == expected
+    assert rewrite_imports(src, MAPPING).strip() == src
 
 
 def test_partial_match():


### PR DESCRIPTION
## Summary
- refine `rewrite_imports` to use `libcst` transformer
- clean up unused variable in `test_no_match`
- keep the rest of the import rewrite tests intact

## Testing
- `pytest tests/refactor/test_update_imports.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688afbda1f8883209ee01f579455adc6

## Resumo por Sourcery

Refatorar a reescrita de importações para usar um transformador libCST e atualizar testes relacionados

Melhorias:
- Usar o parser libCST e CSTTransformer em rewrite_imports em vez de substituição ingênua de string
- Adicionar docstring para rewrite_imports para descrever seu comportamento

Testes:
- Remover variável `expected` não utilizada em test_no_match e simplificar sua asserção

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor import rewriting to use a libCST transformer and update related tests

Enhancements:
- Use libCST parser and CSTTransformer in rewrite_imports instead of naive string replacement
- Add docstring for rewrite_imports to describe its behavior

Tests:
- Remove unused expected variable in test_no_match and simplify its assertion

</details>