### PR TITLE
Update pact-python SSL guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,17 +366,6 @@ More setup tips—including offline usage with mock data—are documented in
 [docs/dev_performance_guide.md](docs/dev_performance_guide.md) for
 strategies to pre-build Docker images and cache Python wheels.
 
-### SSL Certificate Issues with pact-python Installation
-
-Corporate proxies that inspect TLS traffic may cause `pip install pact-python`
-to fail with `CERTIFICATE_VERIFY_FAILED`. Provide the company's root certificate
-export REQUESTS_CA_BUNDLE=/path/to/company-ca.pem
-export SSL_CERT_FILE=$REQUESTS_CA_BUNDLE
-pip install pact-python
-
-Refer back to the
-[Installing Dependencies Behind a Proxy or Offline](#installing-dependencies-behind-a-proxy-or-offline)
-section for more proxy configuration tips.
 
 ## Instalação em rede restrita
 
@@ -430,7 +419,7 @@ export NODE_EXTRA_CA_CERTS=$REQUESTS_CA_BUNDLE
 pip install pact-python
 ```
 
-See the [Installing dependencies offline](#installing-dependencies-offline)
+See the [Installing Dependencies Behind a Proxy or Offline](#installing-dependencies-behind-a-proxy-or-offline)
 section above for proxy variables.
 
 ## GitHub access


### PR DESCRIPTION
## Summary
- clarify instructions for installing pact-python behind TLS inspection
- reference REQUESTS_CA_BUNDLE and NODE_EXTRA_CA_CERTS in README

## Testing
- `pre-commit run --files README.md docs/DEV_SETUP.md`

------
https://chatgpt.com/codex/tasks/task_e_688b082425308320aee7ec1525c0edd7

## Resumo por Sourcery

Melhorar a orientação de instalação do pact-python para ambientes com inspeção TLS, removendo a seção dedicada a SSL, referenciando REQUESTS_CA_BUNDLE e NODE_EXTRA_CA_CERTS, e consolidando as instruções de proxy/SSL sob a seção principal de configuração de dependências.

Documentação:
- Esclarecer as instruções para instalar o pact-python por trás de proxies corporativos com inspeção TLS
- Referenciar as variáveis de ambiente REQUESTS_CA_BUNDLE e NODE_EXTRA_CA_CERTS no README
- Consolidar as dicas de configuração de proxy na seção existente de instalação de proxy/offline

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve pact-python installation guidance for environments with TLS inspection by removing the dedicated SSL section, referencing REQUESTS_CA_BUNDLE and NODE_EXTRA_CA_CERTS, and consolidating proxy/SSL instructions under the main dependency configuration section.

Documentation:
- Clarify instructions for installing pact-python behind TLS-inspecting corporate proxies
- Reference REQUESTS_CA_BUNDLE and NODE_EXTRA_CA_CERTS environment variables in the README
- Consolidate proxy configuration tips under the existing proxy/offline installation section

</details>