### PR TITLE
feat: initialize new modular skeleton

### DIFF
--- a/glpi_dashboard_novo/docker-compose.new.yml
+++ b/glpi_dashboard_novo/docker-compose.new.yml
@@ -1,0 +1,28 @@
+version: "3.9"
+services:
+  backend:
+    build:
+      context: ./glpi_dashboard_novo
+      dockerfile: docker/backend/Dockerfile
+    volumes:
+      - ./glpi_dashboard_novo/src/backend:/app
+    command: ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+    ports:
+      - "8000:8000"
+    depends_on:
+      - redis
+  frontend:
+    build:
+      context: ./glpi_dashboard_novo
+      dockerfile: docker/frontend/Dockerfile
+    volumes:
+      - ./glpi_dashboard_novo/src/frontend:/app
+    command: ["python", "app.py"]
+    ports:
+      - "8050:8050"
+    depends_on:
+      - backend
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"

--- a/glpi_dashboard_novo/docker/backend/Dockerfile
+++ b/glpi_dashboard_novo/docker/backend/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY ../../requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/glpi_dashboard_novo/docker/frontend/Dockerfile
+++ b/glpi_dashboard_novo/docker/frontend/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY ../../requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt
+CMD ["python", "app.py"]

--- a/glpi_dashboard_novo/requirements.txt
+++ b/glpi_dashboard_novo/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn[standard]
+dash
+redis

--- a/glpi_dashboard_novo/src/backend/main.py
+++ b/glpi_dashboard_novo/src/backend/main.py
@@ -1,0 +1,14 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+
+@app.get("/")
+async def root() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/glpi_dashboard_novo/src/frontend/app.py
+++ b/glpi_dashboard_novo/src/frontend/app.py
@@ -1,0 +1,9 @@
+import dash
+from dash import html
+
+app = dash.Dash(__name__)
+
+app.layout = html.Div([html.H1("GLPI Dashboard Novo")])
+
+if __name__ == "__main__":
+    app.run_server(host="0.0.0.0", port=8050, debug=True)


### PR DESCRIPTION
## Summary
- scaffold `glpi_dashboard_novo` directory for clean rebuild
- add simple FastAPI backend
- add minimal Dash frontend
- include Dockerfiles and `docker-compose.new.yml` for backend, frontend and Redis
- add basic requirements file for new environment

## Testing
- `pre-commit run --files glpi_dashboard_novo/src/backend/main.py glpi_dashboard_novo/src/frontend/app.py glpi_dashboard_novo/docker-compose.new.yml glpi_dashboard_novo/docker/backend/Dockerfile glpi_dashboard_novo/docker/frontend/Dockerfile glpi_dashboard_novo/requirements.txt`
- `pytest -q` *(fails: unrecognized arguments --cov=./ --cov-report=term-missing)*

------
https://chatgpt.com/codex/tasks/task_e_688b204c851c8320a47113bfb4160eed