### PR TITLE
Port metrics endpoints to new_project

### DIFF
--- a/docs/REFACTOR_LOG.md
+++ b/docs/REFACTOR_LOG.md
@@ -66,3 +66,6 @@ Descrição: Script auxilia na movimentação de módulos Python utilizando a bi
 - Adicionado `new_project/Dockerfile` (167 bytes) e `new_project/docker-compose.yml` (107 bytes) para um setup simplificado.
 - Copias de `.env.example` adicionadas em `new_project/.env.example` (2623 bytes) e `new_project/frontend/.env.example` (184 bytes).
 - `new_project/backend/main.py` (109 bytes) contem worker FastAPI minimo.
+
+## \ud83d\udcc6 Atualizacao 2025-07-31 (metrics)
+- `new_project/backend/main.py` (4683 bytes) passou a incluir rotas `metrics/overview` e `metrics/level`. As fun\u00e7\u00f5es derivam de `app/api/metrics.py`.

--- a/new_project/backend/main.py
+++ b/new_project/backend/main.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pandas as pd
 from fastapi import FastAPI
+from pydantic import BaseModel, Field
 
 from backend.core.settings import (
     GLPI_APP_TOKEN,
@@ -41,6 +42,65 @@ def calculate_metrics(df: pd.DataFrame) -> dict[str, int]:
     return {"total": int(total), "opened": int(opened), "closed": int(closed)}
 
 
+class MetricsOverview(BaseModel):
+    """Summary of key ticket metrics."""
+
+    open_tickets: dict[str, int] = Field(default_factory=dict)
+    tickets_closed_this_month: dict[str, int] = Field(default_factory=dict)
+    status_distribution: dict[str, int] = Field(default_factory=dict)
+
+
+class LevelMetrics(BaseModel):
+    """Metrics for a specific support level."""
+
+    open_tickets: int = 0
+    resolved_this_month: int = 0
+    status_distribution: dict[str, int] = Field(default_factory=dict)
+
+
+def compute_overview(df: pd.DataFrame) -> MetricsOverview:
+    """Return metrics grouped by support level."""
+
+    df["status"] = df.get("status", pd.Series(dtype=str)).astype(str).str.lower()
+    open_mask = ~df["status"].isin(["closed", "solved"])
+    open_by_level = (
+        df[open_mask].groupby("group", observed=True).size().astype(int).to_dict()
+    )
+
+    closed_mask = df["status"].isin(["closed", "solved"])
+    closed_by_level = (
+        df[closed_mask].groupby("group", observed=True).size().astype(int).to_dict()
+    )
+    status_counts = df["status"].value_counts().astype(int).to_dict()
+
+    return MetricsOverview(
+        open_tickets=open_by_level,
+        tickets_closed_this_month=closed_by_level,
+        status_distribution=status_counts,
+    )
+
+
+def compute_level_metrics(df: pd.DataFrame, level: str) -> LevelMetrics:
+    """Return metrics for a single support level."""
+
+    df["status"] = df.get("status", pd.Series(dtype=str)).astype(str).str.lower()
+    level_df = df[df.get("group", pd.Series(dtype=str)) == level]
+
+    open_mask = ~level_df["status"].isin(["closed", "solved"])
+    open_count = int(level_df[open_mask].shape[0])
+
+    closed_mask = level_df["status"].isin(["closed", "solved"])
+    resolved_count = int(level_df[closed_mask].shape[0])
+
+    status_counts = level_df["status"].value_counts().astype(int).to_dict()
+
+    return LevelMetrics(
+        open_tickets=open_count,
+        resolved_this_month=resolved_count,
+        status_distribution=status_counts,
+    )
+
+
 @app.get("/tickets")
 async def list_tickets() -> list[dict[str, object]]:
     """Fetch tickets from GLPI and return normalized JSON records."""
@@ -59,6 +119,27 @@ async def metrics() -> dict[str, int]:
         records = await session.get_all_paginated("Ticket")
     df = process_raw(records)
     return calculate_metrics(df)
+
+
+@app.get("/metrics/overview", response_model=MetricsOverview)
+async def metrics_overview() -> MetricsOverview:
+    """Return aggregated ticket metrics."""
+
+    async with create_session() as session:
+        records = await session.get_all_paginated("Ticket")
+    df = process_raw(records)
+    return compute_overview(df)
+
+
+@app.get("/metrics/level/{level}", response_model=LevelMetrics)
+async def metrics_level(level: str) -> LevelMetrics:
+    """Return metrics for a specific support level."""
+
+    async with create_session() as session:
+        records = await session.get_all_paginated("Ticket")
+    df = process_raw(records)
+    normalized = level.upper()
+    return compute_level_metrics(df, normalized)
 
 
 if __name__ == "__main__":  # pragma: no cover - manual run

--- a/new_project/tests/backend/test_main.py
+++ b/new_project/tests/backend/test_main.py
@@ -87,3 +87,23 @@ def test_metrics_endpoint(client: TestClient) -> None:
     resp = client.get("/metrics")
     assert resp.status_code == 200
     assert resp.json() == {"total": 2, "opened": 1, "closed": 1}
+
+
+def test_metrics_overview_endpoint(client: TestClient) -> None:
+    resp = client.get("/metrics/overview")
+    assert resp.status_code == 200
+    assert resp.json() == {
+        "open_tickets": {"N1": 1},
+        "tickets_closed_this_month": {"N1": 1},
+        "status_distribution": {"new": 1, "closed": 1},
+    }
+
+
+def test_metrics_level_endpoint(client: TestClient) -> None:
+    resp = client.get("/metrics/level/N1")
+    assert resp.status_code == 200
+    assert resp.json() == {
+        "open_tickets": 1,
+        "resolved_this_month": 1,
+        "status_distribution": {"new": 1, "closed": 1},
+    }


### PR DESCRIPTION
## Summary
- add metrics aggregation helpers in new_project backend
- expose `/metrics/overview` and `/metrics/level` routes
- update unit tests
- document refactor in REFACTOR_LOG

## Testing
- `pytest -q new_project/tests/backend/test_main.py`

------
https://chatgpt.com/codex/tasks/task_e_688b340122348320baf11ba10f69a807

## Resumo por Sourcery

Adiciona endpoints de visão geral e por nível de métricas com auxiliares de agregação

Novas Funcionalidades:
- Implementa as funções auxiliares `compute_overview` e `compute_level_metrics` para agregação de métricas de tickets
- Expõe os endpoints `/metrics/overview` e `/metrics/level/{level}` retornando métricas agregadas

Documentação:
- Documenta as novas rotas de métricas no log de refatoração

Testes:
- Adiciona testes unitários para os endpoints `metrics_overview` e `metrics_level`

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add metrics overview and per-level endpoints with aggregation helpers

New Features:
- Introduce compute_overview and compute_level_metrics helpers for ticket metrics aggregation
- Expose /metrics/overview and /metrics/level/{level} endpoints returning aggregated metrics

Documentation:
- Document the new metrics routes in the refactor log

Tests:
- Add unit tests for metrics_overview and metrics_level endpoints

</details>