### PR TITLE
Add health endpoint and tests

### DIFF
--- a/new_project/README.md
+++ b/new_project/README.md
@@ -5,6 +5,8 @@ This folder contains a minimal setup for experiments separate from the main GLPI
 ## Structure
 
 - `backend/` – FastAPI worker exposing a `/health` endpoint.
+  You can check the server status by visiting `/health`, which returns
+  `{"status": "ok"}`.
 - `frontend/` – placeholder React application (see `docs/frontend_architecture.md` for conventions).
 - `shared/` – utilities shared between backend and frontend.
 

--- a/new_project/backend/main.py
+++ b/new_project/backend/main.py
@@ -19,6 +19,13 @@ from backend.infrastructure.glpi.normalization import process_raw
 app = FastAPI()
 
 
+@app.get("/health")
+async def health() -> dict[str, str]:
+    """Simple health check used for smoke tests."""
+
+    return {"status": "ok"}
+
+
 def create_session() -> GLPISession:
     """Instantiate ``GLPISession`` using settings from ``backend.core``."""
 

--- a/new_project/tests/backend/test_main.py
+++ b/new_project/tests/backend/test_main.py
@@ -74,6 +74,12 @@ def client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
     return TestClient(backend_main.app)
 
 
+def test_health_endpoint(client: TestClient) -> None:
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}
+
+
 def test_tickets_endpoint(client: TestClient) -> None:
     resp = client.get("/tickets")
     assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- implement `/health` route in new_project backend
- document the route in the new_project README
- add `test_health_endpoint` to backend tests

## Testing
- `pytest new_project/tests/backend/test_main.py::test_health_endpoint -q`

------
https://chatgpt.com/codex/tasks/task_e_688b3ba173bc8320997c878519bacfae