### PR TITLE
Refactor metrics helper usage

### DIFF
--- a/new_project/backend/main.py
+++ b/new_project/backend/main.py
@@ -4,8 +4,14 @@ from __future__ import annotations
 
 import pandas as pd
 from fastapi import FastAPI
-from pydantic import BaseModel, Field
 
+# Import shared metric helpers from the main API module
+from app.api.metrics import (
+    LevelMetrics,
+    MetricsOverview,
+    compute_level_metrics,
+    compute_overview,
+)
 from backend.core.settings import (
     GLPI_APP_TOKEN,
     GLPI_BASE_URL,
@@ -49,65 +55,6 @@ def calculate_metrics(df: pd.DataFrame) -> dict[str, int]:
     return {"total": int(total), "opened": int(opened), "closed": int(closed)}
 
 
-class MetricsOverview(BaseModel):
-    """Summary of key ticket metrics."""
-
-    open_tickets: dict[str, int] = Field(default_factory=dict)
-    tickets_closed_this_month: dict[str, int] = Field(default_factory=dict)
-    status_distribution: dict[str, int] = Field(default_factory=dict)
-
-
-class LevelMetrics(BaseModel):
-    """Metrics for a specific support level."""
-
-    open_tickets: int = 0
-    resolved_this_month: int = 0
-    status_distribution: dict[str, int] = Field(default_factory=dict)
-
-
-def compute_overview(df: pd.DataFrame) -> MetricsOverview:
-    """Return metrics grouped by support level."""
-
-    df["status"] = df.get("status", pd.Series(dtype=str)).astype(str).str.lower()
-    open_mask = ~df["status"].isin(["closed", "solved"])
-    open_by_level = (
-        df[open_mask].groupby("group", observed=True).size().astype(int).to_dict()
-    )
-
-    closed_mask = df["status"].isin(["closed", "solved"])
-    closed_by_level = (
-        df[closed_mask].groupby("group", observed=True).size().astype(int).to_dict()
-    )
-    status_counts = df["status"].value_counts().astype(int).to_dict()
-
-    return MetricsOverview(
-        open_tickets=open_by_level,
-        tickets_closed_this_month=closed_by_level,
-        status_distribution=status_counts,
-    )
-
-
-def compute_level_metrics(df: pd.DataFrame, level: str) -> LevelMetrics:
-    """Return metrics for a single support level."""
-
-    df["status"] = df.get("status", pd.Series(dtype=str)).astype(str).str.lower()
-    level_df = df[df.get("group", pd.Series(dtype=str)) == level]
-
-    open_mask = ~level_df["status"].isin(["closed", "solved"])
-    open_count = int(level_df[open_mask].shape[0])
-
-    closed_mask = level_df["status"].isin(["closed", "solved"])
-    resolved_count = int(level_df[closed_mask].shape[0])
-
-    status_counts = level_df["status"].value_counts().astype(int).to_dict()
-
-    return LevelMetrics(
-        open_tickets=open_count,
-        resolved_this_month=resolved_count,
-        status_distribution=status_counts,
-    )
-
-
 @app.get("/tickets")
 async def list_tickets() -> list[dict[str, object]]:
     """Fetch tickets from GLPI and return normalized JSON records."""
@@ -130,23 +77,17 @@ async def metrics() -> dict[str, int]:
 
 @app.get("/metrics/overview", response_model=MetricsOverview)
 async def metrics_overview() -> MetricsOverview:
-    """Return aggregated ticket metrics."""
+    """Return aggregated ticket metrics using shared helpers."""
 
-    async with create_session() as session:
-        records = await session.get_all_paginated("Ticket")
-    df = process_raw(records)
-    return compute_overview(df)
+    return await compute_overview()
 
 
 @app.get("/metrics/level/{level}", response_model=LevelMetrics)
 async def metrics_level(level: str) -> LevelMetrics:
-    """Return metrics for a specific support level."""
+    """Return metrics for a specific support level using shared helpers."""
 
-    async with create_session() as session:
-        records = await session.get_all_paginated("Ticket")
-    df = process_raw(records)
     normalized = level.upper()
-    return compute_level_metrics(df, normalized)
+    return await compute_level_metrics(normalized)
 
 
 if __name__ == "__main__":  # pragma: no cover - manual run

--- a/new_project/tests/backend/test_main.py
+++ b/new_project/tests/backend/test_main.py
@@ -70,6 +70,28 @@ class DummySession:
 @pytest.fixture
 def client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
     monkeypatch.setattr(backend_main, "create_session", lambda: DummySession())
+
+    async def fake_overview(
+        *args: object, **kwargs: object
+    ) -> backend_main.MetricsOverview:
+        return backend_main.MetricsOverview(
+            open_tickets={"N1": 1},
+            tickets_closed_this_month={"N1": 1},
+            status_distribution={"new": 1, "closed": 1},
+        )
+
+    async def fake_level_metrics(
+        *args: object, **kwargs: object
+    ) -> backend_main.LevelMetrics:
+        return backend_main.LevelMetrics(
+            open_tickets=1,
+            resolved_this_month=1,
+            status_distribution={"new": 1, "closed": 1},
+        )
+
+    monkeypatch.setattr(backend_main, "compute_overview", fake_overview)
+    monkeypatch.setattr(backend_main, "compute_level_metrics", fake_level_metrics)
+
     return TestClient(backend_main.app)
 
 


### PR DESCRIPTION
## Summary
- reuse `compute_overview` and `compute_level_metrics` from main API module in mini backend
- call the shared helpers directly in the `/metrics/overview` and `/metrics/level` routes
- update tests to monkeypatch the new helpers

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for several dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688b3dd73b808320aa81d1850dece0ac