### PR TITLE
Refactor metrics to self-contained module

### DIFF
--- a/new_project/backend/main.py
+++ b/new_project/backend/main.py
@@ -4,8 +4,14 @@ from __future__ import annotations
 
 import pandas as pd
 from fastapi import FastAPI
-from pydantic import BaseModel, Field
 
+# Import shared metric helpers from the main API module
+from .metrics import (
+    LevelMetrics,
+    MetricsOverview,
+    compute_level_metrics,
+    compute_overview,
+)
 from backend.core.settings import (
     GLPI_APP_TOKEN,
     GLPI_BASE_URL,
@@ -47,65 +53,6 @@ def calculate_metrics(df: pd.DataFrame) -> dict[str, int]:
         closed = df["status"].astype(str).str.lower().isin(["closed", "solved"]).sum()
     opened = total - int(closed)
     return {"total": int(total), "opened": int(opened), "closed": int(closed)}
-
-
-class MetricsOverview(BaseModel):
-    """Summary of key ticket metrics."""
-
-    open_tickets: dict[str, int] = Field(default_factory=dict)
-    tickets_closed_this_month: dict[str, int] = Field(default_factory=dict)
-    status_distribution: dict[str, int] = Field(default_factory=dict)
-
-
-class LevelMetrics(BaseModel):
-    """Metrics for a specific support level."""
-
-    open_tickets: int = 0
-    resolved_this_month: int = 0
-    status_distribution: dict[str, int] = Field(default_factory=dict)
-
-
-def compute_overview(df: pd.DataFrame) -> MetricsOverview:
-    """Return metrics grouped by support level."""
-
-    df["status"] = df.get("status", pd.Series(dtype=str)).astype(str).str.lower()
-    open_mask = ~df["status"].isin(["closed", "solved"])
-    open_by_level = (
-        df[open_mask].groupby("group", observed=True).size().astype(int).to_dict()
-    )
-
-    closed_mask = df["status"].isin(["closed", "solved"])
-    closed_by_level = (
-        df[closed_mask].groupby("group", observed=True).size().astype(int).to_dict()
-    )
-    status_counts = df["status"].value_counts().astype(int).to_dict()
-
-    return MetricsOverview(
-        open_tickets=open_by_level,
-        tickets_closed_this_month=closed_by_level,
-        status_distribution=status_counts,
-    )
-
-
-def compute_level_metrics(df: pd.DataFrame, level: str) -> LevelMetrics:
-    """Return metrics for a single support level."""
-
-    df["status"] = df.get("status", pd.Series(dtype=str)).astype(str).str.lower()
-    level_df = df[df.get("group", pd.Series(dtype=str)) == level]
-
-    open_mask = ~level_df["status"].isin(["closed", "solved"])
-    open_count = int(level_df[open_mask].shape[0])
-
-    closed_mask = level_df["status"].isin(["closed", "solved"])
-    resolved_count = int(level_df[closed_mask].shape[0])
-
-    status_counts = level_df["status"].value_counts().astype(int).to_dict()
-
-    return LevelMetrics(
-        open_tickets=open_count,
-        resolved_this_month=resolved_count,
-        status_distribution=status_counts,
-    )
 
 
 @app.get("/tickets")

--- a/new_project/backend/metrics.py
+++ b/new_project/backend/metrics.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import pandas as pd
+from pydantic import BaseModel, Field
+
+
+class MetricsOverview(BaseModel):
+    """Summary of key ticket metrics."""
+
+    open_tickets: dict[str, int] = Field(default_factory=dict)
+    tickets_closed_this_month: dict[str, int] = Field(default_factory=dict)
+    status_distribution: dict[str, int] = Field(default_factory=dict)
+
+
+class LevelMetrics(BaseModel):
+    """Metrics for a specific support level."""
+
+    open_tickets: int = 0
+    resolved_this_month: int = 0
+    status_distribution: dict[str, int] = Field(default_factory=dict)
+
+
+def compute_overview(df: pd.DataFrame) -> MetricsOverview:
+    """Return metrics grouped by support level."""
+
+    df["status"] = df.get("status", pd.Series(dtype=str)).astype(str).str.lower()
+    open_mask = ~df["status"].isin(["closed", "solved"])
+    open_by_level = (
+        df[open_mask].groupby("group", observed=True).size().astype(int).to_dict()
+    )
+
+    closed_mask = df["status"].isin(["closed", "solved"])
+    closed_by_level = (
+        df[closed_mask].groupby("group", observed=True).size().astype(int).to_dict()
+    )
+    status_counts = df["status"].value_counts().astype(int).to_dict()
+
+    return MetricsOverview(
+        open_tickets=open_by_level,
+        tickets_closed_this_month=closed_by_level,
+        status_distribution=status_counts,
+    )
+
+
+def compute_level_metrics(df: pd.DataFrame, level: str) -> LevelMetrics:
+    """Return metrics for a single support level."""
+
+    df["status"] = df.get("status", pd.Series(dtype=str)).astype(str).str.lower()
+    level_df = df[df.get("group", pd.Series(dtype=str)) == level]
+
+    open_mask = ~level_df["status"].isin(["closed", "solved"])
+    open_count = int(level_df[open_mask].shape[0])
+
+    closed_mask = level_df["status"].isin(["closed", "solved"])
+    resolved_count = int(level_df[closed_mask].shape[0])
+
+    status_counts = level_df["status"].value_counts().astype(int).to_dict()
+
+    return LevelMetrics(
+        open_tickets=open_count,
+        resolved_this_month=resolved_count,
+        status_distribution=status_counts,
+    )

--- a/new_project/tests/backend/test_main.py
+++ b/new_project/tests/backend/test_main.py
@@ -8,6 +8,7 @@ from fastapi.testclient import TestClient
 
 ROOT = Path(__file__).resolve().parents[3]
 sys.path.insert(0, str(ROOT / "src"))
+sys.path.insert(0, str(ROOT))
 
 # Load glpi_session module without executing package __init__ that depends on
 # optional py_glpi.


### PR DESCRIPTION
## Summary
- add local `metrics` utilities for overview and level calculations
- call these helpers directly from the new backend routes
- simplify backend tests and ensure package discovery works

## Testing
- `pytest -q new_project/tests/backend/test_main.py`


------
https://chatgpt.com/codex/tasks/task_e_688b3dd73b808320aa81d1850dece0ac

## Resumo por Sourcery

Extrair a lógica das métricas de tickets para um módulo dedicado e atualizar os testes para a descoberta adequada do pacote.

Melhorias:
- Mover modelos de métricas e funções auxiliares (MetricsOverview, LevelMetrics, compute_overview, compute_level_metrics) de main.py para backend/metrics.py
- Adaptar as rotas de tickets do backend em main.py para usar as novas utilidades de métricas

Testes:
- Adicionar a raiz do projeto a sys.path nos testes de backend para garantir a descoberta do novo módulo de métricas

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Extract ticket metrics logic into a dedicated module and update tests for proper package discovery.

Enhancements:
- Move metrics models and helper functions (MetricsOverview, LevelMetrics, compute_overview, compute_level_metrics) from main.py into backend/metrics.py
- Adapt backend ticket routes in main.py to use the new metrics utilities

Tests:
- Add project root to sys.path in backend tests to ensure discovery of the new metrics module

</details>