### PR TITLE
Add env file to new_project compose

### DIFF
--- a/new_project/README.md
+++ b/new_project/README.md
@@ -11,3 +11,9 @@ This folder contains a minimal setup for experiments separate from the main GLPI
 - `shared/` – utilities shared between backend and frontend.
 
 The directory includes basic Docker files to start the backend quickly.
+
+## Environment
+
+The Docker Compose file looks for a `.env` file in the project root using
+`env_file: ../.env`. Copy `../.env.example` to `../.env` and fill in the
+required settings before starting the containers.

--- a/new_project/docker-compose.yml
+++ b/new_project/docker-compose.yml
@@ -4,6 +4,8 @@ services:
     build:
       context: ..
       dockerfile: new_project/docker/backend/Dockerfile
+    env_file:
+      - ../.env
     environment:
       PYTHONPATH: /app:/src
     volumes:
@@ -16,5 +18,7 @@ services:
       - redis
   redis:
     image: redis:7-alpine
+    env_file:
+      - ../.env
     ports:
       - "6379:6379"


### PR DESCRIPTION
## Summary
- reference ../.env for each service in new_project compose file
- mention expected env location in new_project README

## Testing
- `pre-commit run --files new_project/docker-compose.yml new_project/README.md`
- `pytest new_project/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_688b42cfd73883208b33a3963b69a58e

## Resumo por Sourcery

Referenciar um arquivo .env compartilhado na configuração docker-compose do new_project e atualizar o README para documentar seu uso

Melhorias:
- Configurar docker-compose para carregar variáveis de ambiente de ../.env para os serviços

Documentação:
- Adicionar seção de Ambiente no README para instruir a cópia de ./.env.example para ../.env antes de iniciar os contêineres

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Reference a shared .env file in the new_project docker-compose configuration and update the README to document its usage

Enhancements:
- Configure docker-compose to load environment variables from ../.env for services

Documentation:
- Add Environment section in README to instruct copying ./.env.example to ../.env before starting containers

</details>