### PR TITLE
Update metrics paths in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,9 +494,9 @@ endpoints are responsive immediately.
 - `/tickets/stream` – Server‑Sent Events (SSE) stream of progress followed by the JSON payload.
 - `/metrics` – summary with `total`, `opened` and `closed` counts.
 - `/metrics/aggregated` – counts grouped by status and technician, pre-computed by the worker.
-- `/metrics/overview` – dictionary with `open_tickets`,
+- `/metrics/aggregated` – dictionary with `open_tickets`,
   `tickets_closed_this_month` and `status_distribution`.
-- `/metrics/level/<level>` – same fields as `/metrics/overview` but scoped
+- `/metrics/levels/<level>` – same fields as `/metrics/aggregated` but scoped
   to a single support level.
 - `/metrics/levels` – mapping of levels to status counts stored in the
   `metrics_levels` cache.
@@ -506,7 +506,7 @@ endpoints are responsive immediately.
 - `/cache/stats` – returns cache hit/miss metrics.
 - `/health` – quick check that the worker can reach the GLPI API.
 
-Example `/metrics/overview` payload:
+Example `/metrics/aggregated` payload:
 
 ```json
 {
@@ -516,7 +516,7 @@ Example `/metrics/overview` payload:
 }
 ```
 
-The `/metrics/level/N1` endpoint yields the same fields scoped to the
+The `/metrics/levels/N1` endpoint yields the same fields scoped to the
 requested level. `/metrics/levels` returns a dictionary of levels mapped
 to status counts.
 

--- a/docs/developer_usage.md
+++ b/docs/developer_usage.md
@@ -76,9 +76,9 @@ Endpoints relevantes:
 - `/tickets` – lista completa de chamados
  - A resposta inclui os campos `priority` e `requester` em formato textual.
 - `/metrics` – contagem de abertos/fechados
-- `/metrics/overview` – retorna `open_tickets`,
+- `/metrics/aggregated` – retorna `open_tickets`,
   `tickets_closed_this_month` e `status_distribution`.
-- `/metrics/level/<nivel>` – mesmos campos do endpoint acima mas
+- `/metrics/levels/<nivel>` – mesmos campos do endpoint acima mas
   restritos ao nível informado.
 - `/metrics/levels` – dicionário com contagem de status por nível
   armazenado em `metrics_levels`.


### PR DESCRIPTION
## Summary
- update `/metrics/overview` references to `/metrics/aggregated`
- rename `/metrics/level/<level>` to `/metrics/levels/<level>`

## Testing
- `pre-commit run --files README.md docs/developer_usage.md`
- `pytest -o addopts='' -k "not test_dashboard_flows"` *(fails: ModuleNotFoundError: No module named 'libcst')*

------
https://chatgpt.com/codex/tasks/task_e_688b5af452288320987bd4b26a30395f

## Resumo por Sourcery

Atualizar a documentação para refletir os endpoints de métricas renomeados

Documentação:
- Mudar todas as referências de `/metrics/overview` para `/metrics/aggregated`
- Renomear referências de `/metrics/level/<level>` para `/metrics/levels/<level>` na documentação e exemplos

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update documentation to reflect renamed metrics endpoints

Documentation:
- Change all references of `/metrics/overview` to `/metrics/aggregated`
- Rename `/metrics/level/<level>` references to `/metrics/levels/<level>` in docs and examples

</details>