### PR TITLE
Update metrics overview endpoint

### DIFF
--- a/src/frontend/react_app/src/hooks/useMetricsOverview.ts
+++ b/src/frontend/react_app/src/hooks/useMetricsOverview.ts
@@ -18,7 +18,7 @@ export function useMetricsOverview() {
   const queryClient = useQueryClient()
   const query = useApiQuery<ApiMetricsOverview>(
     METRICS_QUERY_KEY,
-    '/metrics/overview',
+    '/metrics/aggregated',
     {
       refetchInterval: POLLING_INTERVAL_MS,
     },


### PR DESCRIPTION
## Summary
- update `useMetricsOverview` to fetch from `/metrics/aggregated`
- ensure metrics overview hook tests continue to pass

## Testing
- `NODE_ENV=test NEXT_PUBLIC_API_BASE_URL=http://localhost:8000 npm test -- src/hooks/__tests__/useMetricsOverview.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_688b5afa20dc832087b195d06d9e446f

## Resumo do Sourcery

Atualiza o hook de visão geral de métricas para usar o novo endpoint de métricas agregadas

Melhorias:
- Aponta useMetricsOverview para buscar de "/metrics/aggregated" em vez de "/metrics/overview"

Testes:
- Ajusta os testes do hook de visão geral de métricas para considerar o endpoint atualizado

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update the metrics overview hook to use the new aggregated metrics endpoint

Enhancements:
- Point useMetricsOverview to fetch from "/metrics/aggregated" instead of "/metrics/overview"

Tests:
- Adjust metrics overview hook tests to account for the updated endpoint

</details>