### PR TITLE
Add local backend modules for new project

### DIFF
--- a/new_project/backend/glpi_session.py
+++ b/new_project/backend/glpi_session.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel
+
+
+class Credentials(BaseModel):
+    """Authentication data for the GLPI API."""
+
+    app_token: str
+    user_token: str | None = None
+    username: str | None = None
+    password: str | None = None
+
+
+class GLPISession:
+    """Very small placeholder async session."""
+
+    def __init__(self, base_url: str, credentials: Credentials) -> None:
+        self.base_url = base_url
+        self.credentials = credentials
+
+    async def __aenter__(self) -> "GLPISession":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    async def get_all_paginated(
+        self, itemtype: str, page_size: int = 100, **params: Any
+    ) -> list[dict[str, Any]]:
+        """Return an empty result set.
+
+        Real logic should call the GLPI REST API.
+        """
+
+        return []

--- a/new_project/backend/normalization.py
+++ b/new_project/backend/normalization.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from typing import Iterable
+
+import pandas as pd
+
+
+def process_raw(data: Iterable[dict[str, object]] | pd.DataFrame) -> pd.DataFrame:
+    """Return a DataFrame representation of ``data``."""
+
+    if isinstance(data, pd.DataFrame):
+        return data.copy()
+    return pd.DataFrame(list(data))

--- a/new_project/backend/settings.py
+++ b/new_project/backend/settings.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from pydantic_settings import BaseSettings
+
+
+class Settings(BaseSettings):
+    """Minimal settings for the experimental backend."""
+
+    GLPI_BASE_URL: str = "http://localhost/apirest.php"
+    GLPI_APP_TOKEN: str = "dummy_app_token"
+    GLPI_USERNAME: str = "glpi"
+    GLPI_PASSWORD: str = "glpi"
+    GLPI_USER_TOKEN: str | None = None
+
+    class Config:
+        env_file = ".env"
+        extra = "ignore"
+
+
+settings = Settings()
+
+GLPI_BASE_URL = settings.GLPI_BASE_URL
+GLPI_APP_TOKEN = settings.GLPI_APP_TOKEN
+GLPI_USERNAME = settings.GLPI_USERNAME
+GLPI_PASSWORD = settings.GLPI_PASSWORD
+GLPI_USER_TOKEN = settings.GLPI_USER_TOKEN


### PR DESCRIPTION
## Summary
- provide simplified settings, GLPI session and normalization modules
- update the experimental backend to use the new modules
- adjust tests to load the package via importlib

## Testing
- `pre-commit run --files new_project/backend/main.py new_project/tests/backend/test_main.py new_project/backend/glpi_session.py new_project/backend/normalization.py new_project/backend/settings.py`
- `pytest new_project/tests/backend/test_main.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688b5b02e0648320b31f2b3ee04f0469

## Resumo por Sourcery

Adiciona módulos de backend locais para configurações (`settings`), sessão (`session`) e normalização (`normalization`), refatora os endpoints de métricas para usar esses módulos e ajusta os testes para carregar e referenciar a nova estrutura de pacotes.

Novas Funcionalidades:
- Introduz módulo de configurações local baseado em `Pydantic` para a configuração do `GLPI`
- Adiciona uma classe `GLPISession` "stubbed" (simulada) para gerenciar sessões assíncronas
- Cria um módulo de normalização para converter dados brutos da API em um `DataFrame`

Melhorias:
- Refatora os principais endpoints do backend para estabelecer sessões e normalizar dados antes de calcular as métricas de visão geral (`overview`) e de nível (`level`).

Testes:
- Atualiza `test_main.py` para importar o pacote `new_project` via `importlib` e ajusta as funções de métricas falsas para usar as novas classes `MetricsOverview` e `LevelMetrics`

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add local backend modules for settings, session, and normalization, refactor metrics endpoints to use these modules, and adjust tests to load and reference the new package structure

New Features:
- Introduce local Pydantic-based settings module for GLPI configuration
- Add a stubbed GLPISession class to handle async session management
- Create a normalization module to convert raw API data into DataFrame

Enhancements:
- Refactor backend main endpoints to establish sessions and normalize data before computing overview and level metrics

Tests:
- Update test_main.py to import new_project package via importlib and adjust fake metrics functions to use new MetricsOverview and LevelMetrics classes

</details>