### PR TITLE
Use local modules in new_project backend tests

### DIFF
--- a/new_project/backend/main.py
+++ b/new_project/backend/main.py
@@ -34,7 +34,7 @@ async def health() -> dict[str, str]:
 
 
 def create_session() -> GLPISession:
-    """Instantiate ``GLPISession`` using settings from ``backend.core``."""
+    """Instantiate ``GLPISession`` using settings from this package."""
 
     creds = Credentials(
         app_token=GLPI_APP_TOKEN,

--- a/new_project/tests/backend/test_main.py
+++ b/new_project/tests/backend/test_main.py
@@ -1,23 +1,8 @@
-import importlib
-import importlib.util
-import sys
-from pathlib import Path
-
 import pytest
 from fastapi.testclient import TestClient
 
-ROOT = Path(__file__).resolve().parents[3]
-PKG_SPEC = importlib.util.spec_from_file_location(
-    "new_project", ROOT / "new_project" / "__init__.py"
-)
-assert PKG_SPEC and PKG_SPEC.loader
-new_project_pkg = importlib.util.module_from_spec(PKG_SPEC)
-PKG_SPEC.loader.exec_module(new_project_pkg)
-new_project_pkg.__path__ = [str(ROOT / "new_project")]
-sys.modules["new_project"] = new_project_pkg
-
-backend_main = importlib.import_module("new_project.backend.main")
-from new_project.backend.metrics import LevelMetrics, MetricsOverview  # noqa: E402
+from new_project.backend import main as backend_main
+from new_project.backend.metrics import LevelMetrics, MetricsOverview
 
 
 class DummySession:


### PR DESCRIPTION
## Summary
- update comment in the FastAPI demo app
- simplify backend tests to import the package directly

## Testing
- `PYTHONPATH=$(pwd) pytest -q -p no:cov -c /tmp/empty.ini new_project/tests/backend/test_main.py`

------
https://chatgpt.com/codex/tasks/task_e_688b653886e083209666dece84ca9450

## Resumo por Sourcery

Simplificar testes de backend usando importações diretas de módulos locais e atualizar a docstring de `create_session` para referenciar o pacote atual.

Documentação:
- Atualizar a docstring de `create_session` para referenciar este pacote em vez de `backend.core`

Testes:
- Remover a configuração personalizada de `importlib` nos testes de backend e importar módulos diretamente do pacote

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Simplify backend tests by using direct local module imports and update the create_session docstring to reference the current package.

Documentation:
- Update create_session docstring to reference this package instead of backend.core

Tests:
- Remove custom importlib setup in backend tests and import modules directly from the package

</details>