### PR TITLE
Update metrics overview hook tests

### DIFF
--- a/src/frontend/react_app/src/hooks/__tests__/useMetricsOverview.test.tsx
+++ b/src/frontend/react_app/src/hooks/__tests__/useMetricsOverview.test.tsx
@@ -5,6 +5,22 @@ import { useApiQuery } from '../useApiQuery'
 
 jest.mock('../useApiQuery')
 
+test('calls aggregated metrics endpoint', () => {
+  ;(useApiQuery as jest.Mock).mockReturnValue({
+    data: { open_tickets: {}, tickets_closed_this_month: {} },
+    isLoading: false,
+    isError: false,
+    error: null,
+  })
+  const { wrapper } = createWrapper()
+  renderHook(() => useMetricsOverview(), { wrapper })
+  expect(useApiQuery).toHaveBeenCalledWith(
+    ['metrics-overview'],
+    '/metrics/aggregated',
+    expect.any(Object),
+  )
+})
+
 const createWrapper = () => {
   const queryClient = new QueryClient()
   return {


### PR DESCRIPTION
## Summary
- ensure `useMetricsOverview` requests the new `/metrics/aggregated` endpoint

## Testing
- `npx jest src/hooks/__tests__/useMetricsOverview.test.tsx --runTestsByPath`

------
https://chatgpt.com/codex/tasks/task_e_688b65372564832091d6b42cae001dac

## Resumo por Sourcery

Testes:
- Adiciona teste unitário garantindo que `useApiQuery` é chamado com '/metrics/aggregated' ao invocar `useMetricsOverview`

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Tests:
- Add unit test asserting useApiQuery is called with '/metrics/aggregated' when invoking useMetricsOverview

</details>