### PR TITLE
Fix metrics key names in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,7 +484,7 @@ python -m backend.application.metrics_worker
 
 When the FastAPI service starts it primes the Redis cache by calling
 `load_tickets()`. This fills the `chamados_por_data`,
-`metrics_aggregated`, `metrics_levels` and `metrics:overview` keys so
+`metrics_aggregated`, `metrics_levels` and `metrics:aggregated` keys so
 endpoints are responsive immediately.
 
 - The service exposes several endpoints:

--- a/docs/developer_usage.md
+++ b/docs/developer_usage.md
@@ -92,7 +92,7 @@ python -m glpi_tools count-by-level N1 N2
 ```
 
 O comando `load_tickets()` executado na inicialização preenche os
-redis-keys `metrics_aggregated`, `metrics_levels` e `metrics:overview`
+redis-keys `metrics_aggregated`, `metrics_levels` e `metrics:aggregated`
 para que esses endpoints respondam rapidamente já no primeiro acesso.
 
 Exemplo de retorno:


### PR DESCRIPTION
## Summary
- update cached key documentation from `metrics:overview` to `metrics:aggregated`

## Testing
- `pre-commit run --files README.md docs/developer_usage.md`
- `pytest -q` *(fails: 17 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_688b6536b3b8832093ed2fe69bab946f

## Resumo por Sourcery

Corrige a referência da chave de cache Redis na documentação de 'metrics:overview' para 'metrics:aggregated'

Documentação:
- Substitui 'metrics:overview' por 'metrics:aggregated' em README.md
- Substitui 'metrics:overview' por 'metrics:aggregated' em docs/developer_usage.md

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Correct the Redis cache key reference in documentation from 'metrics:overview' to 'metrics:aggregated'

Documentation:
- Replace 'metrics:overview' with 'metrics:aggregated' in README.md
- Replace 'metrics:overview' with 'metrics:aggregated' in docs/developer_usage.md

</details>