### PR TITLE
Update metrics docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,10 +493,10 @@ endpoints are responsive immediately.
    ticket `priority` label and the `requester` name when available.
 - `/tickets/stream` – Server‑Sent Events (SSE) stream of progress followed by the JSON payload.
 - `/metrics` – summary with `total`, `opened` and `closed` counts.
-- `/metrics/aggregated` – counts grouped by status and technician, pre-computed by the worker.
-- `/metrics/aggregated` – dictionary with `open_tickets`,
-  `tickets_closed_this_month` and `status_distribution`.
-- `/metrics/levels/<level>` – same fields as `/metrics/aggregated` but scoped
+ - `/metrics/aggregated` – dictionary with `open_tickets`,
+  `tickets_closed_this_month` and `status_distribution`. Values are pre-computed
+  by the worker.
+ - `/metrics/levels/{level}` – same fields as `/metrics/aggregated` but scoped
   to a single support level.
 - `/metrics/levels` – mapping of levels to status counts stored in the
   `metrics_levels` cache.
@@ -519,6 +519,16 @@ Example `/metrics/aggregated` payload:
 The `/metrics/levels/N1` endpoint yields the same fields scoped to the
 requested level. `/metrics/levels` returns a dictionary of levels mapped
 to status counts.
+
+Example `/metrics/levels/N1` payload:
+
+```json
+{
+  "open_tickets": 5,
+  "tickets_closed_this_month": 2,
+  "status_distribution": {"new": 3, "closed": 2}
+}
+```
 
 Example ticket payload:
 

--- a/docs/REFACTOR_LOG.md
+++ b/docs/REFACTOR_LOG.md
@@ -67,6 +67,6 @@ Descrição: Script auxilia na movimentação de módulos Python utilizando a bi
 - Copias de `.env.example` adicionadas em `new_project/.env.example` (2623 bytes) e `new_project/frontend/.env.example` (184 bytes).
 - `new_project/backend/main.py` (109 bytes) contem worker FastAPI minimo.
 ## \ud83d\udcc6 Atualizacao 2025-07-31 (metrics)
-- `new_project/backend/main.py` (4683 bytes) passou a incluir rotas `metrics/overview` e `metrics/level`. As fun\u00e7\u00f5es derivam de `app/api/metrics.py`.
+- `new_project/backend/main.py` (4683 bytes) passou a incluir rotas `metrics/aggregated` e `metrics/levels/{level}`. As fun\u00e7\u00f5es derivam de `app/api/metrics.py`.
 ## \ud83d\udcc6 Atualizacao 2025-07-31 (Dockerfile cleanup)
 - Removido `Dockerfile` (474 bytes) em favor de `docker/backend/Dockerfile`. Referências atualizadas.

--- a/docs/developer_usage.md
+++ b/docs/developer_usage.md
@@ -78,7 +78,7 @@ Endpoints relevantes:
 - `/metrics` – contagem de abertos/fechados
 - `/metrics/aggregated` – retorna `open_tickets`,
   `tickets_closed_this_month` e `status_distribution`.
-- `/metrics/levels/<nivel>` – mesmos campos do endpoint acima mas
+ - `/metrics/levels/{nivel}` – mesmos campos do endpoint acima mas
   restritos ao nível informado.
 - `/metrics/levels` – dicionário com contagem de status por nível
   armazenado em `metrics_levels`.
@@ -95,18 +95,14 @@ O comando `load_tickets()` executado na inicialização preenche os
 redis-keys `metrics_aggregated`, `metrics_levels` e `metrics:aggregated`
 para que esses endpoints respondam rapidamente já no primeiro acesso.
 
-Exemplo de retorno:
+Exemplo de retorno de `/metrics/aggregated`:
 
 ```json
-[
-  {
-    "id": 7,
-    "title": "Falha no proxy",
-    "status": "Closed",
-    "priority": "Medium",
-    "requester": "Alice"
-  }
-]
+{
+  "open_tickets": {"N1": 5},
+  "tickets_closed_this_month": {"N1": 2},
+  "status_distribution": {"new": 3, "closed": 2}
+}
 ```
 
 ## Utilizando o ETL


### PR DESCRIPTION
## Summary
- clarify `/metrics/aggregated` endpoint in README
- document `/metrics/levels/{level}` and show sample payloads
- fix outdated references in developer usage guide
- update refactor log to use new endpoint names

## Testing
- `pre-commit run --files README.md docs/developer_usage.md docs/REFACTOR_LOG.md`
- `pytest -k metrics_levels -q` *(fails: ModuleNotFoundError: No module named 'libcst')*

------
https://chatgpt.com/codex/tasks/task_e_688b6b1b4dbc8320b427e40d0bf44b75