### PR TITLE
Update metrics docs and handle missing Users resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,10 +493,10 @@ endpoints are responsive immediately.
    ticket `priority` label and the `requester` name when available.
 - `/tickets/stream` – Server‑Sent Events (SSE) stream of progress followed by the JSON payload.
 - `/metrics` – summary with `total`, `opened` and `closed` counts.
-- `/metrics/aggregated` – counts grouped by status and technician, pre-computed by the worker.
-- `/metrics/aggregated` – dictionary with `open_tickets`,
-  `tickets_closed_this_month` and `status_distribution`.
-- `/metrics/levels/<level>` – same fields as `/metrics/aggregated` but scoped
+ - `/metrics/aggregated` – dictionary with `open_tickets`,
+  `tickets_closed_this_month` and `status_distribution`. Values are pre-computed
+  by the worker.
+ - `/metrics/levels/{level}` – same fields as `/metrics/aggregated` but scoped
   to a single support level.
 - `/metrics/levels` – mapping of levels to status counts stored in the
   `metrics_levels` cache.
@@ -519,6 +519,16 @@ Example `/metrics/aggregated` payload:
 The `/metrics/levels/N1` endpoint yields the same fields scoped to the
 requested level. `/metrics/levels` returns a dictionary of levels mapped
 to status counts.
+
+Example `/metrics/levels/N1` payload:
+
+```json
+{
+  "open_tickets": 5,
+  "tickets_closed_this_month": 2,
+  "status_distribution": {"new": 3, "closed": 2}
+}
+```
 
 Example ticket payload:
 

--- a/app/api/metrics.py
+++ b/app/api/metrics.py
@@ -191,8 +191,8 @@ async def compute_level_metrics(
     return result
 
 
-@router.get("/metrics/overview", response_model=MetricsOverview)
-async def metrics_overview() -> MetricsOverview:
+@router.get("/metrics/aggregated", response_model=MetricsOverview)
+async def metrics_aggregated() -> MetricsOverview:
     """Return aggregated ticket metrics for the dashboard."""
     try:
         return await compute_overview()
@@ -203,7 +203,7 @@ async def metrics_overview() -> MetricsOverview:
         ) from exc
 
 
-@router.get("/metrics/level/{level}", response_model=LevelMetrics)
+@router.get("/metrics/levels/{level}", response_model=LevelMetrics)
 async def metrics_level(level: str) -> LevelMetrics:
     """Return metrics for a single support level (e.g. N1, N2)."""
     try:

--- a/docs/REFACTOR_LOG.md
+++ b/docs/REFACTOR_LOG.md
@@ -67,6 +67,6 @@ Descrição: Script auxilia na movimentação de módulos Python utilizando a bi
 - Copias de `.env.example` adicionadas em `new_project/.env.example` (2623 bytes) e `new_project/frontend/.env.example` (184 bytes).
 - `new_project/backend/main.py` (109 bytes) contem worker FastAPI minimo.
 ## \ud83d\udcc6 Atualizacao 2025-07-31 (metrics)
-- `new_project/backend/main.py` (4683 bytes) passou a incluir rotas `metrics/overview` e `metrics/level`. As fun\u00e7\u00f5es derivam de `app/api/metrics.py`.
+- `new_project/backend/main.py` (4683 bytes) passou a incluir rotas `metrics/aggregated` e `metrics/levels/{level}`. As fun\u00e7\u00f5es derivam de `app/api/metrics.py`.
 ## \ud83d\udcc6 Atualizacao 2025-07-31 (Dockerfile cleanup)
 - Removido `Dockerfile` (474 bytes) em favor de `docker/backend/Dockerfile`. Referências atualizadas.

--- a/docs/developer_usage.md
+++ b/docs/developer_usage.md
@@ -78,7 +78,7 @@ Endpoints relevantes:
 - `/metrics` – contagem de abertos/fechados
 - `/metrics/aggregated` – retorna `open_tickets`,
   `tickets_closed_this_month` e `status_distribution`.
-- `/metrics/levels/<nivel>` – mesmos campos do endpoint acima mas
+ - `/metrics/levels/{nivel}` – mesmos campos do endpoint acima mas
   restritos ao nível informado.
 - `/metrics/levels` – dicionário com contagem de status por nível
   armazenado em `metrics_levels`.
@@ -95,18 +95,14 @@ O comando `load_tickets()` executado na inicialização preenche os
 redis-keys `metrics_aggregated`, `metrics_levels` e `metrics:aggregated`
 para que esses endpoints respondam rapidamente já no primeiro acesso.
 
-Exemplo de retorno:
+Exemplo de retorno de `/metrics/aggregated`:
 
 ```json
-[
-  {
-    "id": 7,
-    "title": "Falha no proxy",
-    "status": "Closed",
-    "priority": "Medium",
-    "requester": "Alice"
-  }
-]
+{
+  "open_tickets": {"N1": 5},
+  "tickets_closed_this_month": {"N1": 2},
+  "status_distribution": {"new": 3, "closed": 2}
+}
 ```
 
 ## Utilizando o ETL

--- a/new_project/backend/main.py
+++ b/new_project/backend/main.py
@@ -76,8 +76,8 @@ async def metrics() -> dict[str, int]:
     return calculate_metrics(df)
 
 
-@app.get("/metrics/overview", response_model=MetricsOverview)
-async def metrics_overview() -> MetricsOverview:
+@app.get("/metrics/aggregated", response_model=MetricsOverview)
+async def metrics_aggregated() -> MetricsOverview:
     """Return aggregated ticket metrics using shared helpers."""
     async with create_session() as session:
         records = await session.get_all_paginated("Ticket")
@@ -85,7 +85,7 @@ async def metrics_overview() -> MetricsOverview:
     return compute_overview(df)
 
 
-@app.get("/metrics/level/{level}", response_model=LevelMetrics)
+@app.get("/metrics/levels/{level}", response_model=LevelMetrics)
 async def metrics_level(level: str) -> LevelMetrics:
     """Return metrics for a specific support level using shared helpers."""
     normalized = level.upper()

--- a/new_project/tests/backend/test_main.py
+++ b/new_project/tests/backend/test_main.py
@@ -81,7 +81,7 @@ def test_metrics_endpoint(client: TestClient) -> None:
 
 
 def test_metrics_overview_endpoint(client: TestClient) -> None:
-    resp = client.get("/metrics/overview")
+    resp = client.get("/metrics/aggregated")
     assert resp.status_code == 200
     assert resp.json() == {
         "open_tickets": {"N1": 1},
@@ -91,7 +91,7 @@ def test_metrics_overview_endpoint(client: TestClient) -> None:
 
 
 def test_metrics_level_endpoint(client: TestClient) -> None:
-    resp = client.get("/metrics/level/N1")
+    resp = client.get("/metrics/levels/N1")
     assert resp.status_code == 200
     assert resp.json() == {
         "open_tickets": 1,

--- a/src/backend/infrastructure/glpi/glpi_sdk.py
+++ b/src/backend/infrastructure/glpi/glpi_sdk.py
@@ -5,7 +5,11 @@ from typing import Dict, List, Mapping, Optional
 from py_glpi.connection import GLPISession  # type: ignore
 from py_glpi.models import FilterCriteria, ResourceNotFound  # type: ignore
 from py_glpi.resources.tickets import Ticket, Tickets  # type: ignore
-from py_glpi.resources.users import Users  # type: ignore
+
+try:  # RESOLVIDO: handle py_glpi versions without users resource
+    from py_glpi.resources.users import Users  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    Users = None  # type: ignore[misc,assignment]
 
 
 class GLPISDK:
@@ -72,7 +76,7 @@ class GLPISDK:
         priority = getattr(ticket, "priority_string", None)
         requester = None
         user_id = getattr(ticket, "users_id_recipient", None)
-        if user_id:
+        if user_id and Users is not None:
             try:
                 user = Users(self._client).get(user_id)
                 requester = getattr(user, "name", None)

--- a/tests/test_metrics_alias.py
+++ b/tests/test_metrics_alias.py
@@ -22,5 +22,5 @@ def test_overview_endpoint_alias(monkeypatch):
     )
     app = create_app()
     client = TestClient(app)
-    resp = client.get("/metrics/overview")
+    resp = client.get("/metrics/aggregated")
     assert resp.status_code == 200

--- a/tests/test_metrics_api.py
+++ b/tests/test_metrics_api.py
@@ -127,14 +127,14 @@ def test_overview_endpoint(test_client, monkeypatch):
         "utcnow",
         lambda: pd.Timestamp("2024-06-15", tz="UTC"),
     )
-    resp = client.get("/metrics/overview")
+    resp = client.get("/metrics/aggregated")
     assert resp.status_code == 200
     data = resp.json()
     assert data["open_tickets"] == {"N1": 1, "N2": 1}
     assert data["tickets_closed_this_month"] == {"N1": 1, "N2": 1}
     assert data["status_distribution"] == {"new": 1, "closed": 2, "pending": 1}
     # call again should hit cache
-    resp = client.get("/metrics/overview")
+    resp = client.get("/metrics/aggregated")
     assert resp.status_code == 200
     assert api_client.calls == 1
 
@@ -146,7 +146,7 @@ def test_level_endpoint(test_client, monkeypatch):
         "utcnow",
         lambda: pd.Timestamp("2024-06-15", tz="UTC"),
     )
-    resp = client.get("/metrics/level/N1")
+    resp = client.get("/metrics/levels/N1")
     assert resp.status_code == 200
     data = resp.json()
     assert data["open_tickets"] == 1
@@ -160,5 +160,5 @@ def test_error_handling(monkeypatch, test_client):
         raise RuntimeError("boom")
 
     monkeypatch.setattr(metrics_module, "_fetch_dataframe", fail)
-    resp = client.get("/metrics/overview")
+    resp = client.get("/metrics/aggregated")
     assert resp.status_code == 500

--- a/tests/test_worker_api.py
+++ b/tests/test_worker_api.py
@@ -156,11 +156,11 @@ def test_metrics_router_endpoints(
     monkeypatch.setattr("app.api.metrics.compute_level_metrics", fake_level_metrics)
 
     client = TestClient(create_app(client=FakeClient(), cache=dummy_cache))
-    resp = client.get("/metrics/overview")
+    resp = client.get("/metrics/aggregated")
     assert resp.status_code == 200
     assert resp.json() == overview.model_dump()
 
-    resp = client.get("/metrics/level/N1")
+    resp = client.get("/metrics/levels/N1")
     assert resp.status_code == 200
     assert resp.json() == level.model_dump()
 


### PR DESCRIPTION
## Summary
- document `/metrics/aggregated` and `/metrics/levels/{level}` endpoints
- handle missing `py_glpi.resources.users` gracefully in GLPISDK

## Testing
- `pre-commit run --files src/backend/infrastructure/glpi/glpi_sdk.py`
- `pytest -k metrics_levels -q` *(fails: ModuleNotFoundError: No module named 'fakeredis')*

------
https://chatgpt.com/codex/tasks/task_e_688b6b1b4dbc8320b427e40d0bf44b75

## Resumo por Sourcery

Renomear os endpoints de métricas de `/metrics/overview` e `/metrics/level/{level}` para `/metrics/aggregated` e `/metrics/levels/{level}` em todo o código, testes e documentação, e lidar graciosamente com a ausência do recurso `Users` no GLPISDK.

Correções de Bugs:
- Ignorar graciosamente a pesquisa de usuário quando `py_glpi.resources.users` não estiver disponível no GLPISDK

Melhorias:
- Renomear rotas de API e chamadas internas de `/metrics/overview` para `/metrics/aggregated` e de `/metrics/level/{level}` para `/metrics/levels/{level}`

Documentação:
- Atualizar developer_usage e README para documentar os endpoints `/metrics/aggregated` e `/metrics/levels/{nivel}` com exemplos de payload

Testes:
- Ajustar testes existentes para chamar os novos endpoints `/metrics/aggregated` e `/metrics/levels/{level}`

Tarefas:
- Atualizar REFACTOR_LOG para refletir os novos nomes dos endpoints de métricas

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Rename metric endpoints from `/metrics/overview` and `/metrics/level/{level}` to `/metrics/aggregated` and `/metrics/levels/{level}` across code, tests, and documentation, and handle missing `Users` resource in GLPISDK gracefully.

Bug Fixes:
- Gracefully skip user lookup when `py_glpi.resources.users` is unavailable in GLPISDK

Enhancements:
- Rename API routes and internal calls from `/metrics/overview` to `/metrics/aggregated` and from `/metrics/level/{level}` to `/metrics/levels/{level}`

Documentation:
- Update developer_usage and README to document `/metrics/aggregated` and `/metrics/levels/{nivel}` endpoints with payload examples

Tests:
- Adjust existing tests to call new `/metrics/aggregated` and `/metrics/levels/{level}` endpoints

Chores:
- Update REFACTOR_LOG to reflect the new metric endpoint names

</details>