### PR TITLE
Improve GLPI client error parsing

### DIFF
--- a/src/backend/infrastructure/glpi/glpi_client.py
+++ b/src/backend/infrastructure/glpi/glpi_client.py
@@ -188,6 +188,8 @@ class GLPISessionManager:
                     else:
                         error_text = str(payload)
                 except ValueError:
+                    # If the response claims to be JSON but can't be decoded,
+                    # we fall back to using the raw response text.
                     pass
             raise exc_cls(f"HTTP {resp.status_code}: {error_text}")
         if raise_for_status:


### PR DESCRIPTION
## Summary
- improve `_handle_response` to parse JSON error bodies
- test that JSON error details appear in raised exceptions

## Testing
- `pre-commit run --files src/backend/infrastructure/glpi/glpi_client.py tests/test_glpi_client_sync.py`
- `pytest -o addopts='' tests/test_glpi_client_sync.py`

------
https://chatgpt.com/codex/tasks/task_e_688b867d56148320a22d4ca356985527

## Resumo por Sourcery

Melhorar o tratamento de erros do cliente GLPI para analisar corpos de erro JSON e incluir detalhes específicos de 'message' ou 'error' em exceções levantadas, e adicionar testes para validar este comportamento

Novas Funcionalidades:
- Extrair campos 'message' ou 'error' de respostas JSON para erros HTTP

Melhorias:
- Detectar o tipo de conteúdo 'application/json' em respostas de erro e analisar o payload para texto de erro detalhado

Testes:
- Adicionar testes para verificar que os campos 'message' e 'error' de erro JSON aparecem em exceções levantadas

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhance GLPI client error handling to parse JSON error bodies and include specific 'message' or 'error' details in raised exceptions, and add tests to validate this behavior

New Features:
- Extract 'message' or 'error' fields from JSON responses for HTTP errors

Enhancements:
- Detect 'application/json' content type in error responses and parse payload for detailed error text

Tests:
- Add tests to verify that JSON error 'message' and 'error' fields appear in raised exceptions

</details>