### PR TITLE
Clarify GLPI session usage and deprecate sync client

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ If a script still depends on `require()`, rename it with the `.cjs` extension or
 ## Main modules
 
 - **`src/backend/infrastructure/glpi/glpi_session.py`** – asynchronous client for the GLPI REST API used by the worker and ETL modules. This file replaces the former `glpi_api.py` referenced in early docs.
+- **`src/backend/infrastructure/glpi/glpi_client.py`** – legacy synchronous wrapper (`GLPISessionManager`). New code should rely on `GLPISession` instead.
 - **`src/backend/utils/pipeline.py`** – normalizes raw ticket data into a `pandas.DataFrame` and exports JSON.
 - **`src/frontend/layout/layout.py`** – defines tables and charts for the Dash UI.
 - **`glpi_tools/__main__.py`** – exposes the CLI commands such as `list-fields`.

--- a/docs/cookbook/glpi-session.md
+++ b/docs/cookbook/glpi-session.md
@@ -1,26 +1,37 @@
 # GLPI Session Setup
 
 ## Context
-The `glpi_session` module authenticates with the GLPI REST API and provides a
-simple client used across the worker and dashboard apps. It wraps `requests`
-with sensible defaults so other modules only deal with high level helpers.
+The `glpi_session` module authenticates with the GLPI REST API and exposes
+``GLPISession``—an **asynchronous** client built on ``aiohttp``. This client is
+used by the worker services and ETL routines. A deprecated synchronous wrapper,
+``GLPISessionManager`` (``glpi_client.py``), is still available for legacy
+scripts but should be avoided for new development.
 
 ## Decision
-Manage authentication tokens via environment variables (`GLPI_BASE_URL`,
-`GLPI_APP_TOKEN`, `GLPI_USER_TOKEN`). The session reuses a single `requests`
-`Session` with a 30‑second timeout and built‑in retry logic. Token refresh is
-handled automatically when the API responds with an authentication error.
+Credentials are read from the environment via ``GLPI_BASE_URL`` and
+``GLPI_APP_TOKEN`` plus either ``GLPI_USER_TOKEN`` or ``GLPI_USERNAME`` /``GLPI_PASSWORD``.
+``GLPISession`` manages token refresh automatically and maintains a single
+``aiohttp.ClientSession`` with retry and circuit breaking provided by
+``shared.utils.resilience``.
 
 ## Consequences
 Centralizing the connection ensures all services share the same caching and
 error handling policy. Failures propagate quickly if credentials are missing or
 invalid, making troubleshooting straightforward during deployment.
 
-## Steps
-1. Export the required variables in your shell or `.env` file before running any
-   component. Using `python-dotenv` helps load them during development.
-2. Call `glpi_session.login()` once at startup to obtain the session cookies; if
-   the call fails due to expired tokens, refresh the environment variables and
-   retry.
-3. Use `glpi_session.get_tickets()` or related helpers throughout the pipeline
-   to fetch data.
+## Usage
+1. Export the required variables in your shell or ``.env`` file before running
+   any component.
+2. Create a ``GLPISession`` using ``async with`` to ensure proper cleanup:
+
+   ```python
+   from backend.infrastructure.glpi.glpi_session import Credentials, GLPISession
+
+   creds = Credentials(app_token="APP", user_token="USER")
+   async with GLPISession("https://glpi/api", creds) as session:
+       ticket = await session.get("Ticket/1")
+   ```
+
+3. The old ``GLPISessionManager`` class mirrors the same API but is synchronous
+   and relies on ``requests``. It is retained only for simple scripts or tests
+   that cannot use ``asyncio``.

--- a/docs/developer_usage.md
+++ b/docs/developer_usage.md
@@ -17,6 +17,10 @@ Principais módulos do projeto:
 | `shared/config/settings.py` | Carrega variáveis de ambiente (GLPI, DB, Redis) |
 | `src/frontend/react_app/` | Projeto Next.js que consome o worker API |
 
+O módulo `glpi_client.py` ainda oferece `GLPISessionManager`, uma versão
+síncrona baseada em `requests` mantida apenas para scripts simples ou testes.
+Todo código novo deve preferir `GLPISession` do arquivo `glpi_session.py`.
+
 Os módulos da Anti-Corruption Layer residem em `src/backend/adapters`. Importe-os diretamente desse pacote. O antigo `glpi_adapter.py` foi removido durante a refatoração.
 
 Scripts utilitários residem em `scripts/` organizados por categoria, como `setup/init_db.py`, `fetch/fetch_tickets.py` e `etl/filters.py`.

--- a/src/backend/infrastructure/glpi/__init__.py
+++ b/src/backend/infrastructure/glpi/__init__.py
@@ -1,3 +1,5 @@
+"""Public interface for GLPI infrastructure helpers."""
+
 from .glpi_client import (
     GLPIClientAuthError,
     GLPIClientError,
@@ -8,9 +10,11 @@ from .glpi_client import (
     SearchCriteriaBuilder,
     get_secret,
 )
+from .glpi_session import GLPISession
 
 __all__ = [
     "GLPISessionManager",
+    "GLPISession",
     "GLPIClientError",
     "GLPIClientAuthError",
     "GLPIClientNotFound",

--- a/src/backend/infrastructure/glpi/glpi_client.py
+++ b/src/backend/infrastructure/glpi/glpi_client.py
@@ -63,7 +63,11 @@ def get_secret(name: str) -> str:
 
 
 class GLPISessionManager:
-    """Synchronous session manager for the GLPI REST API."""
+    """Synchronous session manager for the GLPI REST API.
+
+    .. deprecated:: 0.1.0
+       Use :class:`GLPISession` from ``glpi_session.py`` for new code.
+    """
 
     def __init__(
         self,


### PR DESCRIPTION
## Summary
- document difference between async `GLPISession` and legacy sync client
- mark `GLPISessionManager` as deprecated
- expose `GLPISession` via `backend.infrastructure.glpi`

## Testing
- `make test-backend` *(fails: TypeError in sqlalchemy)*

------
https://chatgpt.com/codex/tasks/task_e_688b867e1ec08320a773dd3f4392dbe3

## Resumo por Sourcery

Promover o novo cliente assíncrono GLPISession, depreciar o GLPISessionManager síncrono legado e atualizar as exportações e a documentação para refletir essas mudanças.

Melhorias:
- Exportar GLPISession em backend.infrastructure.glpi para novo uso assíncrono
- Marcar GLPISessionManager como depreciado em glpi_client.py para desencorajar o uso síncrono futuro

Documentação:
- Revisar o 'cookbook' de sessão do GLPI para destacar o uso assíncrono do GLPISession e a depreciação do cliente síncrono
- Atualizar developer_usage.md e README para referenciar GLPISession e observar a depreciação de GLPISessionManager

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Promote the new asynchronous GLPISession client, deprecate the legacy synchronous GLPISessionManager, and update exports and documentation to reflect these changes.

Enhancements:
- Export GLPISession in backend.infrastructure.glpi for new asynchronous usage
- Mark GLPISessionManager as deprecated in glpi_client.py to discourage further sync usage

Documentation:
- Revise the GLPI session cookbook to highlight async GLPISession usage and deprecation of the sync client
- Update developer_usage.md and README to reference GLPISession and note deprecation of GLPISessionManager

</details>