### PR TITLE
Refactor enrichment service to use session

### DIFF
--- a/src/backend/services/glpi_enrichment.py
+++ b/src/backend/services/glpi_enrichment.py
@@ -29,8 +29,8 @@ class GLPIEnrichmentService:
         provided = session is not None
         if session is None:
             session = create_glpi_session()
-            if session is None:
-                raise RuntimeError("could not create GLPI session")
+        if session is None:
+            raise RuntimeError("could not create GLPI session")
 
         self._session = session
         self._owns_session = not provided

--- a/src/backend/services/glpi_enrichment.py
+++ b/src/backend/services/glpi_enrichment.py
@@ -1,10 +1,8 @@
 import asyncio
 from typing import Any, Dict, List, Optional, Set, TypedDict
 
-import aiohttp
-
-from backend.core.settings import GLPI_APP_TOKEN, GLPI_BASE_URL
-from backend.infrastructure.glpi.glpi_auth import GLPIAuthClient
+from backend.adapters.factory import create_glpi_session
+from backend.infrastructure.glpi.glpi_session import GLPISession
 from shared.utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -25,37 +23,29 @@ class GLPIEnrichmentService:
 
     DEFAULT_UNKNOWN_VALUE = "Unknown"
 
-    def __init__(
-        self,
-        base_url: str = GLPI_BASE_URL,
-        app_token: str = GLPI_APP_TOKEN,
-        auth_client: Optional[GLPIAuthClient] = None,
-        session: Optional[aiohttp.ClientSession] = None,
-    ) -> None:
-        self.base_url = base_url.rstrip("/")
-        self.app_token = app_token
-        self.auth_client = auth_client or GLPIAuthClient(base_url, app_token)
-        self._owns_session = session is None
-        self.session = session or aiohttp.ClientSession()
+    def __init__(self, session: Optional[GLPISession] = None) -> None:
+        """Create service using an existing :class:`GLPISession` if provided."""
+
+        provided = session is not None
+        if session is None:
+            session = create_glpi_session()
+            if session is None:
+                raise RuntimeError("could not create GLPI session")
+
+        self._session = session
+        self._owns_session = not provided
         self._status_map: Dict[int, str] = {}
         self._user_cache: Dict[int, str] = {}
         self._group_cache: Dict[int, str] = {}
 
     async def close(self) -> None:
-        if self._owns_session and not self.session.closed:
-            await self.session.close()
+        if self._owns_session:
+            await self._session.close()
 
     async def _request(self, endpoint: str) -> Dict[str, Any]:
-        token = await self.auth_client.get_session_token()
-        headers = {
-            "App-Token": self.app_token,
-            "Session-Token": token,
-            "Content-Type": "application/json",
-        }
-        url = f"{self.base_url}/{endpoint.lstrip('/')}"
-        async with self.session.get(url, headers=headers) as resp:
-            resp.raise_for_status()
-            return await resp.json()
+        """Proxy ``GET`` requests through the underlying ``GLPISession``."""
+
+        return await self._session.get(endpoint)
 
     async def _load_statuses(self) -> None:
         if self._status_map:

--- a/tests/test_glpi_enrichment.py
+++ b/tests/test_glpi_enrichment.py
@@ -5,9 +5,16 @@ import pytest
 from backend.services.glpi_enrichment import GLPIEnrichmentService
 
 
+@pytest.fixture()
+def fake_session():
+    """Return a simple async session mock."""
+
+    return AsyncMock()
+
+
 @pytest.mark.asyncio
-async def test_enrich_ticket_cache_hit(mocker):
-    svc = GLPIEnrichmentService()
+async def test_enrich_ticket_cache_hit(mocker, fake_session):
+    svc = GLPIEnrichmentService(session=fake_session)
     svc._status_map = {2: "Em andamento"}
     svc._user_cache = {7: "Fulano"}
     svc._group_cache = {4: "N2"}
@@ -31,8 +38,8 @@ async def test_enrich_ticket_cache_hit(mocker):
 
 
 @pytest.mark.asyncio
-async def test_enrich_ticket_missing_user(mocker):
-    svc = GLPIEnrichmentService()
+async def test_enrich_ticket_missing_user(mocker, fake_session):
+    svc = GLPIEnrichmentService(session=fake_session)
     svc._status_map = {2: "Em andamento"}
     fetch = mocker.patch.object(
         svc, "_fetch_user_name", new=AsyncMock(return_value="Fulano")
@@ -47,8 +54,8 @@ async def test_enrich_ticket_missing_user(mocker):
 
 
 @pytest.mark.asyncio
-async def test_enrich_tickets_deduplicates_calls(mocker):
-    svc = GLPIEnrichmentService()
+async def test_enrich_tickets_deduplicates_calls(mocker, fake_session):
+    svc = GLPIEnrichmentService(session=fake_session)
     svc._status_map = {2: "OK"}
     fetch_user = mocker.patch.object(
         svc, "_fetch_user_name", new=AsyncMock(return_value="User")
@@ -70,8 +77,8 @@ async def test_enrich_tickets_deduplicates_calls(mocker):
 
 
 @pytest.mark.asyncio
-async def test_skip_when_already_expanded(mocker):
-    svc = GLPIEnrichmentService()
+async def test_skip_when_already_expanded(mocker, fake_session):
+    svc = GLPIEnrichmentService(session=fake_session)
     get_status = mocker.patch.object(
         svc, "_get_status_name", side_effect=AssertionError("should not be called")
     )


### PR DESCRIPTION
## Summary
- refactor GLPIEnrichmentService to depend on GLPISession
- simplify internal request handling
- update enrichment tests to mock the session

## Testing
- `pytest tests/test_glpi_enrichment.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688b8f84709c8320841482dab07b7b4e

## Resumo por Sourcery

Refatorar o serviço de enriquecimento para usar uma abstração GLPISession para todas as interações HTTP, otimizar o gerenciamento de sessão e atualizar os testes para simular o novo fluxo baseado em sessão.

Novas Funcionalidades:
- Permitir a injeção de uma GLPISession no GLPIEnrichmentService e criar uma automaticamente quando não fornecida

Melhorias:
- Delegar requisições HTTP e autenticação para a abstração GLPISession em vez de gerenciamento manual de cabeçalhos
- Simplificar o ciclo de vida da sessão centralizando a criação via create_glpi_session e a limpeza em close()

Testes:
- Adicionar fixture fake_session e atualizar testes de enriquecimento para injetar e simular GLPISession

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the enrichment service to use a GLPISession abstraction for all HTTP interactions, streamline session management, and update tests to mock the new session-based flow.

New Features:
- Allow injecting a GLPISession into GLPIEnrichmentService and auto-create one when not provided

Enhancements:
- Delegate HTTP requests and authentication to the GLPISession abstraction instead of manual header management
- Simplify session lifecycle by centralizing creation via create_glpi_session and cleanup in close()

Tests:
- Add fake_session fixture and update enrichment tests to inject and mock GLPISession

</details>