### PR TITLE
Remove legacy cache metrics route

### DIFF
--- a/src/backend/api/worker_api.py
+++ b/src/backend/api/worker_api.py
@@ -280,10 +280,7 @@ def create_app(client: Optional[GlpiApiClient] = None, cache=None) -> FastAPI:
 
     @app.get("/cache/stats")
     async def cache_stats() -> dict:  # noqa: F401
-        return cache.get_cache_metrics()
-
-    @app.get("/cache-metrics")  # legacy name
-    async def cache_metrics() -> dict:  # noqa: F401
+        """Return basic hit/miss statistics for the cache."""
         return cache.get_cache_metrics()
 
     @app.get("/knowledge-base", response_class=PlainTextResponse)

--- a/tests/test_worker_api.py
+++ b/tests/test_worker_api.py
@@ -413,15 +413,6 @@ def test_breaker_content_type(dummy_cache: DummyCache):
     assert resp.headers["content-type"] == CONTENT_TYPE_LATEST
 
 
-def test_cache_metrics_legacy(dummy_cache: DummyCache):
-    client = TestClient(create_app(client=FakeClient(), cache=dummy_cache))
-    client.get("/tickets")
-    legacy = client.get("/cache-metrics")
-    stats = client.get("/cache/stats")
-    assert legacy.status_code == 200
-    assert legacy.json() == stats.json()
-
-
 def test_read_model_db_error(monkeypatch: pytest.MonkeyPatch, dummy_cache: DummyCache):
     """Test that a DB error in the read model returns a 503."""
 


### PR DESCRIPTION
## Summary
- prune `/cache-metrics` handler from worker API
- drop redundant `test_cache_metrics_legacy` test

## Testing
- `pre-commit run --files src/backend/api/worker_api.py tests/test_worker_api.py`
- `pytest tests/test_worker_api.py::test_cache_stats_endpoint -q` *(fails: assert 1 == 2)*

------
https://chatgpt.com/codex/tasks/task_e_688b97ad33948320bf6b0b5dbaa48622

## Resumo por Sourcery

Remove o endpoint legado `/cache-metrics` e seu teste associado, consolidando as métricas de cache em `/cache/stats`.

Melhorias:
- Remove a rota `/cache-metrics` da API do worker
- Adiciona docstring ao endpoint `/cache/stats`

Testes:
- Remove o teste redundante `test_cache_metrics_legacy`

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove the legacy `/cache-metrics` endpoint and its associated test, consolidating cache metrics under `/cache/stats`.

Enhancements:
- Remove the `/cache-metrics` route from the worker API
- Add docstring to the `/cache/stats` endpoint

Tests:
- Drop the redundant `test_cache_metrics_legacy` test

</details>