### PR TITLE
Remove compute_level_metrics

### DIFF
--- a/tests/test_metrics_api.py
+++ b/tests/test_metrics_api.py
@@ -139,20 +139,6 @@ def test_overview_endpoint(test_client, monkeypatch):
     assert api_client.calls == 1
 
 
-def test_level_endpoint(test_client, monkeypatch):
-    client, api_client, cache, metrics_module = test_client
-    monkeypatch.setattr(
-        pd.Timestamp,
-        "utcnow",
-        lambda: pd.Timestamp("2024-06-15", tz="UTC"),
-    )
-    resp = client.get("/metrics/level/N1")
-    assert resp.status_code == 200
-    data = resp.json()
-    assert data["open_tickets"] == 1
-    assert data["resolved_this_month"] == 1
-
-
 def test_error_handling(monkeypatch, test_client):
     client, api_client, cache, metrics_module = test_client
 


### PR DESCRIPTION
## Summary
- delete `compute_level_metrics` and `LevelMetrics`
- clean up unused imports
- remove old `/metrics/level` test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b97b1195c8320b4cf7e6cf10113be

## Resumo por Sourcery

Remove o cálculo de métricas legadas por nível e seus testes, e limpa código não utilizado na API de métricas

Melhorias:
- Remove a função `compute_level_metrics` e o modelo `LevelMetrics` associado
- Limpa imports não utilizados em toda a API de métricas
- Exclui o caso de teste depreciado `/metrics/level`

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove the legacy per-level metrics calculation and its tests, and clean up unused code in the metrics API

Enhancements:
- Remove the compute_level_metrics function and associated LevelMetrics model
- Clean up unused imports across the metrics API
- Delete the deprecated /metrics/level test case

</details>