### PR TITLE
Add level metrics endpoint

### DIFF
--- a/tests/test_metrics_api.py
+++ b/tests/test_metrics_api.py
@@ -148,3 +148,28 @@ def test_error_handling(monkeypatch, test_client):
     monkeypatch.setattr(metrics_module, "_fetch_dataframe", fail)
     resp = client.get("/metrics/overview")
     assert resp.status_code == 500
+
+
+def test_level_endpoint(test_client):
+    client, *_ = test_client
+    resp = client.get("/metrics/level/N1")
+    assert resp.status_code == 200
+    assert resp.json() == {"open": 1, "closed": 1}
+
+
+def test_level_unknown(test_client):
+    client, *_ = test_client
+    resp = client.get("/metrics/level/N3")
+    assert resp.status_code == 200
+    assert resp.json() == {"open": 0, "closed": 0}
+
+
+def test_level_error(monkeypatch, test_client):
+    client, _, _, metrics_module = test_client
+
+    async def fail(*args, **kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(metrics_module, "_fetch_dataframe", fail)
+    resp = client.get("/metrics/level/N1")
+    assert resp.status_code == 500


### PR DESCRIPTION
## Summary
- expose level metrics via `/metrics/level/{level}`
- return open and closed counts in new `LevelMetrics` model
- cover level endpoint in `test_metrics_api`

## Testing
- `pytest -o addopts='' tests/test_metrics_api.py::test_level_endpoint -vv -s --maxfail=1` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_688b9d963e4883208bc37246ef694fa9

## Resumo por Sourcery

Adiciona endpoint de métricas específicas por nível com cache e introduz o modelo LevelMetrics

Novas Funcionalidades:
- Define o modelo LevelMetrics para contagens de tickets abertos e fechados
- Implementa a função compute_level_metrics que busca, calcula e armazena em cache as métricas de nível
- Expõe o endpoint da API GET /metrics/level/{level} com tratamento de erros

Testes:
- Adiciona teste para resposta válida de métricas de nível
- Adiciona teste para nível desconhecido retornando contagens zero
- Adiciona teste para cenário de erro retornando HTTP 500

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add level-specific metrics endpoint with caching and introduce LevelMetrics model

New Features:
- Define LevelMetrics model for open and closed ticket counts
- Implement compute_level_metrics function that fetches, computes, and caches level metrics
- Expose GET /metrics/level/{level} API endpoint with error handling

Tests:
- Add test for valid level metrics response
- Add test for unknown level returning zero counts
- Add test for error scenario returning HTTP 500

</details>