### PR TITLE
Refactor metrics and knowledge base into services

### DIFF
--- a/src/backend/services/__init__.py
+++ b/src/backend/services/__init__.py
@@ -1,0 +1,6 @@
+"""Service layer modules for the backend."""
+
+from .document_service import read_file
+from .metrics_service import calculate_dataframe_metrics
+
+__all__ = ["calculate_dataframe_metrics", "read_file"]

--- a/src/backend/services/document_service.py
+++ b/src/backend/services/document_service.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def read_file(path: str | Path) -> str:
+    """Return the text contents of ``path``.
+
+    Errors are propagated so callers can translate them into HTTP responses.
+    """
+    file_path = Path(path)
+    with file_path.open("r", encoding="utf-8") as fh:
+        return fh.read()
+
+
+__all__ = ["read_file"]

--- a/src/backend/services/metrics_service.py
+++ b/src/backend/services/metrics_service.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from typing import Dict
+
+import pandas as pd
+
+
+def calculate_dataframe_metrics(df: pd.DataFrame) -> Dict[str, int]:
+    """Return basic ticket metrics from ``df``.
+
+    Parameters
+    ----------
+    df:
+        DataFrame containing a ``status`` column.
+
+    Returns
+    -------
+    dict
+        Mapping with ``total``, ``opened`` and ``closed`` counts.
+    """
+    if df.empty:
+        return {"total": 0, "opened": 0, "closed": 0}
+
+    total = len(df)
+    closed = 0
+    if "status" in df.columns:
+        status_series = df["status"].astype(str).str.lower()
+        closed = df[status_series.isin(["closed", "solved"])].shape[0]
+
+    opened = total - closed
+    return {"total": total, "opened": opened, "closed": closed}
+
+
+__all__ = ["calculate_dataframe_metrics"]

--- a/tests/test_document_read_service.py
+++ b/tests/test_document_read_service.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+import pytest
+
+from backend.services.document_service import read_file
+
+
+def test_read_file_success(tmp_path):
+    p = tmp_path / "kb.txt"
+    p.write_text("hello")
+    assert read_file(p) == "hello"
+
+
+def test_read_file_not_found(tmp_path):
+    p = tmp_path / "missing.txt"
+    with pytest.raises(FileNotFoundError):
+        read_file(p)
+
+
+def test_read_file_permission_error(monkeypatch, tmp_path):
+    p = tmp_path / "secret.txt"
+    p.write_text("data")
+
+    def fail(*args, **kwargs):
+        raise PermissionError
+
+    monkeypatch.setattr(Path, "open", lambda *a, **k: fail())
+    with pytest.raises(PermissionError):
+        read_file(p)

--- a/tests/test_metrics_service.py
+++ b/tests/test_metrics_service.py
@@ -1,0 +1,14 @@
+import pandas as pd
+
+from backend.services.metrics_service import calculate_dataframe_metrics
+
+
+def test_calculate_metrics_empty_df():
+    df = pd.DataFrame()
+    assert calculate_dataframe_metrics(df) == {"total": 0, "opened": 0, "closed": 0}
+
+
+def test_calculate_metrics_counts():
+    df = pd.DataFrame({"status": ["new", "closed", "solved", "pending"]})
+    result = calculate_dataframe_metrics(df)
+    assert result == {"total": 4, "opened": 2, "closed": 2}


### PR DESCRIPTION
## Summary
- factor out metric calculation to `metrics_service`
- add `document_service` with file reader
- use these services in `worker_api`
- add unit tests for new services

## Testing
- `pytest tests/test_metrics_service.py tests/test_document_read_service.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688b9d6ca4d4832098c801ef41bdd94f