### PR TITLE
Prefix API routes with /v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,16 +479,16 @@ When the FastAPI service starts it primes the Redis cache by calling
 
 - The service exposes several endpoints:
 
- - `/tickets` – full list of tickets in JSON format. The payload includes the
+ - `/v1/tickets` – full list of tickets in JSON format. The payload includes the
    ticket `priority` label and the `requester` name when available.
-- `/tickets/stream` – Server‑Sent Events (SSE) stream of progress followed by the JSON payload.
-- `/metrics` – summary with `total`, `opened` and `closed` counts.
-- `/metrics/aggregated` – counts grouped by status and technician, pre-computed by the worker.
-- `/chamados/por-data` – tickets per creation date, refreshed every 10 minutes.
-- `/chamados/por-dia` – totals for calendar heatmaps, refreshed every 10 minutes.
-- `/graphql/` – GraphQL API providing the same information.
-- `/cache/stats` – returns cache hit/miss metrics.
-- `/health` – quick check that the worker can reach the GLPI API.
+ - `/v1/tickets/stream` – Server‑Sent Events (SSE) stream of progress followed by the JSON payload.
+ - `/v1/metrics` – summary with `total`, `opened` and `closed` counts.
+ - `/v1/metrics/aggregated` – counts grouped by status and technician, pre-computed by the worker.
+ - `/v1/chamados/por-data` – tickets per creation date, refreshed every 10 minutes.
+ - `/v1/chamados/por-dia` – totals for calendar heatmaps, refreshed every 10 minutes.
+ - `/v1/graphql/` – GraphQL API providing the same information.
+ - `/v1/cache/stats` – returns cache hit/miss metrics.
+ - `/v1/health` – quick check that the worker can reach the GLPI API.
 
 Example ticket payload:
 

--- a/src/backend/api/worker_api.py
+++ b/src/backend/api/worker_api.py
@@ -12,7 +12,7 @@ from typing import Any, Dict, List, Optional, cast
 import pandas as pd
 import strawberry
 import uvicorn
-from fastapi import Depends, FastAPI, HTTPException, Request, Response
+from fastapi import APIRouter, Depends, FastAPI, HTTPException, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import (
     PlainTextResponse,
@@ -152,6 +152,7 @@ def create_app(client: Optional[GlpiApiClient] = None, cache=None) -> FastAPI:
         lifespan=lifespan,
         dependencies=deps,
     )
+    router = APIRouter()
     app.add_middleware(RequestIdMiddleware)
     FastAPIInstrumentor().instrument_app(app)
     Instrumentator().instrument(app).expose(app)
@@ -186,13 +187,13 @@ def create_app(client: Optional[GlpiApiClient] = None, cache=None) -> FastAPI:
             allow_credentials=True,
         )
 
-    @app.get("/tickets", response_model=list[CleanTicketDTO])
+    @router.get("/tickets", response_model=list[CleanTicketDTO])
     async def tickets(response: Response) -> list[CleanTicketDTO]:  # noqa: F401
         return await load_and_translate_tickets(
             client=client, cache=cache, response=response
         )
 
-    @app.get("/tickets/stream")
+    @router.get("/tickets/stream")
     async def tickets_stream(response: Response) -> StreamingResponse:  # noqa: F401
         return StreamingResponse(
             stream_tickets(client, cache=cache, response=response),
@@ -200,12 +201,12 @@ def create_app(client: Optional[GlpiApiClient] = None, cache=None) -> FastAPI:
             headers=response.headers,
         )
 
-    @app.get("/metrics/summary")
+    @router.get("/metrics/summary")
     async def metrics_summary(response: Response) -> dict:  # noqa: F401
         df = await load_tickets(client=client, cache=cache, response=response)
         return calculate_dataframe_metrics(df)
 
-    @app.get("/breaker")
+    @router.get("/breaker")
     async def breaker_metrics() -> Response:  # noqa: F401
         """Expose Prometheus metrics for the circuit breaker."""
         from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
@@ -213,14 +214,14 @@ def create_app(client: Optional[GlpiApiClient] = None, cache=None) -> FastAPI:
         data = generate_latest()
         return Response(content=data, media_type=CONTENT_TYPE_LATEST)
 
-    @app.get("/metrics/aggregated")
+    @router.get("/metrics/aggregated")
     async def metrics_aggregated() -> dict:  # noqa: F401
         metrics = await get_cached_aggregated(cache, "metrics_aggregated")
         if metrics is None:
             raise HTTPException(status_code=503, detail="metrics not available")
         return metrics
 
-    @app.get("/metrics/levels")
+    @router.get("/metrics/levels")
     async def metrics_levels() -> Dict[str, Dict[str, int]]:  # noqa: F401
         """Return status counts grouped by ticket level (group)."""
         data = await cache.get("metrics_levels")
@@ -228,7 +229,7 @@ def create_app(client: Optional[GlpiApiClient] = None, cache=None) -> FastAPI:
             raise HTTPException(status_code=503, detail="metrics not available")
         return cast(Dict[str, Dict[str, int]], data)
 
-    @app.get(
+    @router.get(
         "/chamados/por-data",
         response_model=List[ChamadoPorData],
     )
@@ -239,7 +240,7 @@ def create_app(client: Optional[GlpiApiClient] = None, cache=None) -> FastAPI:
         # avisa ao type checker que raw é List[Dict[str, Any]]
         return cast(List[Dict[str, Any]], raw)
 
-    @app.get(
+    @router.get(
         "/chamados/por-dia",
         response_model=List[ChamadosPorDia],
     )
@@ -249,7 +250,7 @@ def create_app(client: Optional[GlpiApiClient] = None, cache=None) -> FastAPI:
             raise HTTPException(status_code=503, detail="metrics not available")
         return cast(List[Dict[str, Any]], raw)
 
-    @app.get("/read-model/tickets", response_model=list[TicketSummaryOut])
+    @router.get("/read-model/tickets", response_model=list[TicketSummaryOut])
     async def read_model_tickets(
         limit: int = 100, offset: int = 0
     ) -> list[TicketSummaryOut]:
@@ -263,12 +264,12 @@ def create_app(client: Optional[GlpiApiClient] = None, cache=None) -> FastAPI:
                 status_code=503, detail="Read model is currently unavailable."
             ) from exc
 
-    @app.get("/cache/stats")
+    @router.get("/cache/stats")
     async def cache_stats() -> dict:  # noqa: F401
         """Return basic hit/miss statistics for the cache."""
         return cache.get_cache_metrics()
 
-    @app.get("/knowledge-base", response_class=PlainTextResponse)
+    @router.get("/knowledge-base", response_class=PlainTextResponse)
     async def knowledge_base() -> PlainTextResponse:  # noqa: F401
         """Return the contents of the configured knowledge base file."""
         try:
@@ -287,7 +288,7 @@ def create_app(client: Optional[GlpiApiClient] = None, cache=None) -> FastAPI:
                 detail=f"Could not read knowledge base file: {str(e)}",
             )
 
-    @app.get("/health")
+    @router.get("/health")
     async def health_glpi() -> UTF8JSONResponse:  # noqa: F401
         """Check GLPI connectivity and return a JSON body."""
         status = await check_glpi_connection()
@@ -309,7 +310,7 @@ def create_app(client: Optional[GlpiApiClient] = None, cache=None) -> FastAPI:
             headers={"Cache-Control": "no-cache"},
         )
 
-    @app.head("/health")
+    @router.head("/health")
     async def health_glpi_head() -> Response:  # noqa: F401
         """Same as ``health_glpi`` but returns headers only."""
         status = await check_glpi_connection()
@@ -325,7 +326,8 @@ def create_app(client: Optional[GlpiApiClient] = None, cache=None) -> FastAPI:
         path="/",
         context_getter=get_context,
     )
-    app.include_router(graphql, prefix="/graphql")
+    app.include_router(router, prefix="/v1")
+    app.include_router(graphql, prefix="/v1/graphql")
     return app
 
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -2,6 +2,6 @@
 
 This directory contains unit and integration tests for the GLPI dashboard.
 
-- `test_health_endpoint.py` verifies the `/health` endpoint.
-  - A `HEAD /health` request should return `200` when GLPI is reachable.
+- `test_health_endpoint.py` verifies the `/v1/health` endpoint.
+  - A `HEAD /v1/health` request should return `200` when GLPI is reachable.
   - When GLPI is unavailable (simulated via the `glpi_unavailable` fixture) the endpoint responds with `500`.

--- a/tests/test_health_endpoint.py
+++ b/tests/test_health_endpoint.py
@@ -18,12 +18,12 @@ def test_head_health_ok(
 
     monkeypatch.setattr("src.backend.api.worker_api.check_glpi_connection", ok)
     client = TestClient(create_app(cache=dummy_cache))
-    resp = client.head("/health")
+    resp = client.head("/v1/health")
     assert resp.status_code == 200
     assert resp.text == ""
 
 
 def test_health_unavailable(glpi_unavailable, dummy_cache: DummyCache) -> None:
     client = TestClient(create_app(cache=dummy_cache))
-    resp = client.get("/health")
+    resp = client.get("/v1/health")
     assert resp.status_code == 500

--- a/tests/test_metrics_alias.py
+++ b/tests/test_metrics_alias.py
@@ -22,5 +22,5 @@ def test_overview_endpoint_alias(monkeypatch):
     )
     app = create_app()
     client = TestClient(app)
-    resp = client.get("/metrics/overview")
+    resp = client.get("/v1/metrics/overview")
     assert resp.status_code == 200

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -30,10 +30,10 @@ def test_api_token_required(monkeypatch, dummy_cache):
     app = create_app(cache=dummy_cache)
     client = TestClient(app)
 
-    resp = client.get("/health")
+    resp = client.get("/v1/health")
     assert resp.status_code == 401
 
-    resp = client.get("/health", headers={"X-API-Token": "secret" * 8})
+    resp = client.get("/v1/health", headers={"X-API-Token": "secret" * 8})
     assert resp.status_code == 200
 
 


### PR DESCRIPTION
## Summary
- serve REST and GraphQL endpoints under `/v1/`
- update tests for new paths
- document new URL structure in README

## Testing
- `python scripts/generate_bug_prompt.py --output bug_prompt.md` *(fails: ModuleNotFoundError: No module named 'libcst')*
- `pytest -q` *(fails: missing dependencies)*
- `flake8` *(fails: E402 module level import not at top of file)*

------
https://chatgpt.com/codex/tasks/task_e_688ba5f87770832086ea8e13be80fe1b