### PR TITLE
Validate CORS env vars

### DIFF
--- a/tests/test_worker_api.py
+++ b/tests/test_worker_api.py
@@ -452,3 +452,23 @@ def test_metrics_aggregated_cache(dummy_cache: DummyCache):
     assert first == second
     stats = client.get("/cache/stats").json()
     assert stats["hits"] >= 1
+
+
+def test_invalid_cors_methods(
+    monkeypatch: pytest.MonkeyPatch, dummy_cache: DummyCache
+) -> None:
+    """Ensure invalid HTTP methods in env vars raise an error."""
+
+    monkeypatch.setenv("APP_ENV", "production")
+    monkeypatch.setenv("API_CORS_ALLOW_METHODS", "GET,INVALID")
+    with pytest.raises(ValueError):
+        create_app(client=FakeClient(), cache=dummy_cache)
+
+
+def test_empty_cors_methods(
+    monkeypatch: pytest.MonkeyPatch, dummy_cache: DummyCache
+) -> None:
+    monkeypatch.setenv("APP_ENV", "production")
+    monkeypatch.setenv("API_CORS_ALLOW_METHODS", "")
+    with pytest.raises(ValueError):
+        create_app(client=FakeClient(), cache=dummy_cache)


### PR DESCRIPTION
## Summary
- add env parsing helpers for CORS config and APP_ENV in `settings`
- use helpers in `create_app`
- test invalid or empty CORS method lists

## Testing
- `pytest tests/test_worker_api.py::test_invalid_cors_methods -vv`
- `pytest tests/test_worker_api.py::test_empty_cors_methods -vv`
- `pre-commit run --files src/backend/api/worker_api.py src/backend/core/settings.py tests/test_worker_api.py`

------
https://chatgpt.com/codex/tasks/task_e_688ba601ddbc83208f260847eafb8469