### PR TITLE
Refactor metrics endpoints into router

### DIFF
--- a/src/backend/api/routers/metrics.py
+++ b/src/backend/api/routers/metrics.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from typing import Dict, cast
+
+from fastapi import APIRouter, HTTPException, Response
+from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
+
+from backend.application.aggregated_metrics import get_cached_aggregated
+from backend.application.ticket_loader import load_tickets
+from backend.services.metrics_service import calculate_dataframe_metrics
+
+
+def create_metrics_router(client, cache) -> APIRouter:
+    """Return a router with metrics endpoints bound to ``client`` and ``cache``."""
+    router = APIRouter()
+
+    @router.get("/metrics/summary")
+    async def metrics_summary(response: Response) -> dict:
+        df = await load_tickets(client=client, cache=cache, response=response)
+        return calculate_dataframe_metrics(df)
+
+    @router.get("/metrics/aggregated")
+    async def metrics_aggregated() -> dict:
+        metrics = await get_cached_aggregated(cache, "metrics_aggregated")
+        if metrics is None:
+            raise HTTPException(status_code=503, detail="metrics not available")
+        return metrics
+
+    @router.get("/metrics/levels")
+    async def metrics_levels() -> Dict[str, Dict[str, int]]:
+        data = await cache.get("metrics_levels")
+        if data is None:
+            raise HTTPException(status_code=503, detail="metrics not available")
+        return cast(Dict[str, Dict[str, int]], data)
+
+    @router.get("/breaker")
+    async def breaker_metrics() -> Response:
+        data = generate_latest()
+        return Response(content=data, media_type=CONTENT_TYPE_LATEST)
+
+    return router


### PR DESCRIPTION
## Summary
- add new `metrics` router module containing `/metrics/*` and `/breaker` endpoints
- include the metrics router in `create_app`

## Testing
- `pytest tests/test_worker_api.py::test_rest_endpoints -q`
- `pytest tests/test_worker_api.py -q` *(fails: assert 0 == 1)*

------
https://chatgpt.com/codex/tasks/task_e_688ba5f3366c8320ae81e385ad43a0cb

## Resumo por Sourcery

Extrair endpoints relacionados a métricas para um módulo de roteador dedicado e conectá-lo à inicialização da aplicação

Melhorias:
- Mover os endpoints `/metrics/summary`, `/metrics/aggregated`, `/metrics/levels` e `/breaker` do arquivo principal da API para um novo roteador `metrics`
- Incluir o novo roteador `metrics` na aplicação FastAPI durante a inicialização e remover definições inline de `worker_api`

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Extract metrics-related endpoints into a dedicated router module and wire it into the application initialization

Enhancements:
- Move `/metrics/summary`, `/metrics/aggregated`, `/metrics/levels`, and `/breaker` endpoints from the main API file into a new `metrics` router
- Include the new `metrics` router in the FastAPI application during startup and remove inline definitions from `worker_api`

</details>