### PR TITLE
Prefix REST endpoints with /v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,22 +489,22 @@ endpoints are responsive immediately.
 
 - The service exposes several endpoints:
 
- - `/tickets` – full list of tickets in JSON format. The payload includes the
-   ticket `priority` label and the `requester` name when available.
-- `/tickets/stream` – Server‑Sent Events (SSE) stream of progress followed by the JSON payload.
-- `/metrics` – summary with `total`, `opened` and `closed` counts.
- - `/metrics/aggregated` – dictionary with `open_tickets`,
+- `/v1/tickets` – full list of tickets in JSON format. The payload includes the
+  ticket `priority` label and the `requester` name when available.
+- `/v1/tickets/stream` – Server‑Sent Events (SSE) stream of progress followed by the JSON payload.
+- `/v1/metrics` – summary with `total`, `opened` and `closed` counts.
+- `/v1/metrics/aggregated` – dictionary with `open_tickets`,
   `tickets_closed_this_month` and `status_distribution`. Values are pre-computed
   by the worker.
- - `/metrics/levels/{level}` – same fields as `/metrics/aggregated` but scoped
+- `/v1/metrics/levels/{level}` – same fields as `/v1/metrics/aggregated` but scoped
   to a single support level.
-- `/metrics/levels` – mapping of levels to status counts stored in the
+- `/v1/metrics/levels` – mapping of levels to status counts stored in the
   `metrics_levels` cache.
-- `/chamados/por-data` – tickets per creation date, refreshed every 10 minutes.
-- `/chamados/por-dia` – totals for calendar heatmaps, refreshed every 10 minutes.
+- `/v1/chamados/por-data` – tickets per creation date, refreshed every 10 minutes.
+- `/v1/chamados/por-dia` – totals for calendar heatmaps, refreshed every 10 minutes.
 - `/graphql/` – GraphQL API providing the same information.
-- `/cache/stats` – returns cache hit/miss metrics.
-- `/health` – quick check that the worker can reach the GLPI API.
+- `/v1/cache/stats` – returns cache hit/miss metrics.
+- `/v1/health` – quick check that the worker can reach the GLPI API.
 
 Example `/metrics/aggregated` payload:
 

--- a/docs/developer_usage.md
+++ b/docs/developer_usage.md
@@ -73,17 +73,17 @@ python worker.py
 
 Endpoints relevantes:
 
-- `/tickets` – lista completa de chamados
+- `/v1/tickets` – lista completa de chamados
  - A resposta inclui os campos `priority` e `requester` em formato textual.
-- `/metrics` – contagem de abertos/fechados
-- `/metrics/aggregated` – retorna `open_tickets`,
+- `/v1/metrics` – contagem de abertos/fechados
+- `/v1/metrics/aggregated` – retorna `open_tickets`,
   `tickets_closed_this_month` e `status_distribution`.
- - `/metrics/levels/{nivel}` – mesmos campos do endpoint acima mas
+- `/v1/metrics/levels/{nivel}` – mesmos campos do endpoint acima mas
   restritos ao nível informado.
-- `/metrics/levels` – dicionário com contagem de status por nível
+- `/v1/metrics/levels` – dicionário com contagem de status por nível
   armazenado em `metrics_levels`.
 - `/graphql/` – versão GraphQL
-- `/cache/stats` – estatísticas de cache
+- `/v1/cache/stats` – estatísticas de cache
 
 Utilize o CLI para consultar esses números diretamente pela API:
 
@@ -221,7 +221,7 @@ O helper `useApiQuery` padroniza chamadas ao worker API. Ele recebe uma
 `queryKey`, o `endpoint` e, opcionalmente, um objeto de opções do React Query:
 
 ```ts
-const { data, isLoading } = useApiQuery(['tickets'], '/tickets')
+const { data, isLoading } = useApiQuery(['tickets'], '/v1/tickets')
 ```
 
 Se precisar passar opções criadas inline, serializá-las ou extraia-as para uma

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -100,17 +100,17 @@ Imports reference `@/` as a shortcut to the `src/` folder. Both Vite and TypeScr
 
 ### API Integration
 
-Start the worker with `python worker.py` (it listens on port `8000` by default) and point the front-end to it using the `NEXT_PUBLIC_API_BASE_URL` variable. The `/tickets` endpoint now returns the `priority` label and the `requester` name. Example fetching ticket metrics:
+Start the worker with `python worker.py` (it listens on port `8000` by default) and point the front-end to it using the `NEXT_PUBLIC_API_BASE_URL` variable. The `/v1/tickets` endpoint now returns the `priority` label and the `requester` name. Example fetching ticket metrics:
 
 ```ts
-const resp = await fetch(`${import.meta.env.NEXT_PUBLIC_API_BASE_URL}/tickets/metrics`);
+const resp = await fetch(`${import.meta.env.NEXT_PUBLIC_API_BASE_URL}/v1/metrics`);
 const data = await resp.json();
 ```
 
-The worker also streams progress using `/tickets/stream`:
+The worker also streams progress using `/v1/tickets/stream`:
 
 ```ts
-const url = `${import.meta.env.NEXT_PUBLIC_API_BASE_URL}/tickets/stream`;
+const url = `${import.meta.env.NEXT_PUBLIC_API_BASE_URL}/v1/tickets/stream`;
 const es = new EventSource(url);
 es.onmessage = (ev) => console.log('chunk', ev.data);
 ```

--- a/docs/frontend_charts.md
+++ b/docs/frontend_charts.md
@@ -6,8 +6,8 @@ This guide describes how to display GLPI ticket trends and heatmaps using SWR an
 
 Two REST routes provide the aggregated data used by the charts and leverage the worker's Redis cache:
 
-- `/chamados/por-data` — returns a list of `{ "date": "YYYY-MM-DD", "total": n }` grouped by ticket creation date. The response is cached for **one hour**.
-- `/chamados/por-dia` — returns the same structure for calendar heatmap totals and is cached for **24 hours**.
+- `/v1/chamados/por-data` — returns a list of `{ "date": "YYYY-MM-DD", "total": n }` grouped by ticket creation date. The response is cached for **one hour**.
+- `/v1/chamados/por-dia` — returns the same structure for calendar heatmap totals and is cached for **24 hours**.
 
 Both endpoints perform the aggregation server-side so the front-end only consumes summarized values.
 
@@ -19,7 +19,7 @@ requests in the examples below use this variable.
 
 ### `useChamadosPorData`
 
-Fetches aggregated ticket counts per day from `/chamados/por-data`.
+Fetches aggregated ticket counts per day from `/v1/chamados/por-data`.
 
 ```ts
 import useSWR from 'swr'
@@ -32,7 +32,7 @@ export interface ChamadoPorData {
 
 export function useChamadosPorData() {
   const { data, error, isLoading } = useSWR<ChamadoPorData[]>(
-    '/chamados/por-data',
+    '/v1/chamados/por-data',
     fetcher,
     { refreshInterval: 60000, revalidateOnFocus: false },
   )
@@ -41,13 +41,13 @@ export function useChamadosPorData() {
 }
 
 // The fetcher prefixes `NEXT_PUBLIC_API_BASE_URL` automatically,
-// so `/chamados/por-data` resolves to
-// `${import.meta.env.NEXT_PUBLIC_API_BASE_URL}/chamados/por-data`.
+// so `/v1/chamados/por-data` resolves to
+// `${import.meta.env.NEXT_PUBLIC_API_BASE_URL}/v1/chamados/por-data`.
 ```
 
 ### `useChamadosPorDia`
 
-Same pattern but pointing to `/chamados/por-dia` for daily totals.
+Same pattern but pointing to `/v1/chamados/por-dia` for daily totals.
 
 ## Components
 

--- a/docs/glpi_tokens_guide.md
+++ b/docs/glpi_tokens_guide.md
@@ -128,7 +128,7 @@ Cobertura mínima de 85 % garantida no CI (GitHub Actions).
 ## 10 ▪️ Monitoramento de produção
 
 O contêiner **worker** possui `HEALTHCHECK` interno que executa `curl -I` no␊
-endpoint `/health` (método **HEAD**). A rota `GET` continua disponível para
+endpoint `/v1/health` (método **HEAD**). A rota `GET` continua disponível para
 verificações manuais. Use:
 
 ```bash

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -22,7 +22,7 @@ The dashboard aggregates GLPI service desk metrics using a FastAPI backend and a
 
    The command prints `✅ Conexão com GLPI bem-sucedida!` when the API accepts
    the tokens. If the variables are missing or invalid the worker's␊
-   `/health` endpoint will return **HTTP 500**.
+   `/v1/health` endpoint will return **HTTP 500**.
 
    Example snippet:
 

--- a/src/frontend/react_app/scripts/healthcheck/healthcheck-webapp.sh
+++ b/src/frontend/react_app/scripts/healthcheck/healthcheck-webapp.sh
@@ -4,7 +4,7 @@
 
 set -euo pipefail
 
-WEBAPP_URL="${WEBAPP_URL:-http://localhost:8000/health}"
+WEBAPP_URL="${WEBAPP_URL:-http://localhost:8000/v1/health}"
 
 curl --fail --head "$WEBAPP_URL" > /dev/null
 

--- a/src/frontend/react_app/src/components/GlpiTicketsTable.tsx
+++ b/src/frontend/react_app/src/components/GlpiTicketsTable.tsx
@@ -32,7 +32,7 @@ export function GlpiTicketsTable() {
     error,
     isSuccess,
     refetch,
-  } = useApiQuery<Ticket[]>(['tickets'], '/tickets')
+  } = useApiQuery<Ticket[]>(['tickets'], '/v1/tickets')
 
   const sortedTickets = useMemo(() => {
     if (!tickets) return []

--- a/src/frontend/react_app/src/features/tickets/api.ts
+++ b/src/frontend/react_app/src/features/tickets/api.ts
@@ -2,5 +2,5 @@ import { useApiQuery } from '../../hooks/useApiQuery'
 import type { TicketMetrics } from '../../types/dashboard'
 
 export function useTicketMetrics() {
-  return useApiQuery<TicketMetrics>(['ticket-metrics'], '/metrics')
+  return useApiQuery<TicketMetrics>(['ticket-metrics'], '/v1/metrics')
 }

--- a/src/frontend/react_app/src/hooks/__tests__/useMetricsOverview.test.tsx
+++ b/src/frontend/react_app/src/hooks/__tests__/useMetricsOverview.test.tsx
@@ -16,7 +16,7 @@ test('calls aggregated metrics endpoint', () => {
   renderHook(() => useMetricsOverview(), { wrapper })
   expect(useApiQuery).toHaveBeenCalledWith(
     ['metrics-overview'],
-    '/metrics/aggregated',
+    '/v1/metrics/aggregated',
     expect.any(Object),
   )
 })

--- a/src/frontend/react_app/src/hooks/useChamadosPorData.ts
+++ b/src/frontend/react_app/src/hooks/useChamadosPorData.ts
@@ -35,7 +35,7 @@ import type { ChamadoPorData } from '../types/chamado'
  * }
  */
 export function useChamadosPorData() {
-  return useApiQuery<ChamadoPorData[]>(['chamados-por-data'], '/chamados/por-data', {
+  return useApiQuery<ChamadoPorData[]>(['chamados-por-data'], '/v1/chamados/por-data', {
     staleTime: 1000 * 60 * 5, // 5 minutos
     gcTime: 1000 * 60 * 10, // 10 minutos
     refetchOnWindowFocus: true,

--- a/src/frontend/react_app/src/hooks/useChamadosPorDia.ts
+++ b/src/frontend/react_app/src/hooks/useChamadosPorDia.ts
@@ -2,7 +2,7 @@ import { useApiQuery } from './useApiQuery'
 import type { ChamadoPorDia } from '../types/chamado'
 
 export function useChamadosPorDia() {
-  const query = useApiQuery<ChamadoPorDia[]>(['chamados-por-dia'], '/chamados/por-dia', {
+  const query = useApiQuery<ChamadoPorDia[]>(['chamados-por-dia'], '/v1/chamados/por-dia', {
     refetchInterval: 60000,
   })
 

--- a/src/frontend/react_app/src/hooks/useDashboardData.ts
+++ b/src/frontend/react_app/src/hooks/useDashboardData.ts
@@ -26,7 +26,7 @@ export function useDashboardData(filters?: FiltersState) {
   const serialized = stableStringify(filters)
   const query = useApiQuery<Aggregated>(
     ['metrics-aggregated', serialized],
-    `/metrics/aggregated${qs}`,
+    `/v1/metrics/aggregated${qs}`,
     {
       // Automatically refetch metrics every 30 seconds
       refetchInterval: 30000,

--- a/src/frontend/react_app/src/hooks/useLevelsMetrics.ts
+++ b/src/frontend/react_app/src/hooks/useLevelsMetrics.ts
@@ -16,7 +16,7 @@ export interface LevelEntry {
 const LEVELS_QUERY_KEY = ['levels-metrics'] as const
 
 export function useLevelsMetrics() {
-  const query = useApiQuery<Record<string, LevelMetrics>>(LEVELS_QUERY_KEY, '/metrics/levels')
+  const query = useApiQuery<Record<string, LevelMetrics>>(LEVELS_QUERY_KEY, '/v1/metrics/levels')
 
   const levels = useMemo<LevelEntry[]>(() => {
     if (!query.data) return []

--- a/src/frontend/react_app/src/hooks/useMetricsLevels.ts
+++ b/src/frontend/react_app/src/hooks/useMetricsLevels.ts
@@ -14,7 +14,7 @@ interface ApiLevelMetrics {
 export function useMetricsLevels() {
   const query = useApiQuery<Record<string, ApiLevelMetrics>>(
     ['metrics-levels'],
-    '/metrics/levels',
+    '/v1/metrics/levels',
     { refetchInterval: 60000 },
   )
 

--- a/src/frontend/react_app/src/hooks/useMetricsOverview.ts
+++ b/src/frontend/react_app/src/hooks/useMetricsOverview.ts
@@ -18,7 +18,7 @@ export function useMetricsOverview() {
   const queryClient = useQueryClient()
   const query = useApiQuery<ApiMetricsOverview>(
     METRICS_QUERY_KEY,
-    '/metrics/aggregated',
+    '/v1/metrics/aggregated',
     {
       refetchInterval: POLLING_INTERVAL_MS,
     },

--- a/src/frontend/react_app/tests/hooks/useApiQuery.test.tsx
+++ b/src/frontend/react_app/tests/hooks/useApiQuery.test.tsx
@@ -23,7 +23,7 @@ describe('useApiQuery', () => {
   })
 
   it('deve iniciar em estado de carregamento', () => {
-    const { result } = renderHook(() => useApiQuery(['tickets'], '/tickets'), {
+    const { result } = renderHook(() => useApiQuery(['tickets'], '/v1/tickets'), {
       wrapper,
     })
     expect(result.current.isLoading).toBe(true)
@@ -46,14 +46,14 @@ describe('useApiQuery', () => {
 
     expect(result.current.data).toEqual(mockData)
     expect(result.current.error).toBeNull()
-    expect(fetchMock).toHaveBeenCalledWith(`${MOCK_API_URL}/tickets`, expect.any(Object))
+    expect(fetchMock).toHaveBeenCalledWith(`${MOCK_API_URL}/v1/tickets`, expect.any(Object))
   })
 
   it('deve tratar erros de busca e atualizar o estado', async () => {
     const errorMessage = 'Network Error'
     fetchMock.mockRejectedValue(new Error(errorMessage))
 
-    const { result } = renderHook(() => useApiQuery(['tickets'], '/tickets'), {
+    const { result } = renderHook(() => useApiQuery(['tickets'], '/v1/tickets'), {
       wrapper,
     })
 
@@ -67,7 +67,7 @@ describe('useApiQuery', () => {
   it('deve tratar erro de URL base não configurada', async () => {
     delete process.env.NEXT_PUBLIC_API_BASE_URL
 
-    const { result } = renderHook(() => useApiQuery(['tickets'], '/tickets'), {
+    const { result } = renderHook(() => useApiQuery(['tickets'], '/v1/tickets'), {
       wrapper,
     })
 

--- a/src/frontend/react_app/tests/integration/health.test.ts
+++ b/src/frontend/react_app/tests/integration/health.test.ts
@@ -1,16 +1,16 @@
 test('health endpoint', async () => {
   const base = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8000';
-  const res = await fetch(`${base}/health`);
+  const res = await fetch(`${base}/v1/health`);
   expect(res.status).toBe(200);
 });
 
 test('health endpoint HEAD', async () => {
   const base = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8000';
-  let res = await fetch(`${base}/health`, { method: 'HEAD' });
+  let res = await fetch(`${base}/v1/health`, { method: 'HEAD' });
 
   // Caso res.status seja undefined, faz um GET como fallback
   if (typeof res.status !== 'number') {
-    res = await fetch(`${base}/health`);
+    res = await fetch(`${base}/v1/health`);
   }
   expect(res.status).toBe(200);
 });

--- a/tests/test_health_endpoint.py
+++ b/tests/test_health_endpoint.py
@@ -18,12 +18,12 @@ def test_head_health_ok(
 
     monkeypatch.setattr("src.backend.api.worker_api.check_glpi_connection", ok)
     client = TestClient(create_app(cache=dummy_cache))
-    resp = client.head("/health")
+    resp = client.head("/v1/health")
     assert resp.status_code == 200
     assert resp.text == ""
 
 
 def test_health_unavailable(glpi_unavailable, dummy_cache: DummyCache) -> None:
     client = TestClient(create_app(cache=dummy_cache))
-    resp = client.get("/health")
+    resp = client.get("/v1/health")
     assert resp.status_code == 500

--- a/tests/test_metrics_alias.py
+++ b/tests/test_metrics_alias.py
@@ -22,5 +22,5 @@ def test_overview_endpoint_alias(monkeypatch):
     )
     app = create_app()
     client = TestClient(app)
-    resp = client.get("/metrics/aggregated")
+    resp = client.get("/v1/metrics/aggregated")
     assert resp.status_code == 200

--- a/tests/test_metrics_api.py
+++ b/tests/test_metrics_api.py
@@ -127,14 +127,14 @@ def test_overview_endpoint(test_client, monkeypatch):
         "utcnow",
         lambda: pd.Timestamp("2024-06-15", tz="UTC"),
     )
-    resp = client.get("/metrics/aggregated")
+    resp = client.get("/v1/metrics/aggregated")
     assert resp.status_code == 200
     data = resp.json()
     assert data["open_tickets"] == {"N1": 1, "N2": 1}
     assert data["tickets_closed_this_month"] == {"N1": 1, "N2": 1}
     assert data["status_distribution"] == {"new": 1, "closed": 2, "pending": 1}
     # call again should hit cache
-    resp = client.get("/metrics/aggregated")
+    resp = client.get("/v1/metrics/aggregated")
     assert resp.status_code == 200
     assert api_client.calls == 1
 
@@ -146,7 +146,7 @@ def test_level_endpoint(test_client, monkeypatch):
         "utcnow",
         lambda: pd.Timestamp("2024-06-15", tz="UTC"),
     )
-    resp = client.get("/metrics/levels/N1")
+    resp = client.get("/v1/metrics/levels/N1")
     assert resp.status_code == 200
     data = resp.json()
     assert data["open_tickets"] == 1
@@ -160,5 +160,5 @@ def test_error_handling(monkeypatch, test_client):
         raise RuntimeError("boom")
 
     monkeypatch.setattr(metrics_module, "_fetch_dataframe", fail)
-    resp = client.get("/metrics/aggregated")
+    resp = client.get("/v1/metrics/aggregated")
     assert resp.status_code == 500

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -30,10 +30,10 @@ def test_api_token_required(monkeypatch, dummy_cache):
     app = create_app(cache=dummy_cache)
     client = TestClient(app)
 
-    resp = client.get("/health")
+    resp = client.get("/v1/health")
     assert resp.status_code == 401
 
-    resp = client.get("/health", headers={"X-API-Token": "secret" * 8})
+    resp = client.get("/v1/health", headers={"X-API-Token": "secret" * 8})
     assert resp.status_code == 200
 
 

--- a/tests/test_worker_api.py
+++ b/tests/test_worker_api.py
@@ -105,14 +105,14 @@ async def test_app(dummy_cache: DummyCache):
 
 
 def test_rest_endpoints(test_app: TestClient):
-    resp = test_app.get("/tickets")
+    resp = test_app.get("/v1/tickets")
     assert resp.status_code == 200
     tickets = resp.json()
     assert isinstance(tickets, list)
     assert tickets and "id" in tickets[0]
     assert tickets[0]["requester"] == "Alice"
 
-    resp = test_app.get("/metrics/summary")
+    resp = test_app.get("/v1/metrics/summary")
     assert resp.status_code == 200
     metrics = resp.json()
     assert metrics == {"total": 2, "opened": 0, "closed": 2}
@@ -121,7 +121,7 @@ def test_rest_endpoints(test_app: TestClient):
 def test_aggregated_metrics(dummy_cache: DummyCache):
     dummy_cache.data["metrics_aggregated"] = {"status": {}, "per_user": {}}
     client = TestClient(create_app(client=FakeClient(), cache=dummy_cache))
-    resp = client.get("/metrics/aggregated")
+    resp = client.get("/v1/metrics/aggregated")
     assert resp.status_code == 200
     data = resp.json()
     assert "status" in data
@@ -156,11 +156,11 @@ def test_metrics_router_endpoints(
     monkeypatch.setattr("app.api.metrics.compute_level_metrics", fake_level_metrics)
 
     client = TestClient(create_app(client=FakeClient(), cache=dummy_cache))
-    resp = client.get("/metrics/aggregated")
+    resp = client.get("/v1/metrics/aggregated")
     assert resp.status_code == 200
     assert resp.json() == overview.model_dump()
 
-    resp = client.get("/metrics/levels/N1")
+    resp = client.get("/v1/metrics/levels/N1")
     assert resp.status_code == 200
     assert resp.json() == level.model_dump()
 
@@ -171,7 +171,7 @@ def test_chamados_por_data(dummy_cache: DummyCache):
         {"date": "2024-06-02", "total": 1},
     ]
     client = TestClient(create_app(client=FakeClient(), cache=dummy_cache))
-    resp = client.get("/chamados/por-data")
+    resp = client.get("/v1/chamados/por-data")
     assert resp.status_code == 200
     data = resp.json()
     assert data == [
@@ -186,7 +186,7 @@ def test_chamados_por_dia(dummy_cache: DummyCache):
         {"date": "2024-06-02", "total": 1},
     ]
     client = TestClient(create_app(client=FakeClient(), cache=dummy_cache))
-    resp = client.get("/chamados/por-dia")
+    resp = client.get("/v1/chamados/por-dia")
     assert resp.status_code == 200
     data = resp.json()
     assert data == [
@@ -198,7 +198,7 @@ def test_chamados_por_dia(dummy_cache: DummyCache):
 def test_chamados_por_data_cache(dummy_cache: DummyCache):
     session = FakeClient()
     client = TestClient(create_app(client=session, cache=dummy_cache))
-    first = client.get("/chamados/por-data").json()
+    first = client.get("/v1/chamados/por-data").json()
 
     def later_data(*args: object, **kwargs: object) -> list[CleanTicketDTO]:
         raw: list[dict[str, object]] = [
@@ -224,9 +224,9 @@ def test_chamados_por_data_cache(dummy_cache: DummyCache):
         return [CleanTicketDTO.model_validate(r) for r in raw]
 
     session.fetch_tickets = later_data  # type: ignore[assignment]
-    second = client.get("/chamados/por-data").json()
+    second = client.get("/v1/chamados/por-data").json()
     assert first == second
-    stats = client.get("/cache/stats").json()
+    stats = client.get("/v1/cache/stats").json()
     assert stats["hits"] == 1
     assert stats["misses"] == 2
 
@@ -234,7 +234,7 @@ def test_chamados_por_data_cache(dummy_cache: DummyCache):
 def test_chamados_por_dia_cache(dummy_cache: DummyCache):
     session = FakeClient()
     client = TestClient(create_app(client=session, cache=dummy_cache))
-    first = client.get("/chamados/por-dia").json()
+    first = client.get("/v1/chamados/por-dia").json()
 
     def later_data(*args: object, **kwargs: object) -> list[CleanTicketDTO]:
         raw: list[dict[str, object]] = [
@@ -260,9 +260,9 @@ def test_chamados_por_dia_cache(dummy_cache: DummyCache):
         return [CleanTicketDTO.model_validate(r) for r in raw]
 
     session.fetch_tickets = later_data  # type: ignore[assignment]
-    second = client.get("/chamados/por-dia").json()
+    second = client.get("/v1/chamados/por-dia").json()
     assert first == second
-    stats = client.get("/cache/stats").json()
+    stats = client.get("/v1/cache/stats").json()
     assert stats["hits"] == 1
     assert stats["misses"] == 2
 
@@ -277,11 +277,11 @@ async def test_loader_primes_cache(dummy_cache: DummyCache) -> None:
 
     client = TestClient(create_app(client=FakeClient(), cache=dummy_cache))
 
-    resp = client.get("/chamados/por-data")
+    resp = client.get("/v1/chamados/por-data")
     assert resp.status_code == 200
     assert resp.json() == dummy_cache.data["chamados_por_data"]
 
-    resp = client.get("/chamados/por-dia")
+    resp = client.get("/v1/chamados/por-dia")
     assert resp.status_code == 200
     assert resp.json() == dummy_cache.data["chamados_por_dia"]
 
@@ -289,11 +289,11 @@ async def test_loader_primes_cache(dummy_cache: DummyCache) -> None:
 def test_openapi_schema_models(dummy_cache: DummyCache):
     app = create_app(client=FakeClient(), cache=dummy_cache)
     schema = app.openapi()
-    por_data = schema["paths"]["/chamados/por-data"]["get"]["responses"]["200"][
+    por_data = schema["paths"]["/v1/chamados/por-data"]["get"]["responses"]["200"][
         "content"
     ]["application/json"]["schema"]
     assert por_data["items"]["$ref"].endswith("ChamadoPorData")
-    por_dia = schema["paths"]["/chamados/por-dia"]["get"]["responses"]["200"][
+    por_dia = schema["paths"]["/v1/chamados/por-dia"]["get"]["responses"]["200"][
         "content"
     ]["application/json"]["schema"]
     assert por_dia["items"]["$ref"].endswith("ChamadosPorDia")
@@ -316,7 +316,7 @@ def test_tickets_stream(monkeypatch: pytest.MonkeyPatch, dummy_cache: DummyCache
     )
 
     client = TestClient(create_app(client=FakeClient(), cache=dummy_cache))
-    resp = client.get("/tickets/stream")
+    resp = client.get("/v1/tickets/stream")
     assert resp.status_code == 200
     assert resp.text.splitlines() == ["fetching...", "done"]
 
@@ -355,8 +355,8 @@ def test_client_reused(monkeypatch: pytest.MonkeyPatch, dummy_cache: DummyCache)
 
     # Create the app without passing a client, so it uses the patched factory
     client = TestClient(create_app(cache=dummy_cache))
-    client.get("/tickets")
-    client.get("/metrics/summary")
+    client.get("/v1/tickets")
+    client.get("/v1/metrics/summary")
 
     # Only one client instance should have been created for the app's lifespan
     assert len(instances) == 1
@@ -364,8 +364,8 @@ def test_client_reused(monkeypatch: pytest.MonkeyPatch, dummy_cache: DummyCache)
 
 def test_cache_stats_endpoint(dummy_cache: DummyCache):
     client = TestClient(create_app(client=FakeClient(), cache=dummy_cache))
-    client.get("/tickets")
-    resp = client.get("/cache/stats")
+    client.get("/v1/tickets")
+    resp = client.get("/v1/cache/stats")
     assert resp.status_code == 200
     data = resp.json()
     assert data["misses"] == 2
@@ -374,9 +374,9 @@ def test_cache_stats_endpoint(dummy_cache: DummyCache):
 
 def test_cache_middleware(dummy_cache: DummyCache):
     client = TestClient(create_app(client=FakeClient(), cache=dummy_cache))
-    client.get("/tickets")
-    client.get("/tickets")
-    resp = client.get("/cache/stats")
+    client.get("/v1/tickets")
+    client.get("/v1/tickets")
+    resp = client.get("/v1/cache/stats")
     data = resp.json()
     assert data["hits"] == 1
     assert data["misses"] == 2
@@ -384,14 +384,14 @@ def test_cache_middleware(dummy_cache: DummyCache):
 
 def test_health_glpi(dummy_cache: DummyCache):
     client = TestClient(create_app(client=FakeClient(), cache=dummy_cache))
-    resp = client.get("/health")
+    resp = client.get("/v1/health")
     assert resp.status_code == 200
     assert resp.json()["status"] == "success"
 
 
 def test_health_glpi_head_success(dummy_cache: DummyCache) -> None:
     client = TestClient(create_app(client=FakeClient(), cache=dummy_cache))
-    resp = client.head("/health")
+    resp = client.head("/v1/health")
     assert resp.status_code == 200
     assert resp.text == ""
 
@@ -407,7 +407,7 @@ def test_redis_connection_error(
         create_app(client=FakeClient(), cache=dummy_cache),
         raise_server_exceptions=False,
     )
-    resp = client.get("/tickets")
+    resp = client.get("/v1/tickets")
     assert resp.status_code == 500
     assert "Internal Server Error" in resp.text
 
@@ -426,7 +426,7 @@ def test_health_glpi_auth_failure(
         create_app(client=FakeClient(), cache=dummy_cache),
         raise_server_exceptions=False,
     )
-    resp = client.get("/health")
+    resp = client.get("/v1/health")
     assert resp.status_code == 500
     data = resp.json()
     assert data["status"] == "error"
@@ -448,7 +448,7 @@ def test_session_init_failure_fallback(
     app.dependency_overrides[get_glpi_client] = lambda: None
     client = TestClient(app)
 
-    resp = client.get("/tickets")
+    resp = client.get("/v1/tickets")
     assert resp.status_code == 200
     assert resp.headers.get("X-Warning") == "using mock data"
     tickets = resp.json()
@@ -457,16 +457,16 @@ def test_session_init_failure_fallback(
 
 def test_breaker_content_type(dummy_cache: DummyCache):
     client = TestClient(create_app(client=FakeClient(), cache=dummy_cache))
-    resp = client.get("/breaker")
+    resp = client.get("/v1/breaker")
     assert resp.status_code == 200
     assert resp.headers["content-type"] == CONTENT_TYPE_LATEST
 
 
 def test_cache_metrics_legacy(dummy_cache: DummyCache):
     client = TestClient(create_app(client=FakeClient(), cache=dummy_cache))
-    client.get("/tickets")
-    legacy = client.get("/cache-metrics")
-    stats = client.get("/cache/stats")
+    client.get("/v1/tickets")
+    legacy = client.get("/v1/cache-metrics")
+    stats = client.get("/v1/cache/stats")
     assert legacy.status_code == 200
     assert legacy.json() == stats.json()
 
@@ -479,7 +479,7 @@ def test_read_model_db_error(monkeypatch: pytest.MonkeyPatch, dummy_cache: Dummy
 
     monkeypatch.setattr("backend.api.worker_api.query_ticket_summary", raise_db_error)
     client = TestClient(create_app(client=FakeClient(), cache=dummy_cache))
-    resp = client.get("/read-model/tickets")
+    resp = client.get("/v1/read-model/tickets")
     assert resp.status_code == 503
     assert "Read model is currently unavailable" in resp.json()["detail"]
 
@@ -488,7 +488,7 @@ def test_metrics_aggregated_cache(dummy_cache: DummyCache):
     dummy_cache.data["metrics_aggregated"] = {"status": {}, "per_user": {}}
     session = FakeClient()
     client = TestClient(create_app(client=session, cache=dummy_cache))
-    first = client.get("/metrics/aggregated").json()
+    first = client.get("/v1/metrics/aggregated").json()
 
     def later_data(*args: object, **kwargs: object) -> list[CleanTicketDTO]:
         raw: list[dict[str, object]] = [
@@ -505,10 +505,10 @@ def test_metrics_aggregated_cache(dummy_cache: DummyCache):
         return [CleanTicketDTO.model_validate(r) for r in raw]
 
     session.fetch_tickets = later_data  # type: ignore[assignment]
-    second = client.get("/metrics/aggregated").json()
+    second = client.get("/v1/metrics/aggregated").json()
 
     assert first == second
-    stats = client.get("/cache/stats").json()
+    stats = client.get("/v1/cache/stats").json()
     assert stats["hits"] >= 1
 
 
@@ -531,7 +531,7 @@ def test_metrics_levels_endpoint(
     """Return cached status counts grouped by ticket level."""
     dummy_cache.data = cache_data
     client = TestClient(create_app(client=FakeClient(), cache=dummy_cache))
-    resp = client.get("/metrics/levels")
+    resp = client.get("/v1/metrics/levels")
     assert resp.status_code == expected_status
     assert resp.json() == expected_response
 
@@ -540,6 +540,6 @@ def test_metrics_levels(dummy_cache: DummyCache) -> None:
     """Return cached status counts grouped by ticket level."""
     dummy_cache.data["metrics_levels"] = {"N1": {"new": 1, "pending": 2, "solved": 0}}
     client = TestClient(create_app(client=FakeClient(), cache=dummy_cache))
-    resp = client.get("/metrics/levels")
+    resp = client.get("/v1/metrics/levels")
     assert resp.status_code == 200
     assert resp.json() == {"N1": {"new": 1, "pending": 2, "solved": 0}}


### PR DESCRIPTION
## Summary
- register all REST routes on a shared APIRouter
- mount router under `/v1`
- update front-end hooks, tests and docs to use the new prefix
- adjust healthcheck script

## Testing
- `pytest tests/test_worker_api.py tests/test_metrics_api.py tests/test_metrics_alias.py tests/test_security.py tests/test_health_endpoint.py` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*

------
https://chatgpt.com/codex/tasks/task_e_688bbea1222483209aea4caa2b11da89