### PR TITLE
Add API version prefix docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,7 +477,7 @@ When the FastAPI service starts it primes the Redis cache by calling
 `load_tickets()`. This fills the `chamados_por_data` and
 `metrics_aggregated` keys so endpoints are responsive immediately.
 
-- The service exposes several endpoints:
+- The service exposes several endpoints (all prefixed with `/v1`):
 
  - `/v1/tickets` – full list of tickets in JSON format. The payload includes the
    ticket `priority` label and the `requester` name when available.

--- a/src/backend/api/worker_api.py
+++ b/src/backend/api/worker_api.py
@@ -1,4 +1,9 @@
-"""FastAPI service exposing GLPI tickets via REST and GraphQL."""
+"""FastAPI service exposing GLPI tickets via REST and GraphQL.
+
+All REST endpoints must be accessed with the ``/v1`` prefix. GraphQL is
+available at ``/v1/graphql``. This convention allows new versions to
+coexist without breaking existing clients.
+"""
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary
- document `/v1` prefix usage in README
- clarify version prefix in worker API module docstring

## Testing
- `pytest tests/test_worker_api.py::test_rest_endpoints tests/test_worker_api.py::test_graphql_query -q`

------
https://chatgpt.com/codex/tasks/task_e_688bd7eaf4108320943280a1ed5dd2e2