### PR TITLE
Remove deprecated save_json function

### DIFF
--- a/docs/prompt_cookbook_codex.md
+++ b/docs/prompt_cookbook_codex.md
@@ -29,7 +29,6 @@ Crie backend/utils/pipeline.py com:
 - process_raw(data: List[dict]) -> pandas.DataFrame
 - Campos obrigatórios: id, status, group, date_creation, assigned_to, requester
 - Converta datas para datetime, preencha NaN com None
-- Função save_json(df, path="mock/sample_data.json")
 ```
 
 ### 3️⃣ Gerar **dashboard/layout.py**

--- a/src/backend/utils/__init__.py
+++ b/src/backend/utils/__init__.py
@@ -3,11 +3,10 @@
 from shared.utils.logging import init_logging, set_correlation_id
 
 from .pagination import paginate_items
-from .pipeline import process_raw, save_json
+from .pipeline import process_raw
 
 __all__ = [
     "process_raw",
-    "save_json",
     "init_logging",
     "set_correlation_id",
     "paginate_items",

--- a/src/backend/utils/pipeline.py
+++ b/src/backend/utils/pipeline.py
@@ -2,15 +2,6 @@
 
 from __future__ import annotations
 
-from pandas import DataFrame
-
 from backend.infrastructure.glpi.normalization import process_raw
 
-
-def save_json(df: DataFrame, path: str = "mock/sample_data.json") -> None:
-    """Save dataframe to JSON file."""
-
-    df.to_json(path, orient="records", indent=2, date_format="iso")
-
-
-__all__ = ["process_raw", "save_json"]
+__all__ = ["process_raw"]


### PR DESCRIPTION
## Summary
- drop `save_json` function from `backend.utils.pipeline`
- stop exporting `save_json` in `backend.utils`
- update prompt cookbook to remove reference

## Testing
- `pre-commit run --files src/backend/utils/pipeline.py src/backend/utils/__init__.py docs/prompt_cookbook_codex.md`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fakeredis')*

------
https://chatgpt.com/codex/tasks/task_e_688bd990e83483208eaa85ad3c5e0fad

## Resumo por Sourcery

Remove o utilitário obsoleto `save_json` e limpa as exportações e documentação relacionadas

Documentação:
- Remove referências a `save_json` da documentação do prompt cookbook

Tarefas:
- Elimina a função `save_json` e sua exportação de `backend.utils.pipeline`
- Deixa de exportar `save_json` na inicialização de `backend.utils`

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove the deprecated save_json utility and clean up related exports and documentation

Documentation:
- Remove save_json references from the prompt cookbook documentation

Chores:
- Drop the save_json function and its export from backend.utils.pipeline
- Stop exporting save_json in backend.utils initialization

</details>