### PR TITLE
Relocate example_api to examples directory

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -2,7 +2,7 @@
 
 Este diretório reúne material educativo usado em treinamentos e demonstrações. Nenhum dos scripts aqui presentes é empacotado no build de produção.
 
-Arquivos como `song_serializer.py`, `sort_strategy.py` e `demo_resilient_client.py` servem apenas como referência de padrões e experimentos. Esses exemplos ficavam originalmente em `src/patterns/` ou `labs/patterns/` e foram movidos para cá para reforçar que não fazem parte do código de produção.
+Arquivos como `song_serializer.py`, `sort_strategy.py`, `demo_resilient_client.py` e `example_api.py` servem apenas como referência de padrões e experimentos. Esses exemplos ficavam originalmente em `src/patterns/` ou `labs/patterns/` e foram movidos para cá para reforçar que não fazem parte do código de produção.
 
 These examples are for educational purposes only and are not intended for production use.
 

--- a/examples/example_api.py
+++ b/examples/example_api.py
@@ -1,0 +1,23 @@
+"""Example API call using retry_api_call."""
+
+from __future__ import annotations
+
+import random
+
+import requests  # type: ignore
+
+from src.shared.utils.resilience.retry_decorator import retry_api_call
+
+
+@retry_api_call
+def unstable_call(url: str) -> dict:
+    if random.random() < 0.7:
+        raise requests.exceptions.HTTPError("simulated failure")
+    resp = requests.Response()
+    resp._content = b'{"status": "ok"}'
+    resp.status_code = 200
+    return resp.json()
+
+
+if __name__ == "__main__":
+    print(unstable_call("http://example.com"))


### PR DESCRIPTION
## Summary
- restore `example_api.py` and place it under `examples/`
- mention the example in `examples/README.md`

## Testing
- `pre-commit run --files examples/example_api.py examples/README.md`
- `pytest tests/test_circuit_breaker.py::test_breaker_opens_after_failures -q`

------
https://chatgpt.com/codex/tasks/task_e_688bdd8463fc83209cf1ae1c7ae547c4

## Resumo por Sourcery

Restaurar o script example_api no diretório examples e atualizar o README dos exemplos para referenciá-lo

Melhorias:
- Restaurar e realocar example_api.py sob o diretório examples/

Documentação:
- Adicionar example_api.py à lista de scripts de referência em examples/README.md

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restore example_api script in the examples directory and update the examples README to reference it

Enhancements:
- Restore and relocate example_api.py under the examples/ directory

Documentation:
- Add example_api.py to the list of reference scripts in examples/README.md

</details>