### PR TITLE
Fix import path for process_raw

### DIFF
--- a/dashboard_app.py
+++ b/dashboard_app.py
@@ -24,7 +24,7 @@ from backend.core.settings import (
 from backend.domain.exceptions import GLPIAPIError
 from backend.infrastructure.glpi import glpi_client_logging
 from backend.infrastructure.glpi.glpi_session import Credentials, GLPISession
-from backend.utils import process_raw
+from backend.infrastructure.glpi.normalization import process_raw
 
 __all__ = ["create_app", "main"]
 


### PR DESCRIPTION
## Summary
- update `dashboard_app.py` to import `process_raw` from the normalization module

## Testing
- `pre-commit run --files dashboard_app.py`
- `pytest tests/test_pagination.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688bdd7f7fe88320815252034bd0120e

## Resumo por Sourcery

Correções de Bug:
- Atualizar importação de `process_raw` para usar o módulo `backend.infrastructure.glpi.normalization`

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Update process_raw import to use backend.infrastructure.glpi.normalization module

</details>