### PR TITLE
Update docs and frontend to use /v1 API prefix

### DIFF
--- a/docs/ARCHITECTURE_backup.md
+++ b/docs/ARCHITECTURE_backup.md
@@ -15,7 +15,7 @@ This document provides a quick overview of how the repository is structured, the
 
 1. `glpi_session.py` authenticates against the GLPI REST API.
 2. Background workers normalise the responses into `pandas.DataFrame` objects and store them in Redis/PostgreSQL.
-3. The FastAPI layer (`src/backend/api/worker_api.py`) exposes `/tickets` and `/metrics` endpoints that read from this cache. The `/tickets` response now includes the `priority` label and the requester name.
+3. The FastAPI layer (`src/backend/api/worker_api.py`) exposes `/v1/tickets` and `/v1/metrics/summary` endpoints that read from this cache. The `/v1/tickets` response now includes the `priority` label and the requester name.
 4. Dash components or the React front‑end request these endpoints to render tables and charts.
 
 ```text

--- a/docs/adr/0004-cache-strategy.md
+++ b/docs/adr/0004-cache-strategy.md
@@ -15,7 +15,7 @@ expiration times was not documented.
 ## Decision
 
 Store all aggregated ticket data in Redis with explicit TTLs.  Endpoints such as
-`/metrics/aggregated` expire after one hour, while daily summaries keep data for
+`/v1/metrics/aggregated` expire after one hour, while daily summaries keep data for
 24 hours.  The worker updates Redis after fetching from GLPI and persists the
 results to PostgreSQL for long‑term storage.
 

--- a/docs/adr/0005-observability.md
+++ b/docs/adr/0005-observability.md
@@ -14,8 +14,8 @@ Grafana but observability decisions were not yet captured in an ADR.
 
 ## Decision
 
-Expose Prometheus metrics from the FastAPI worker at `/metrics` and circuit
-breaker stats at `/breaker`.  Ship default Grafana dashboards and logging in
+Expose Prometheus metrics from the FastAPI worker at `/v1/metrics` and circuit
+breaker stats at `/v1/breaker`.  Ship default Grafana dashboards and logging in
 structured JSON.  These tools run as optional containers in Docker Compose and
 are enabled in staging and production environments.
 

--- a/docs/developer_usage.md
+++ b/docs/developer_usage.md
@@ -74,11 +74,11 @@ python worker.py
 
 Endpoints relevantes:
 
-- `/tickets` – lista completa de chamados
+- `/v1/tickets` – lista completa de chamados
  - A resposta inclui os campos `priority` e `requester` em formato textual.
-- `/metrics` – contagem de abertos/fechados
-- `/graphql/` – versão GraphQL
-- `/cache/stats` – estatísticas de cache
+- `/v1/metrics/summary` – contagem de abertos/fechados
+- `/v1/graphql/` – versão GraphQL
+- `/v1/cache/stats` – estatísticas de cache
 
 Exemplo de retorno:
 
@@ -115,7 +115,7 @@ conhecidos. Por padrão o caminho é `docs/knowledge_base_errors.md`.
    `.env.example`.
 3. Reinicie o `worker.py` para que o conteúdo seja recarregado.
 
-É possível consultar o material via endpoint `GET /knowledge-base`.
+É possível consultar o material via endpoint `GET /v1/knowledge-base`.
 
 ## Testes e Lint
 
@@ -210,7 +210,7 @@ O helper `useApiQuery` padroniza chamadas ao worker API. Ele recebe uma
 `queryKey`, o `endpoint` e, opcionalmente, um objeto de opções do React Query:
 
 ```ts
-const { data, isLoading } = useApiQuery(['tickets'], '/tickets')
+const { data, isLoading } = useApiQuery(['tickets'], '/v1/tickets')
 ```
 
 Se precisar passar opções criadas inline, serializá-las ou extraia-as para uma

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -100,22 +100,22 @@ Imports reference `@/` as a shortcut to the `src/` folder. Both Vite and TypeScr
 
 ### API Integration
 
-Start the worker with `python worker.py` (it listens on port `8000` by default) and point the front-end to it using the `NEXT_PUBLIC_API_BASE_URL` variable. The `/tickets` endpoint now returns the `priority` label and the `requester` name. Example fetching ticket metrics:
+Start the worker with `python worker.py` (it listens on port `8000` by default) and point the front-end to it using the `NEXT_PUBLIC_API_BASE_URL` variable. The `/v1/tickets` endpoint now returns the `priority` label and the `requester` name. Example fetching ticket metrics:
 
 ```ts
-const resp = await fetch(`${import.meta.env.NEXT_PUBLIC_API_BASE_URL}/tickets/metrics`);
+const resp = await fetch(`${import.meta.env.NEXT_PUBLIC_API_BASE_URL}/v1/metrics/summary`);
 const data = await resp.json();
 ```
 
-The worker also streams progress using `/tickets/stream`:
+The worker also streams progress using `/v1/tickets/stream`:
 
 ```ts
-const url = `${import.meta.env.NEXT_PUBLIC_API_BASE_URL}/tickets/stream`;
+const url = `${import.meta.env.NEXT_PUBLIC_API_BASE_URL}/v1/tickets/stream`;
 const es = new EventSource(url);
 es.onmessage = (ev) => console.log('chunk', ev.data);
 ```
 
-For aggregated statistics the worker offers `/metrics/aggregated`. This endpoint
+For aggregated statistics the worker offers `/v1/metrics/aggregated`. This endpoint
 returns cached counts grouped by status and technician, enabling dashboards to
 load summary values quickly.
 

--- a/docs/frontend_charts.md
+++ b/docs/frontend_charts.md
@@ -6,8 +6,8 @@ This guide describes how to display GLPI ticket trends and heatmaps using SWR an
 
 Two REST routes provide the aggregated data used by the charts and leverage the worker's Redis cache:
 
-- `/chamados/por-data` — returns a list of `{ "date": "YYYY-MM-DD", "total": n }` grouped by ticket creation date. The response is cached for **one hour**.
-- `/chamados/por-dia` — returns the same structure for calendar heatmap totals and is cached for **24 hours**.
+- `/v1/chamados/por-data` — returns a list of `{ "date": "YYYY-MM-DD", "total": n }` grouped by ticket creation date. The response is cached for **one hour**.
+- `/v1/chamados/por-dia` — returns the same structure for calendar heatmap totals and is cached for **24 hours**.
 
 Both endpoints perform the aggregation server-side so the front-end only consumes summarized values.
 
@@ -19,7 +19,7 @@ requests in the examples below use this variable.
 
 ### `useChamadosPorData`
 
-Fetches aggregated ticket counts per day from `/chamados/por-data`.
+Fetches aggregated ticket counts per day from `/v1/chamados/por-data`.
 
 ```ts
 import useSWR from 'swr'
@@ -32,7 +32,7 @@ export interface ChamadoPorData {
 
 export function useChamadosPorData() {
   const { data, error, isLoading } = useSWR<ChamadoPorData[]>(
-    '/chamados/por-data',
+    '/v1/chamados/por-data',
     fetcher,
     { refreshInterval: 60000, revalidateOnFocus: false },
   )
@@ -41,13 +41,13 @@ export function useChamadosPorData() {
 }
 
 // The fetcher prefixes `NEXT_PUBLIC_API_BASE_URL` automatically,
-// so `/chamados/por-data` resolves to
-// `${import.meta.env.NEXT_PUBLIC_API_BASE_URL}/chamados/por-data`.
+// so `/v1/chamados/por-data` resolves to
+// `${import.meta.env.NEXT_PUBLIC_API_BASE_URL}/v1/chamados/por-data`.
 ```
 
 ### `useChamadosPorDia`
 
-Same pattern but pointing to `/chamados/por-dia` for daily totals.
+Same pattern but pointing to `/v1/chamados/por-dia` for daily totals.
 
 ## Components
 

--- a/docs/glpi_tokens_guide.md
+++ b/docs/glpi_tokens_guide.md
@@ -92,7 +92,7 @@ Todos os serviços devem aparecer como **running / healthy**.
 
 ## 7 ▪️ Acessar o dashboard
 
-- **API worker:** <http://localhost:8000/metrics>
+- **API worker:** <http://localhost:8000/v1/metrics/summary>
 - **Dashboard (Dash/Plotly):** <http://localhost:8080>
 
 Caso a API esteja indisponível ou tokens inválidos, o front‑end exibe um alerta amigável:
@@ -128,7 +128,7 @@ Cobertura mínima de 85 % garantida no CI (GitHub Actions).
 ## 10 ▪️ Monitoramento de produção
 
 O contêiner **worker** possui `HEALTHCHECK` interno que executa `curl -I` no␊
-endpoint `/health` (método **HEAD**). A rota `GET` continua disponível para
+endpoint `/v1/health` (método **HEAD**). A rota `GET` continua disponível para
 verificações manuais. Use:
 
 ```bash

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,6 +1,6 @@
 # Observability
 
-The development compose file includes Prometheus and Grafana services. Prometheus scrapes metrics from the FastAPI backend at `/metrics` and the circuit breaker endpoint `/breaker`.
+The development compose file includes Prometheus and Grafana services. Prometheus scrapes metrics from the FastAPI backend at `/v1/metrics` and the circuit breaker endpoint `/v1/breaker`.
 
 ## FastAPI instrumentation
 
@@ -16,7 +16,7 @@ Instrumentator().instrument(app).expose(app)
 ```
 
 The library [`prometheus-fastapi-instrumentator`](https://github.com/trallnag/prometheus-fastapi-instrumentator)
-collects default metrics and exposes them at the `/metrics` endpoint.
+collects default metrics and exposes them at the `/v1/metrics` endpoint.
 
 `resources/prometheus.yml` (development compose file) configures Prometheus to scrape the metrics endpoint:
 
@@ -25,15 +25,15 @@ scrape_configs:
   - job_name: 'fastapi'
     static_configs:
       - targets: ['localhost:8000']
-    metrics_path: /metrics
+    metrics_path: /v1/metrics
   - job_name: 'circuitbreaker'
     static_configs:
       - targets: ['localhost:8000']
-    metrics_path: /breaker
+    metrics_path: /v1/breaker
 ```
 
-Prometheus scrapes both the default `/metrics` endpoint instrumented by the
-FastAPI application and the circuit breaker metrics at `/breaker`.
+Prometheus scrapes both the default `/v1/metrics` endpoint instrumented by the
+FastAPI application and the circuit breaker metrics at `/v1/breaker`.
 
 Grafana loads dashboards from JSON. An example (`resources/grafana_dashboard.json`):
 

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -22,7 +22,7 @@ The dashboard aggregates GLPI service desk metrics using a FastAPI backend and a
 
    The command prints `✅ Conexão com GLPI bem-sucedida!` when the API accepts
    the tokens. If the variables are missing or invalid the worker's␊
-   `/health` endpoint will return **HTTP 500**.
+   `/v1/health` endpoint will return **HTTP 500**.
 
    Example snippet:
 

--- a/src/frontend/react_app/scripts/healthcheck/healthcheck-webapp.sh
+++ b/src/frontend/react_app/scripts/healthcheck/healthcheck-webapp.sh
@@ -4,7 +4,7 @@
 
 set -euo pipefail
 
-WEBAPP_URL="${WEBAPP_URL:-http://localhost:8000/health}"
+WEBAPP_URL="${WEBAPP_URL:-http://localhost:8000/v1/health}"
 
 curl --fail --head "$WEBAPP_URL" > /dev/null
 

--- a/src/frontend/react_app/src/components/GlpiTicketsTable.tsx
+++ b/src/frontend/react_app/src/components/GlpiTicketsTable.tsx
@@ -32,7 +32,7 @@ export function GlpiTicketsTable() {
     error,
     isSuccess,
     refetch,
-  } = useApiQuery<Ticket[]>(['tickets'], '/tickets')
+  } = useApiQuery<Ticket[]>(['tickets'], '/v1/tickets')
 
   const sortedTickets = useMemo(() => {
     if (!tickets) return []

--- a/src/frontend/react_app/src/features/tickets/api.ts
+++ b/src/frontend/react_app/src/features/tickets/api.ts
@@ -2,5 +2,5 @@ import { useApiQuery } from '../../hooks/useApiQuery'
 import type { TicketMetrics } from '../../types/dashboard'
 
 export function useTicketMetrics() {
-  return useApiQuery<TicketMetrics>(['ticket-metrics'], '/metrics')
+  return useApiQuery<TicketMetrics>(['ticket-metrics'], '/v1/metrics/summary')
 }

--- a/src/frontend/react_app/src/hooks/useChamadosPorData.ts
+++ b/src/frontend/react_app/src/hooks/useChamadosPorData.ts
@@ -35,7 +35,7 @@ import type { ChamadoPorData } from '../types/chamado'
  * }
  */
 export function useChamadosPorData() {
-  return useApiQuery<ChamadoPorData[]>(['chamados-por-data'], '/chamados/por-data', {
+  return useApiQuery<ChamadoPorData[]>(['chamados-por-data'], '/v1/chamados/por-data', {
     staleTime: 1000 * 60 * 5, // 5 minutos
     gcTime: 1000 * 60 * 10, // 10 minutos
     refetchOnWindowFocus: true,

--- a/src/frontend/react_app/src/hooks/useChamadosPorDia.ts
+++ b/src/frontend/react_app/src/hooks/useChamadosPorDia.ts
@@ -2,7 +2,7 @@ import { useApiQuery } from './useApiQuery'
 import type { ChamadoPorDia } from '../types/chamado'
 
 export function useChamadosPorDia() {
-  const query = useApiQuery<ChamadoPorDia[]>(['chamados-por-dia'], '/chamados/por-dia', {
+  const query = useApiQuery<ChamadoPorDia[]>(['chamados-por-dia'], '/v1/chamados/por-dia', {
     refetchInterval: 60000,
   })
 

--- a/src/frontend/react_app/src/hooks/useDashboardData.ts
+++ b/src/frontend/react_app/src/hooks/useDashboardData.ts
@@ -26,7 +26,7 @@ export function useDashboardData(filters?: FiltersState) {
   const serialized = stableStringify(filters)
   const query = useApiQuery<Aggregated>(
     ['metrics-aggregated', serialized],
-    `/metrics/aggregated${qs}`,
+    `/v1/metrics/aggregated${qs}`,
     {
       // Automatically refetch metrics every 30 seconds
       refetchInterval: 30000,

--- a/src/frontend/react_app/src/hooks/useLevelsMetrics.ts
+++ b/src/frontend/react_app/src/hooks/useLevelsMetrics.ts
@@ -18,7 +18,7 @@ const LEVELS_QUERY_KEY = ['levels-metrics'] as const
 
 export function useLevelsMetrics() {
   const queryClient = useQueryClient()
-  const query = useApiQuery<Record<string, LevelMetrics>>(LEVELS_QUERY_KEY, '/metrics/levels')
+  const query = useApiQuery<Record<string, LevelMetrics>>(LEVELS_QUERY_KEY, '/v1/metrics/levels')
 
   const levels = useMemo<LevelEntry[]>(() => {
     if (!query.data) return []

--- a/src/frontend/react_app/src/hooks/useMetricsLevels.ts
+++ b/src/frontend/react_app/src/hooks/useMetricsLevels.ts
@@ -14,7 +14,7 @@ interface ApiLevelMetrics {
 export function useMetricsLevels() {
   const query = useApiQuery<Record<string, ApiLevelMetrics>>(
     ['metrics-levels'],
-    '/metrics/levels',
+    '/v1/metrics/levels',
     { refetchInterval: 60000 },
   )
 

--- a/src/frontend/react_app/src/hooks/useMetricsOverview.ts
+++ b/src/frontend/react_app/src/hooks/useMetricsOverview.ts
@@ -18,7 +18,7 @@ export function useMetricsOverview() {
   const queryClient = useQueryClient()
   const query = useApiQuery<Record<string, ApiMetricsEntry>>(
     METRICS_QUERY_KEY,
-    '/metrics/overview',
+    '/v1/metrics/overview',
     {
       refetchInterval: POLLING_INTERVAL_MS,
     },

--- a/src/frontend/react_app/src/hooks/useTickets.ts
+++ b/src/frontend/react_app/src/hooks/useTickets.ts
@@ -26,7 +26,7 @@ export function useTickets(filters?: FiltersState) {
   const serialized = stableStringify(filters as Record<string, unknown> | undefined)
   const query = useApiQuery<CleanTicketDTO[]>(
     ['tickets', serialized],
-    `/tickets${qs}`,
+    `/v1/tickets${qs}`,
   )
   const tickets = useMemo(() => query.data?.map(toTicket), [query.data])
 

--- a/src/frontend/react_app/tests/hooks/useApiQuery.test.tsx
+++ b/src/frontend/react_app/tests/hooks/useApiQuery.test.tsx
@@ -23,7 +23,7 @@ describe('useApiQuery', () => {
   })
 
   it('deve iniciar em estado de carregamento', () => {
-    const { result } = renderHook(() => useApiQuery(['tickets'], '/tickets'), {
+    const { result } = renderHook(() => useApiQuery(['tickets'], '/v1/tickets'), {
       wrapper,
     })
     expect(result.current.isLoading).toBe(true)
@@ -38,7 +38,7 @@ describe('useApiQuery', () => {
       json: async () => mockData,
     } as Response)
 
-    const { result } = renderHook(() => useApiQuery(['tickets'], '/tickets'), {
+    const { result } = renderHook(() => useApiQuery(['tickets'], '/v1/tickets'), {
       wrapper,
     })
 
@@ -46,14 +46,14 @@ describe('useApiQuery', () => {
 
     expect(result.current.data).toEqual(mockData)
     expect(result.current.error).toBeNull()
-    expect(fetchMock).toHaveBeenCalledWith(`${MOCK_API_URL}/tickets`, expect.any(Object))
+    expect(fetchMock).toHaveBeenCalledWith(`${MOCK_API_URL}/v1/tickets`, expect.any(Object))
   })
 
   it('deve tratar erros de busca e atualizar o estado', async () => {
     const errorMessage = 'Network Error'
     fetchMock.mockRejectedValue(new Error(errorMessage))
 
-    const { result } = renderHook(() => useApiQuery(['tickets'], '/tickets'), {
+    const { result } = renderHook(() => useApiQuery(['tickets'], '/v1/tickets'), {
       wrapper,
     })
 
@@ -67,7 +67,7 @@ describe('useApiQuery', () => {
   it('deve tratar erro de URL base não configurada', async () => {
     delete process.env.NEXT_PUBLIC_API_BASE_URL
 
-    const { result } = renderHook(() => useApiQuery(['tickets'], '/tickets'), {
+    const { result } = renderHook(() => useApiQuery(['tickets'], '/v1/tickets'), {
       wrapper,
     })
 

--- a/src/frontend/react_app/tests/integration/health.test.ts
+++ b/src/frontend/react_app/tests/integration/health.test.ts
@@ -1,16 +1,16 @@
 test('health endpoint', async () => {
   const base = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8000';
-  const res = await fetch(`${base}/health`);
+  const res = await fetch(`${base}/v1/health`);
   expect(res.status).toBe(200);
 });
 
 test('health endpoint HEAD', async () => {
   const base = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8000';
-  let res = await fetch(`${base}/health`, { method: 'HEAD' });
+  let res = await fetch(`${base}/v1/health`, { method: 'HEAD' });
 
   // Caso res.status seja undefined, faz um GET como fallback
   if (typeof res.status !== 'number') {
-    res = await fetch(`${base}/health`);
+    res = await fetch(`${base}/v1/health`);
   }
   expect(res.status).toBe(200);
 });


### PR DESCRIPTION
## Summary
- update documentation to show `/v1` REST paths
- adjust React hooks, tests and healthcheck script to use versioned endpoints

## Testing
- `pre-commit run --files docs/developer_usage.md docs/frontend_architecture.md docs/frontend_charts.md docs/glpi_tokens_guide.md docs/observability.md docs/adr/0005-observability.md docs/adr/0004-cache-strategy.md docs/onboarding.md docs/ARCHITECTURE_backup.md src/frontend/react_app/src/features/tickets/api.ts src/frontend/react_app/src/components/GlpiTicketsTable.tsx src/frontend/react_app/src/hooks/useTickets.ts src/frontend/react_app/src/hooks/useChamadosPorData.ts src/frontend/react_app/src/hooks/useChamadosPorDia.ts src/frontend/react_app/src/hooks/useMetricsOverview.ts src/frontend/react_app/src/hooks/useMetricsLevels.ts src/frontend/react_app/src/hooks/useLevelsMetrics.ts src/frontend/react_app/src/hooks/useDashboardData.ts src/frontend/react_app/scripts/healthcheck/healthcheck-webapp.sh src/frontend/react_app/tests/integration/health.test.ts src/frontend/react_app/tests/hooks/useApiQuery.test.tsx`
- `pytest --override-ini addopts='' -q` *(fails: 54 errors during collection)*


------
https://chatgpt.com/codex/tasks/task_e_688bd83157b88320b2e8685537aa8498