### PR TITLE
Refactor models into backend.schemas

### DIFF
--- a/dashboard_app.py
+++ b/dashboard_app.py
@@ -22,8 +22,9 @@ from backend.core.settings import (
     USE_MOCK_DATA,
 )
 from backend.domain.exceptions import GLPIAPIError
-from backend.infrastructure.glpi.glpi_session import Credentials, GLPISession
+from backend.infrastructure.glpi.glpi_session import GLPISession
 from backend.infrastructure.glpi.normalization import process_raw
+from backend.schemas.auth import Credentials
 from shared.utils.logging import init_logging
 
 __all__ = ["create_app", "main"]

--- a/docs/REFACTOR_LOG.md
+++ b/docs/REFACTOR_LOG.md
@@ -63,5 +63,8 @@ Descrição: Script auxilia na movimentação de módulos Python utilizando a bi
 ## 📄 Atualizacao 2025-07-31
 
 - Removido `src/backend/utils/cache.py` (substituído por `src/backend/utils/redis_client.py`) e o teste correspondente `tests/test_cache_initialization.py`.
-- Removido `src/shared/utils/resilience/example_api.py` por se tratar de exemplo obsoleto.
--
+ - Removido `src/shared/utils/resilience/example_api.py` por se tratar de exemplo obsoleto.
+
+## 📄 Atualizacao 2025-08-01
+
+- Movidos modelos para `src/backend/schemas/` e ajustados imports em todo o projeto.

--- a/docs/cookbook/glpi-session.md
+++ b/docs/cookbook/glpi-session.md
@@ -25,7 +25,8 @@ invalid, making troubleshooting straightforward during deployment.
 2. Create a ``GLPISession`` using ``async with`` to ensure proper cleanup:
 
    ```python
-   from backend.infrastructure.glpi.glpi_session import Credentials, GLPISession
+   from backend.schemas.auth import Credentials
+   from backend.infrastructure.glpi.glpi_session import GLPISession
 
    creds = Credentials(app_token="APP", user_token="USER")
    async with GLPISession("https://glpi/api", creds) as session:

--- a/src/backend/adapters/factory.py
+++ b/src/backend/adapters/factory.py
@@ -13,7 +13,8 @@ from backend.core.settings import (
     USE_MOCK_DATA,
     VERIFY_SSL,
 )
-from backend.infrastructure.glpi.glpi_session import Credentials, GLPISession
+from backend.infrastructure.glpi.glpi_session import GLPISession
+from backend.schemas.auth import Credentials
 from shared.dto import TicketTranslator
 
 from .mapping_service import MappingService

--- a/src/backend/api/worker_api.py
+++ b/src/backend/api/worker_api.py
@@ -25,7 +25,6 @@ from fastapi.responses import (
 )
 from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
 from prometheus_fastapi_instrumentator import Instrumentator
-from pydantic import BaseModel, Field
 from strawberry.fastapi import GraphQLRouter
 from strawberry.types import Info
 
@@ -45,6 +44,7 @@ from backend.application.ticket_loader import (
     stream_tickets,
 )
 from backend.core.settings import KNOWLEDGE_BASE_FILE
+from backend.schemas.ticket import ChamadoPorData, ChamadosPorDia, TicketSummaryOut
 from backend.services.document_service import read_file
 from backend.services.metrics_service import calculate_dataframe_metrics
 from shared.dto import CleanTicketDTO  # imported from shared DTOs
@@ -82,30 +82,6 @@ class Metrics:
     total: int
     opened: int
     closed: int
-
-
-class ChamadoPorData(BaseModel):
-    """Aggregated tickets per creation date."""
-
-    date: str = Field(..., examples=["2024-06-01"])
-    total: int = Field(..., examples=[5])
-
-
-class ChamadosPorDia(BaseModel):
-    """Daily ticket totals used for heatmaps."""
-
-    date: str = Field(..., examples=["2024-06-01"])
-    total: int = Field(..., examples=[5])
-
-
-class TicketSummaryOut(BaseModel):
-    """Row from the materialized view used as read model."""
-
-    ticket_id: int
-    status: str
-    priority: str
-    group_name: str
-    opened_at: str
 
 
 async def _load_and_cache_df(info: Info) -> pd.DataFrame:

--- a/src/backend/application/batch_fetch.py
+++ b/src/backend/application/batch_fetch.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 import json
 from typing import List
 
-from pydantic import BaseModel, Field
-
 from backend.application.glpi_api_client import GlpiApiClient
 from backend.core.settings import (
     GLPI_APP_TOKEN,
@@ -18,13 +16,9 @@ from backend.core.settings import (
 
 # Import custom error raised by the GLPI client
 from backend.domain.tool_error import ToolError
-from backend.infrastructure.glpi.glpi_session import Credentials, GLPISession
-
-
-class BatchFetchParams(BaseModel):
-    """Input IDs for :func:`fetch_all_tickets`."""
-
-    ids: List[int] = Field(..., description="Ticket IDs to fetch")
+from backend.infrastructure.glpi.glpi_session import GLPISession
+from backend.schemas.auth import Credentials
+from backend.schemas.batch import BatchFetchParams
 
 
 async def fetch_all_tickets(ids: List[int]) -> List[dict]:

--- a/src/backend/application/langgraph_workflow.py
+++ b/src/backend/application/langgraph_workflow.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 
 import ast
 import tempfile
-from enum import Enum
 from pathlib import Path
 from typing import List, Optional, TypedDict
 
@@ -17,7 +16,7 @@ from langchain_core.prompts import PromptTemplate
 from langchain_core.runnables import Runnable
 from langgraph.checkpoint.sqlite import SqliteSaver
 from langgraph.graph import END, StateGraph
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 
 from backend.core.settings import (
     GLPI_APP_TOKEN,
@@ -26,8 +25,10 @@ from backend.core.settings import (
     GLPI_USER_TOKEN,
     GLPI_USERNAME,
 )
-from backend.infrastructure.glpi.glpi_session import Credentials, GLPISession
+from backend.infrastructure.glpi.glpi_session import GLPISession
 from backend.infrastructure.glpi.normalization import process_raw
+from backend.schemas.auth import Credentials
+from backend.schemas.workflow import FetcherArgs, Metrics, NextAgent
 from shared.utils.messages import sanitize_message
 
 
@@ -47,40 +48,6 @@ class AgentState(TypedDict):
     iteration_count: int
     data: Optional[pd.DataFrame]
     error: Optional[str]
-
-
-class NextAgent(BaseModel):
-    """Structured output deciding the next node."""
-
-    next_agent: str = Field(..., description="Name of the next agent to execute")
-
-
-class TicketStatus(str, Enum):
-    """Allowed GLPI ticket statuses."""
-
-    NEW = "new"
-    ASSIGNED = "assigned"
-    PLANNED = "planned"
-    WAITING = "waiting"
-    SOLVED = "solved"
-    CLOSED = "closed"
-
-
-class FetcherArgs(BaseModel):
-    """Input parameters for the fetcher node."""
-
-    status: TicketStatus | None = Field(
-        default=None, description="Optional status filter for tickets"
-    )
-    limit: int = Field(..., description="Maximum number of tickets to fetch")
-
-
-class Metrics(BaseModel):
-    """Validated metrics produced by the analyzer."""
-
-    total: int
-    opened: int
-    closed: int
 
 
 AVAILABLE_AGENTS = ["fetcher", "analyzer", "fallback"]
@@ -277,6 +244,5 @@ __all__ = [
     "recovery_node",
     "build_workflow",
     "GLPISession",
-    "TicketStatus",
     "AVAILABLE_AGENTS",
 ]

--- a/src/backend/application/tickets_groups.py
+++ b/src/backend/application/tickets_groups.py
@@ -19,7 +19,8 @@ from backend.core.settings import (
     GLPI_USER_TOKEN,
     GLPI_USERNAME,
 )
-from backend.infrastructure.glpi.glpi_session import Credentials, GLPISession
+from backend.infrastructure.glpi.glpi_session import GLPISession
+from backend.schemas.auth import Credentials
 
 log = logging.getLogger(__name__)
 

--- a/src/backend/infrastructure/glpi/glpi_session.py
+++ b/src/backend/infrastructure/glpi/glpi_session.py
@@ -10,7 +10,6 @@ from urllib.parse import urlsplit, urlunsplit
 
 import aiohttp
 from aiohttp import BasicAuth, ClientResponse, ClientSession, FormData, TCPConnector
-from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from backend.core.settings import (
     GLPI_APP_TOKEN,
@@ -32,6 +31,7 @@ from backend.domain.exceptions import (
     GLPIUnauthorizedError,
 )
 from backend.domain.tool_error import ToolError
+from backend.schemas.auth import Credentials, SessionParams
 from shared.utils.resilience import call_with_breaker, retry_api_call
 
 logger = logging.getLogger(__name__)
@@ -63,70 +63,6 @@ def mask_proxy_url(url: Optional[str]) -> Optional[str]:
         return url
     except Exception:
         return url
-
-
-class Credentials(BaseModel):
-    """Authentication data for the GLPI REST API.
-
-    Use this model when calling GLPI tools so credentials are validated before
-    any network request is attempted.
-    """
-
-    app_token: str = Field(..., description="GLPI application token")
-    user_token: Optional[str] = Field(
-        default=None, description="Optional user API token"
-    )
-    username: Optional[str] = Field(
-        default=None, description="GLPI username used when no token is provided"
-    )
-    password: Optional[str] = Field(
-        default=None,
-        description="GLPI password used together with ``username``",
-    )
-
-    @model_validator(mode="after")
-    def _check_auth(self) -> "Credentials":
-        """Ensure at least one authentication method is supplied."""
-        auth_methods = sum(
-            [
-                1 if self.user_token else 0,
-                1 if (self.username and self.password) else 0,
-            ]
-        )
-        if auth_methods == 0:
-            raise ValueError("Either user_token or username/password must be provided.")
-        if auth_methods > 1:
-            logger.debug(
-                "Both user_token and username/password provided. "
-                "Prioritizing user_token."
-            )
-            self.username = None
-            self.password = None
-        return self
-
-
-class SessionParams(BaseModel):
-    """Input data for creating :class:`GLPISession`."""
-
-    model_config = ConfigDict(arbitrary_types_allowed=True)
-
-    base_url: str = Field(..., description="GLPI REST base URL")
-    credentials: Credentials
-    proxy: Optional[str] = Field(
-        default_factory=lambda: os.environ.get("HTTP_PROXY"),
-        description="Optional proxy URL; defaults to HTTP_PROXY env var",
-    )
-    verify_ssl: bool = Field(default=True, description="Verify SSL certificates")
-    ssl_context: Optional[ssl.SSLContext] = Field(
-        default=None, description="Custom SSL context for TLS connections", exclude=True
-    )
-    timeout: Union[int, aiohttp.ClientTimeout] = Field(
-        default=300, description="Request timeout in seconds", exclude=True
-    )
-    refresh_interval: int = Field(
-        default=3000,
-        description="Interval in seconds to proactively refresh the session",
-    )
 
 
 class GLPISession:

--- a/src/backend/schemas/auth.py
+++ b/src/backend/schemas/auth.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import logging
+import os
+import ssl
+from typing import Optional, Union
+
+import aiohttp
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+logger = logging.getLogger(__name__)
+
+
+class Credentials(BaseModel):
+    """Authentication data for the GLPI REST API."""
+
+    app_token: str = Field(..., description="GLPI application token")
+    user_token: Optional[str] = Field(
+        default=None, description="Optional user API token"
+    )
+    username: Optional[str] = Field(
+        default=None, description="GLPI username used when no token is provided"
+    )
+    password: Optional[str] = Field(
+        default=None,
+        description="GLPI password used together with ``username``",
+    )
+
+    @model_validator(mode="after")
+    def _check_auth(self) -> "Credentials":
+        """Ensure at least one authentication method is supplied."""
+        auth_methods = sum(
+            [1 if self.user_token else 0, 1 if (self.username and self.password) else 0]
+        )
+        if auth_methods == 0:
+            raise ValueError("Either user_token or username/password must be provided.")
+        if auth_methods > 1:
+            logger.debug(
+                "Both user_token and username/password provided. "
+                "Prioritizing user_token."
+            )
+            self.username = None
+            self.password = None
+        return self
+
+
+class SessionParams(BaseModel):
+    """Input data for creating :class:`GLPISession`."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    base_url: str = Field(..., description="GLPI REST base URL")
+    credentials: Credentials
+    proxy: Optional[str] = Field(
+        default_factory=lambda: os.environ.get("HTTP_PROXY"),
+        description="Optional proxy URL; defaults to HTTP_PROXY env var",
+    )
+    verify_ssl: bool = Field(default=True, description="Verify SSL certificates")
+    ssl_context: Optional[ssl.SSLContext] = Field(
+        default=None, description="Custom SSL context for TLS connections", exclude=True
+    )
+    timeout: Union[int, aiohttp.ClientTimeout] = Field(
+        default=300, description="Request timeout in seconds", exclude=True
+    )
+    refresh_interval: int = Field(
+        default=3000,
+        description="Interval in seconds to proactively refresh the session",
+    )

--- a/src/backend/schemas/batch.py
+++ b/src/backend/schemas/batch.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from typing import List
+
+from pydantic import BaseModel, Field
+
+
+class BatchFetchParams(BaseModel):
+    """Input IDs for batch ticket fetching."""
+
+    ids: List[int] = Field(..., description="Ticket IDs to fetch")

--- a/src/backend/schemas/ticket.py
+++ b/src/backend/schemas/ticket.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class ChamadoPorData(BaseModel):
+    """Aggregated tickets per creation date."""
+
+    date: str = Field(..., examples=["2024-06-01"])
+    total: int = Field(..., examples=[5])
+
+
+class ChamadosPorDia(BaseModel):
+    """Daily ticket totals used for heatmaps."""
+
+    date: str = Field(..., examples=["2024-06-01"])
+    total: int = Field(..., examples=[5])
+
+
+class TicketSummaryOut(BaseModel):
+    """Row from the materialized view used as read model."""
+
+    ticket_id: int
+    status: str
+    priority: str
+    group_name: str
+    opened_at: str

--- a/src/backend/schemas/workflow.py
+++ b/src/backend/schemas/workflow.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from enum import Enum
+
+from pydantic import BaseModel, Field
+
+
+class NextAgent(BaseModel):
+    """Structured output deciding the next node."""
+
+    next_agent: str = Field(..., description="Name of the next agent to execute")
+
+
+class TicketStatus(str, Enum):
+    """Allowed GLPI ticket statuses."""
+
+    NEW = "new"
+    ASSIGNED = "assigned"
+    PLANNED = "planned"
+    WAITING = "waiting"
+    SOLVED = "solved"
+    CLOSED = "closed"
+
+
+class FetcherArgs(BaseModel):
+    """Input parameters for the fetcher node."""
+
+    status: TicketStatus | None = Field(
+        default=None, description="Optional status filter for tickets"
+    )
+    limit: int = Field(..., description="Maximum number of tickets to fetch")
+
+
+class Metrics(BaseModel):
+    """Validated metrics produced by the analyzer."""
+
+    total: int
+    opened: int
+    closed: int

--- a/src/glpi_tools/__main__.py
+++ b/src/glpi_tools/__main__.py
@@ -12,7 +12,8 @@ from rich.console import Console
 from rich.table import Table
 
 from backend.core.settings import settings
-from backend.infrastructure.glpi.glpi_session import Credentials, GLPISession
+from backend.infrastructure.glpi.glpi_session import GLPISession
+from backend.schemas.auth import Credentials
 
 
 @click.group()

--- a/tests/test_glpi_session.py
+++ b/tests/test_glpi_session.py
@@ -12,7 +12,6 @@ from aiohttp import BasicAuth
 
 from backend.infrastructure.glpi import glpi_session
 from backend.infrastructure.glpi.glpi_session import (
-    Credentials,
     GLPIAPIError,
     GLPIBadRequestError,
     GLPIForbiddenError,
@@ -22,6 +21,7 @@ from backend.infrastructure.glpi.glpi_session import (
     GLPITooManyRequestsError,
     GLPIUnauthorizedError,
 )
+from backend.schemas.auth import Credentials, SessionParams
 from shared.utils.logging import init_logging
 from tests.helpers import make_cm, make_mock_response
 
@@ -809,8 +809,8 @@ async def test_open_session_tool_error(monkeypatch):
             return False
 
     monkeypatch.setattr(glpi_session, "GLPISession", lambda *a, **k: BadSession())
-    creds = glpi_session.Credentials(app_token="a", user_token="u")
-    params = glpi_session.SessionParams(base_url="http://x", credentials=creds)
+    creds = Credentials(app_token="a", user_token="u")
+    params = SessionParams(base_url="http://x", credentials=creds)
     out = await glpi_session.open_session_tool(params)
     data = json.loads(out)
     assert data["error"]["details"] == "boom"


### PR DESCRIPTION
## Summary
- create `src/backend/schemas` package for shared models
- move auth, batch, ticket and workflow models into schemas package
- update imports across backend and tests
- document move in refactor log

## Testing
- `pre-commit run --files dashboard_app.py docs/REFACTOR_LOG.md docs/cookbook/glpi-session.md src/backend/adapters/factory.py src/backend/api/worker_api.py src/backend/application/batch_fetch.py src/backend/application/langgraph_workflow.py src/backend/application/tickets_groups.py src/backend/infrastructure/glpi/glpi_session.py src/backend/schemas/__init__.py src/backend/schemas/auth.py src/backend/schemas/batch.py src/backend/schemas/ticket.py src/backend/schemas/workflow.py src/glpi_tools/__main__.py tests/test_glpi_session.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'libcst')*

------
https://chatgpt.com/codex/tasks/task_e_688c2776e94483209dcfa33fa3002dae