### PR TITLE
Centralize CleanTicketDTO definition

### DIFF
--- a/src/backend/domain/__init__.py
+++ b/src/backend/domain/__init__.py
@@ -1,5 +1,7 @@
 """Domain layer package."""
 
+from shared.dto import CleanTicketDTO
+
 from .exceptions import (
     HTTP_STATUS_ERROR_MAP,
     GLPIAPIError,
@@ -13,7 +15,6 @@ from .exceptions import (
     parse_error,
 )
 from .ticket_models import (
-    CleanTicketDTO,
     RawTicketDTO,
     TicketType,
     convert_ticket,

--- a/src/backend/domain/ticket_models.py
+++ b/src/backend/domain/ticket_models.py
@@ -6,7 +6,9 @@ import logging
 from datetime import datetime
 from typing import Any, Type, TypeVar
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field
+
+from shared.dto import CleanTicketDTO
 
 from .ticket_status import Impact, Priority, TicketStatus, Urgency
 from .ticket_status import _BaseIntEnum as _BaseIntEnumLocal
@@ -47,40 +49,6 @@ class RawTicketDTO(BaseModel):
     users_id_requester: int | None = Field(None, description="Requester user ID")
 
     model_config = ConfigDict(extra="allow")
-
-
-class CleanTicketDTO(BaseModel):
-    """Validated domain ticket object."""
-
-    id: int = Field(..., description="Ticket identifier")
-    title: str | None = Field(
-        None,
-        alias="name",
-        description="Short summary",
-    )
-    content: str | None = Field(None, description="Detailed description")
-    status: TicketStatus = Field(TicketStatus.UNKNOWN, description="Status")
-    priority: str = Field(
-        "Unknown",
-        description="Prioridade do ticket",
-    )
-    urgency: Urgency = Field(Urgency.UNKNOWN, description="Urgency")
-    impact: Impact = Field(Impact.UNKNOWN, description="Impact")
-    type: TicketType = Field(TicketType.UNKNOWN, description="Ticket type")
-    creation_date: datetime | None = Field(
-        None, alias="date_creation", description="Creation timestamp"
-    )
-    requester: str | None = Field(None, description="Requester user name")
-
-    model_config = ConfigDict(extra="forbid", populate_by_name=True)
-
-    @model_validator(mode="before")
-    @classmethod
-    def _set_title(cls, data: dict[str, Any]) -> dict[str, Any]:
-        title = data.get("title") or data.get("name")
-        data["title"] = "[Título não informado]" if title in (None, "") else str(title)
-        data.pop("name", None)
-        return data
 
 
 E = TypeVar("E", bound="_BaseIntEnumLocal")
@@ -187,7 +155,6 @@ def convert_ticket(raw: RawTicketDTO) -> CleanTicketDTO:
 
 __all__ = [
     "RawTicketDTO",
-    "CleanTicketDTO",
     "TicketStatus",
     "Priority",
     "Urgency",

--- a/src/shared/models/__init__.py
+++ b/src/shared/models/__init__.py
@@ -1,10 +1,10 @@
 from backend.domain.ticket_models import (
-    CleanTicketDTO,
     RawTicketDTO,
     TicketType,
     convert_ticket,
 )
 from backend.domain.ticket_status import Impact, Priority, TicketStatus, Urgency
+from shared.dto import CleanTicketDTO
 
 __all__ = [
     "TicketStatus",

--- a/src/shared/models/ts_models.py
+++ b/src/shared/models/ts_models.py
@@ -1,37 +1,14 @@
 from __future__ import annotations
 
-from datetime import datetime
 from enum import IntEnum
 
-from pydantic import BaseModel, ConfigDict, Field
-
-from backend.domain.ticket_status import Impact, TicketStatus, Urgency
+from shared.dto import CleanTicketDTO
 
 
 class TicketType(IntEnum):
     UNKNOWN = 0
     INCIDENT = 1
     REQUEST = 2
-
-
-class CleanTicketDTO(BaseModel):
-    """Subset of ticket fields exposed to the frontend."""
-
-    id: int = Field(..., description="Ticket identifier")
-    name: str = Field("", description="Short summary")
-    content: str | None = Field(None, description="Detailed description")
-    status: TicketStatus = Field(TicketStatus.UNKNOWN, description="Status")
-    priority: str = Field(
-        "Unknown",
-        description="Priority",
-    )
-    urgency: Urgency = Field(Urgency.UNKNOWN, description="Urgency")
-    impact: Impact = Field(Impact.UNKNOWN, description="Impact")
-    type: TicketType = Field(TicketType.UNKNOWN, description="Ticket type")
-    date_creation: datetime | None = Field(None, description="Creation timestamp")
-    requester: str | None = Field(None, description="Requester")
-
-    model_config = ConfigDict(extra="forbid")
 
 
 __all__ = ["CleanTicketDTO", "TicketType"]


### PR DESCRIPTION
## Summary
- keep `CleanTicketDTO` only in `shared.dto`
- update domain imports to use the consolidated DTO
- simplify TypeScript model stub

## Testing
- `pre-commit run --files src/backend/domain/ticket_models.py src/shared/models/ts_models.py src/shared/models/__init__.py src/backend/domain/__init__.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fakeredis')*

------
https://chatgpt.com/codex/tasks/task_e_688c2770ffe883209742323231ca64f2