### PR TITLE
Remove obsolete pipeline wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ If a script still depends on `require()`, rename it with the `.cjs` extension or
 
 - **`src/backend/infrastructure/glpi/glpi_session.py`** – asynchronous client for the GLPI REST API used by the worker and ETL modules. This file replaces the former `glpi_api.py` referenced in early docs.
 - **`src/backend/application/glpi_api_client.py`** – high-level interface built on `GLPISession` that resolves field IDs and returns translated tickets.
-- **`src/backend/utils/pipeline.py`** – normalizes raw ticket data into a `pandas.DataFrame` and exports JSON.
+- **`src/backend/infrastructure/glpi/normalization.py`** – normalizes raw ticket data into a `pandas.DataFrame` and exports JSON.
 - **`src/frontend/layout/layout.py`** – defines tables and charts for the Dash UI.
 - **`glpi_tools/__main__.py`** – exposes the CLI commands such as `list-fields`.
 - **`src/backend/adapters/mapping_service.py`** – obtém e cacheia IDs de campos

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -42,7 +42,7 @@ Você é um especialista em engenharia de prompts que cria fluxos multi-agente.
 ## Objetivo
 Gerar automaticamente todo o boilerplate do projeto **GLPI Dashboard MVP**:
 1. `glpi_session.py` – cliente REST oficial
-2. `backend/utils/pipeline.py` – normalização DataFrame
+2. `backend/infrastructure/glpi/normalization.py` – normalização DataFrame
 3. `dashboard_app.py` – layout Dash
 4. `tests/` – pytest + requests-mock
 5. `.github/workflows/ci.yml` – CI Python 3.10/3.12

--- a/docs/cookbook/data-pipeline.md
+++ b/docs/cookbook/data-pipeline.md
@@ -7,7 +7,7 @@ technician to keep metrics consistent. It runs asynchronously to retrieve
 pages in parallel and keep up with large backlogs.
 
 ## Decision
-Implement the pipeline in `backend/utils/pipeline.py` using async functions.
+Implement the pipeline in `backend/infrastructure/glpi/normalization.py` using async functions.
 It pulls pages from the GLPI API through `glpi_session`, converts them to
 DataFrame rows and writes the final result to SQLite. A scheduler or cron job
 should invoke the pipeline regularly to refresh metrics.

--- a/docs/developer_usage.md
+++ b/docs/developer_usage.md
@@ -12,7 +12,7 @@ Principais módulos do projeto:
 | ------- | ------ |
 | `src/backend/infrastructure/glpi/glpi_session.py` | Cliente assíncrono para autenticação e chamadas à API GLPI |
 | `src/backend/application/glpi_api_client.py` | Interface de alto nível que usa `GLPISession` para obter tickets completos |
-| `src/backend/utils/pipeline.py` | Normaliza tickets em `pandas.DataFrame` e gera JSON |
+| `src/backend/infrastructure/glpi/normalization.py` | Normaliza tickets em `pandas.DataFrame` e gera JSON |
 | `src/frontend/layout/layout.py` | Layout e callbacks do dashboard em Dash |
 | `src/backend/services/worker_api.py` | Lógica de cache e métricas usadas pelo `worker.py` |
 | `shared/config/settings.py` | Carrega variáveis de ambiente (GLPI, DB, Redis) |
@@ -103,7 +103,7 @@ python scripts/fetch/fetch_tickets.py --output data/tickets.json
 python -m cli.tickets_groups --since 2025-06-01 --until 2025-06-30 --outfile grupos.parquet
 ```
 
-Consulte `src/backend/utils/pipeline.py` para transformar os dados em DataFrame.
+Consulte `src/backend/infrastructure/glpi/normalization.py` para transformar os dados em DataFrame.
 
 ## Atualizando a Knowledge Base
 

--- a/docs/glpi_dashboard_plan.md
+++ b/docs/glpi_dashboard_plan.md
@@ -23,7 +23,7 @@ glpi_dashboard/
 ├── .env.example
 ├── requirements.txt
 ├── glpi_session.py
-├── backend/utils/pipeline.py
+├── backend/infrastructure/glpi/normalization.py
 ├── dashboard/layout.py
 ├── dashboard_app.py
 ├── scripts/
@@ -49,7 +49,7 @@ glpi_dashboard/
 
 | Fase                   | Ambiente | Entregáveis-chave                                                |
 |------------------------|----------|-----------------------------------------------------------------|
-| **1. Backend (API)**   | Intra    | `glpi_session.py`, `backend/utils/pipeline.py`, `hash_data.py`   |
+| **1. Backend (API)**   | Intra    | `glpi_session.py`, `backend/infrastructure/glpi/normalization.py`, `hash_data.py`   |
 | **2. Frontend Offline**| Externo  | `dashboard/layout.py`, `dashboard_app.py`, `mock/*.json`         |
 | **3. Refino & Deploy** | Ambos    | Testes, refresh automático, `ci_mock.yml`                        |
 

--- a/docs/prompt_cookbook_codex.md
+++ b/docs/prompt_cookbook_codex.md
@@ -21,11 +21,11 @@ Crie **glpi_session.py** com:
 - Type hints e docstrings.
 ```
 
-### 2️⃣ Gerar **backend/utils/pipeline.py**
+### 2️⃣ Gerar **backend/infrastructure/glpi/normalization.py**
 
 ```text
 Você é um especialista em ETL.
-Crie backend/utils/pipeline.py com:
+Crie backend/infrastructure/glpi/normalization.py com:
 - process_raw(data: List[dict]) -> pandas.DataFrame
 - Campos obrigatórios: id, status, group, date_creation, assigned_to, requester
 - Converta datas para datetime, preencha NaN com None
@@ -73,7 +73,7 @@ Teste que get_tickets() retorna lista não vazia e lança HTTPError em 500.
 ### 7️⃣ Refatorar depois
 
 ```text
-Reescreva backend.utils.pipeline.process_raw para aceitar DataFrame e Series.
+Reescreva backend.infrastructure.glpi.normalization.process_raw para aceitar DataFrame e Series.
 Garanta 100% coverage nos testes.
 ```
 

--- a/scripts/refactor/file_map.json
+++ b/scripts/refactor/file_map.json
@@ -119,7 +119,7 @@
   "src/glpi_dashboard/dashboard/components.py": "src/frontend/components/components.py",
   "src/glpi_dashboard/dashboard/layout.py": "src/frontend/layout/layout.py",
   "src/glpi_dashboard/data/database.py": "src/backend/db/database.py",
-  "src/glpi_dashboard/data/pipeline.py": "src/backend/utils/pipeline.py",
+  "src/glpi_dashboard/data/pipeline.py": "src/backend/infrastructure/glpi/normalization.py",
   "src/glpi_dashboard/data/transform.py": "src/backend/utils/transform.py",
   "src/glpi_dashboard/events/consumer.py": "src/backend/services/events_consumer.py",
   "src/glpi_dashboard/glpi_adapter.py": "src/backend/adapters/glpi_adapter.py",

--- a/src/backend/utils/__init__.py
+++ b/src/backend/utils/__init__.py
@@ -3,10 +3,8 @@
 from shared.utils.logging import init_logging, set_correlation_id
 
 from .pagination import paginate_items
-from .pipeline import process_raw
 
 __all__ = [
-    "process_raw",
     "init_logging",
     "set_correlation_id",
     "paginate_items",

--- a/src/backend/utils/pipeline.py
+++ b/src/backend/utils/pipeline.py
@@ -1,7 +1,0 @@
-"""Compatibility wrappers for the new Anti-Corruption Layer."""
-
-from __future__ import annotations
-
-from backend.infrastructure.glpi.normalization import process_raw
-
-__all__ = ["process_raw"]


### PR DESCRIPTION
## Summary
- delete `src/backend/utils/pipeline.py`
- stop re-exporting `process_raw` from `backend.utils`
- update documentation to reference `backend/infrastructure/glpi/normalization.py`
- fix refactor map entry for the pipeline module

## Testing
- `pytest tests/test_data_pipeline.py::test_process_raw_sanitization -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_688c2eb7f4f48320b94e17613481e997

## Resumo por Sourcery

Remover o wrapper de pipeline obsoleto do pacote utils, atualizar importações e documentação para usar o novo módulo de normalização e corrigir o mapeamento de refatoração.

Melhorias:
- Remover o módulo descontinuado `src/backend/utils/pipeline.py` e parar de re-exportar seu `process_raw`
- Corrigir a entrada de mapeamento de refatoração para o módulo de pipeline removido

Documentação:
- Atualizar toda a documentação para referenciar `backend/infrastructure/glpi/normalization.py` em vez de `backend/utils/pipeline.py`

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove the obsolete pipeline wrapper from the utils package, update imports and docs to use the new normalization module, and correct the refactoring mapping.

Enhancements:
- Remove the deprecated src/backend/utils/pipeline.py module and stop re-exporting its process_raw
- Fix the refactor mapping entry for the removed pipeline module

Documentation:
- Update all documentation to reference backend/infrastructure/glpi/normalization.py instead of backend/utils/pipeline.py

</details>