### PR TITLE
Remove deprecated HelloWidget component

### DIFF
--- a/src/frontend/react_app/src/widgets/HelloWidget/HelloWidget.tsx
+++ b/src/frontend/react_app/src/widgets/HelloWidget/HelloWidget.tsx
@@ -1,3 +1,0 @@
-export const HelloWidget = () => {
-  return <div>Hello Widget</div>;
-};

--- a/src/frontend/react_app/src/widgets/HelloWidget/index.ts
+++ b/src/frontend/react_app/src/widgets/HelloWidget/index.ts
@@ -1,1 +1,0 @@
-export { HelloWidget } from './HelloWidget';

--- a/src/frontend/react_app/src/widgets/index.ts
+++ b/src/frontend/react_app/src/widgets/index.ts
@@ -1,1 +1,0 @@
-export * from './HelloWidget/HelloWidget';


### PR DESCRIPTION
## Summary
- delete unused `HelloWidget` widget and its barrel file
- clear the `widgets/index.ts` export list

## Testing
- `npm test` *(fails: SyntaxError Cannot use 'import.meta' outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_688c3ca683608320a37ffc407efa6cd2