### PR TITLE
Update Faro env docs

### DIFF
--- a/src/frontend/react_app/.env.example
+++ b/src/frontend/react_app/.env.example
@@ -1,4 +1,4 @@
 # Example environment for the Vite React frontend
 # Points to the worker API running locally
 NEXT_PUBLIC_API_BASE_URL=http://localhost:8000
-VITE_FARO_URL=http://localhost:1234/collect
+# NEXT_PUBLIC_FARO_URL=http://localhost:1234/collect

--- a/src/frontend/react_app/.env.example
+++ b/src/frontend/react_app/.env.example
@@ -1,4 +1,4 @@
 # Example environment for the Vite React frontend
 # Points to the worker API running locally
 NEXT_PUBLIC_API_BASE_URL=http://localhost:8000
-# NEXT_PUBLIC_FARO_URL=http://localhost:1234/collect
+# VITE_FARO_URL=http://localhost:1234/collect

--- a/src/frontend/react_app/README.md
+++ b/src/frontend/react_app/README.md
@@ -6,7 +6,7 @@ This folder contains the React front-end of the **GLPI Dashboard CAU**. The appl
 
 1. Copy `.env.example` to `.env` and set `NEXT_PUBLIC_API_BASE_URL` to the worker address.
 
-2. (Optional) If you are running the Grafana observability stack, also set `NEXT_PUBLIC_FARO_URL` to point to your Faro collector (e.g., `http://localhost:1234/collect`). If you are not running the collector, leave this variable commented out to avoid connection errors in the browser console.
+2. (Optional) If you use the Grafana observability stack, set `NEXT_PUBLIC_FARO_URL` to your Faro collector (for example `http://localhost:1234/collect`). Leave this line commented if the collector isn't running to avoid browser errors.
 
 3. Install Node dependencies with:
 


### PR DESCRIPTION
## Summary
- clean up example environment
- clarify Faro URL usage in the React README

## Testing
- `python scripts/generate_bug_prompt.py --output bug_prompt.md`

------
https://chatgpt.com/codex/tasks/task_e_688c54ffc3b483209ace477c87a2b988

## Resumo por Sourcery

Esclarecer a configuração do coletor Faro na documentação do front-end React e limpar o arquivo de ambiente de exemplo

Documentação:
- Atualizar o README do React para fornecer um exemplo mais claro e orientação de uso para `NEXT_PUBLIC_FARO_URL`
- Limpar o `.env.example` para refletir apenas as variáveis de ambiente necessárias

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clarify Faro collector configuration in the React front-end docs and clean up the example environment file

Documentation:
- Update React README to provide a clearer example and usage guidance for NEXT_PUBLIC_FARO_URL
- Clean up .env.example to reflect only the necessary environment variables

</details>