### PR TITLE
Remove unused settings helpers

### DIFF
--- a/src/backend/core/settings.py
+++ b/src/backend/core/settings.py
@@ -59,14 +59,6 @@ class Settings(BaseSettings):
     mock_tickets_file: str = os.getenv(
         "MOCK_TICKETS_FILE", "tests/resources/mock_tickets.json"
     )
-    database_url: str = ""
-    redis_url: str = ""
-    cache_type: str = ""
-    cache_redis_host: str = ""
-    cache_redis_port: str = ""
-    cache_redis_db: str = ""
-    cache_default_timeout: str = ""
-    codegpt_plus_api_key: str = ""
 
     OTEL_EXPORTER_OTLP_ENDPOINT: str | None = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
     OTEL_EXPORTER_OTLP_HEADERS: str | None = os.getenv("OTEL_EXPORTER_OTLP_HEADERS")
@@ -129,58 +121,3 @@ EVENT_BROKER_URL = settings.EVENT_BROKER_URL
 VERIFY_SSL = settings.VERIFY_SSL
 CLIENT_TIMEOUT_SECONDS = settings.CLIENT_TIMEOUT_SECONDS
 DASH_PORT = settings.DASH_PORT
-
-# ---------------------------------------------------------------------------
-# Helper functions for parsing environment variables
-# ---------------------------------------------------------------------------
-
-VALID_HTTP_METHODS: set[str] = {
-    "GET",
-    "POST",
-    "PUT",
-    "PATCH",
-    "DELETE",
-    "OPTIONS",
-    "HEAD",
-}
-
-
-def get_env(key: str, default: str | None = None) -> str | None:
-    """Wrapper around :func:`os.getenv` for easier mocking."""
-
-    return os.getenv(key, default)
-
-
-def _split_list(value: str | None) -> list[str]:
-    """Split a comma-separated string into a cleaned list."""
-
-    return [item.strip() for item in (value or "").split(",") if item.strip()]
-
-
-def cors_origins_from_env() -> list[str]:
-    """Return allowed origins parsed from ``API_CORS_ALLOW_ORIGINS``."""
-
-    return _split_list(get_env("API_CORS_ALLOW_ORIGINS", ""))
-
-
-def cors_methods_from_env() -> list[str]:
-    """Return allowed HTTP methods parsed and validated from the environment."""
-
-    methods = [
-        m.upper()
-        for m in _split_list(get_env("API_CORS_ALLOW_METHODS", "GET,HEAD,OPTIONS"))
-    ]
-    if not methods:
-        raise ValueError("API_CORS_ALLOW_METHODS cannot be empty")
-    if invalid := [m for m in methods if m not in VALID_HTTP_METHODS]:
-        raise ValueError(f"Invalid HTTP methods: {', '.join(invalid)}")
-    return methods
-
-
-def get_app_env() -> str:
-    """Return the current application environment."""
-
-    env = (get_env("APP_ENV") or "development").lower()
-    if env not in {"development", "production"}:
-        raise ValueError(f"Invalid APP_ENV: {env}")
-    return env


### PR DESCRIPTION
## Summary
- drop unused settings attributes
- remove unused helper functions and constants

## Testing
- `pre-commit run --files src/backend/core/settings.py`
- `pytest tests/test_auth.py -q` *(fails: AssertionError in `test_get_session_token_cache`)*

------
https://chatgpt.com/codex/tasks/task_e_688c55068d1483208fd592bc33bba925

## Resumo por Sourcery

Remove atributos de configuração não utilizados e funções auxiliares do módulo de configurações principal

Melhorias:
- Remove atributos de configuração obsoletos (database_url, redis_url, cache settings, codegpt_plus_api_key) da classe Settings
- Remove auxiliares e constantes de parsing de ambiente (get_env, _split_list, cors_origins_from_env, cors_methods_from_env, get_app_env, VALID_HTTP_METHODS)

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove unused settings attributes and helper functions from the core settings module

Enhancements:
- Drop obsolete settings attributes (database_url, redis_url, cache settings, codegpt_plus_api_key) from Settings class
- Remove environment parsing helpers and constants (get_env, _split_list, cors_origins_from_env, cors_methods_from_env, get_app_env, VALID_HTTP_METHODS)

</details>