### PR TITLE
Update Faro env var name

### DIFF
--- a/src/frontend/react_app/.env.example
+++ b/src/frontend/react_app/.env.example
@@ -1,4 +1,4 @@
-# Example environment for the Vite React frontend
+# Example environment for the Next.js frontend
 # Points to the worker API running locally
 NEXT_PUBLIC_API_BASE_URL=http://localhost:8000
 # NEXT_PUBLIC_FARO_URL=http://localhost:1234/collect

--- a/src/frontend/react_app/.env.example
+++ b/src/frontend/react_app/.env.example
@@ -1,4 +1,4 @@
 # Example environment for the Vite React frontend
 # Points to the worker API running locally
 NEXT_PUBLIC_API_BASE_URL=http://localhost:8000
-# VITE_FARO_URL=http://localhost:1234/collect
+# NEXT_PUBLIC_FARO_URL=http://localhost:1234/collect


### PR DESCRIPTION
## Summary
- use `NEXT_PUBLIC_FARO_URL` instead of the old `VITE_FARO_URL`

## Testing
- `pre-commit run --files src/frontend/react_app/.env.example src/frontend/react_app/scripts/check-env.js src/frontend/react_app/src/main.tsx docs/observability.md docs/frontend_architecture.md src/frontend/react_app/README.md`
- `pytest -c /dev/null -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_688c59a373b48320a3b8395a29da17e7

## Resumo por Sourcery

Renomear a variável de ambiente da URL do Faro de `VITE_FARO_URL` para `NEXT_PUBLIC_FARO_URL` em todo o aplicativo React, incluindo exemplos, scripts de validação, referências de código e documentação.

Melhorias:
- Atualizar `.env.example` e o script de validação de ambiente para exigir `NEXT_PUBLIC_FARO_URL` em vez de `VITE_FARO_URL`
- Modificar `main.tsx` para ler a URL do Faro de `NEXT_PUBLIC_FARO_URL`
- Substituir referências de `VITE_FARO_URL` por `NEXT_PUBLIC_FARO_URL` na base de código

Documentação:
- Atualizar `observability.md`, `frontend_architecture.md` e `README.md` para refletir a nova variável `NEXT_PUBLIC_FARO_URL`

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Rename the Faro URL environment variable from VITE_FARO_URL to NEXT_PUBLIC_FARO_URL across the React app, including examples, validation scripts, code references, and documentation.

Enhancements:
- Update .env.example and environment validation script to require NEXT_PUBLIC_FARO_URL instead of VITE_FARO_URL
- Modify main.tsx to read the Faro URL from NEXT_PUBLIC_FARO_URL
- Replace VITE_FARO_URL references with NEXT_PUBLIC_FARO_URL in codebase

Documentation:
- Update observability.md, frontend_architecture.md, and README.md to reflect the new NEXT_PUBLIC_FARO_URL variable

</details>