### PR TITLE
Remove unused MV_REFRESH_INTERVAL_MINUTES

### DIFF
--- a/src/backend/core/settings.py
+++ b/src/backend/core/settings.py
@@ -45,7 +45,6 @@ class Settings(BaseSettings):
     EVENT_BROKER_URL: str = os.getenv("EVENT_BROKER_URL", "localhost:9092")
 
     FETCH_PAGE_SIZE: int = 50
-    MV_REFRESH_INTERVAL_MINUTES: int = 5
 
     USE_MOCK_DATA: bool = False
 
@@ -105,7 +104,6 @@ REDIS_DB = settings.REDIS_DB
 REDIS_TTL_SECONDS = settings.REDIS_TTL_SECONDS
 
 FETCH_PAGE_SIZE = settings.FETCH_PAGE_SIZE
-MV_REFRESH_INTERVAL_MINUTES = settings.MV_REFRESH_INTERVAL_MINUTES
 
 USE_MOCK_DATA = settings.USE_MOCK_DATA
 


### PR DESCRIPTION
## Summary
- remove obsolete `MV_REFRESH_INTERVAL_MINUTES` from settings

## Testing
- `make lint` *(fails: module attribute errors in tests, trailing whitespace fix)*
- `make test-backend` *(fails: SQLAlchemy TypeError during pytest setup)*

------
https://chatgpt.com/codex/tasks/task_e_688c59afc9088320a7ab5badb5f01494

## Resumo por Sourcery

Remove a configuração obsoleta `MV_REFRESH_INTERVAL_MINUTES` e referências associadas do módulo de configurações

Ajustes:
- Excluir o atributo `MV_REFRESH_INTERVAL_MINUTES` da classe `Settings`
- Remover a constante `MV_REFRESH_INTERVAL_MINUTES` a nível de módulo

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove the obsolete MV_REFRESH_INTERVAL_MINUTES configuration and associated references from the settings module

Chores:
- Delete the MV_REFRESH_INTERVAL_MINUTES attribute from the Settings class
- Remove the module-level MV_REFRESH_INTERVAL_MINUTES constant

</details>