### PR TITLE
Improve front-end theme utilities

### DIFF
--- a/src/frontend/react_app/src/lib/styleUtils.ts
+++ b/src/frontend/react_app/src/lib/styleUtils.ts
@@ -1,0 +1,7 @@
+export function cn(...classes: Array<string | false | null | undefined>): string {
+  return classes.filter(Boolean).join(' ')
+}
+
+export function theme(token: string): string {
+  return `var(--${token})`
+}

--- a/src/frontend/react_app/tailwind.config.ts
+++ b/src/frontend/react_app/tailwind.config.ts
@@ -1,0 +1,56 @@
+import type { Config } from 'tailwindcss'
+
+export const theme = {
+  extend: {
+    colors: {
+      primary: 'var(--primary)',
+      'primary-light': 'var(--primary-light)',
+      secondary: 'var(--secondary)',
+      'accent-green': 'var(--accent-green)',
+      'accent-amber': 'var(--accent-amber)',
+      'accent-red': 'var(--accent-red)',
+      'accent-purple': 'var(--accent-purple)',
+      'accent-cyan': 'var(--accent-cyan)',
+      surface: 'var(--surface)',
+      'surface-secondary': 'var(--surface-secondary)',
+      'surface-tertiary': 'var(--surface-tertiary)',
+      'surface-hover': 'var(--surface-hover)',
+      border: 'var(--border)',
+      'border-light': 'var(--border-light)',
+      'text-primary': 'var(--text-primary)',
+      'text-secondary': 'var(--text-secondary)',
+      'text-muted': 'var(--text-muted)'
+    },
+    spacing: {
+      xs: 'var(--spacing-xs)',
+      sm: 'var(--spacing-sm)',
+      md: 'var(--spacing-md)',
+      lg: 'var(--spacing-lg)',
+      xl: 'var(--spacing-xl)'
+    },
+    borderRadius: {
+      '2xl': '1rem'
+    },
+    boxShadow: {
+      xs: 'var(--shadow-xs)',
+      sm: 'var(--shadow-sm)',
+      md: 'var(--shadow-md)',
+      lg: 'var(--shadow-lg)',
+      xl: 'var(--shadow-xl)'
+    },
+    screens: {
+      sm: '640px',
+      md: '768px',
+      lg: '1024px',
+      xl: '1280px'
+    }
+  }
+}
+
+const config: Config = {
+  content: ['./index.html', './src/**/*.{ts,tsx,css}'],
+  theme,
+  plugins: []
+}
+
+export default config


### PR DESCRIPTION
## Summary
- add Tailwind theme configuration referencing CSS variables
- expose `cn` and `theme` helpers for styling

## Testing
- `make test` *(fails: TypeError during SQLAlchemy import)*

------
https://chatgpt.com/codex/tasks/task_e_688c78d628148320afefe1b7ffb366e7