### PR TITLE
Add ticket summary API route

### DIFF
--- a/src/backend/routes/tickets.py
+++ b/src/backend/routes/tickets.py
@@ -1,0 +1,35 @@
+"""Ticket-related API routes.
+
+This router exposes endpoints for summarising ticket information. The
+primary endpoint implemented here aggregates ticket counts by status
+for each configured support level (N1–N4). See
+``backend.services.glpi.get_ticket_summary_by_group`` for details on
+how the data is gathered.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException
+
+from backend.services.glpi import get_ticket_summary_by_group
+
+router = APIRouter()
+
+
+@router.get("/api/tickets/summary-per-level", response_model=dict)
+def tickets_summary_per_level() -> dict:
+    """Return a summary of tickets grouped by status per service level.
+
+    The returned object has a top-level key for each level (e.g. ``"N1"``),
+    whose value is another dictionary mapping ticket statuses to counts.
+    In case of any internal failure this endpoint raises an HTTP 500.
+    """
+    try:
+        return get_ticket_summary_by_group()
+    except Exception as exc:
+        # Convert unexpected errors into a generic 500 response so the
+        # underlying exception details are not leaked to the client.
+        raise HTTPException(
+            status_code=500,
+            detail="Failed to compute ticket summary. See server logs for details.",
+        ) from exc

--- a/src/backend/routes/tickets.py
+++ b/src/backend/routes/tickets.py
@@ -12,12 +12,13 @@ from __future__ import annotations
 from fastapi import APIRouter, HTTPException
 
 from backend.services.glpi import get_ticket_summary_by_group
+from backend.models.ts_models import TicketsSummaryPerLevel
 
 router = APIRouter()
 
 
-@router.get("/api/tickets/summary-per-level", response_model=dict)
-def tickets_summary_per_level() -> dict:
+@router.get("/api/tickets/summary-per-level", response_model=TicketsSummaryPerLevel)
+def tickets_summary_per_level() -> TicketsSummaryPerLevel:
     """Return a summary of tickets grouped by status per service level.
 
     The returned object has a top-level key for each level (e.g. ``"N1"``),

--- a/src/backend/routes/tickets.py
+++ b/src/backend/routes/tickets.py
@@ -27,10 +27,12 @@ def tickets_summary_per_level() -> TicketsSummaryPerLevel:
     """
     try:
         return get_ticket_summary_by_group()
-    except Exception as exc:
+    except Exception:
+        logger.exception("Failed to compute ticket summary due to an unexpected error.")
+
         # Convert unexpected errors into a generic 500 response so the
         # underlying exception details are not leaked to the client.
         raise HTTPException(
             status_code=500,
             detail="Failed to compute ticket summary. See server logs for details.",
-        ) from exc
+        )


### PR DESCRIPTION
## Summary
- add FastAPI router for ticket summaries

## Testing
- `ruff check src/backend/routes/tickets.py`
- `ruff format src/backend/routes/tickets.py`
- `pytest tests/test_metrics_api.py::test_overview_endpoint -q` *(failed: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_688d15d0c1ec83208405fbe4334ee86f

## Resumo por Sourcery

Introduz uma nova rota de API de resumo de tickets para agregar e retornar a contagem de tickets por status para cada nível de suporte com tratamento de erros robusto.

Novos Recursos:
- Adiciona o endpoint FastAPI GET /api/tickets/summary-per-level para retornar a contagem de tickets agrupados por nível de suporte e status

Melhorias:
- Envolve erros internos em respostas HTTP 500 para ocultar detalhes de implementação

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a new tickets summary API route to aggregate and return ticket counts by status for each support level with robust error handling.

New Features:
- Add FastAPI endpoint GET /api/tickets/summary-per-level to return ticket counts grouped by support level and status

Enhancements:
- Wrap internal errors in HTTP 500 responses to hide implementation details

</details>