### PR TITLE
Add minimal FastAPI app entrypoint

### DIFF
--- a/src/backend/app.py
+++ b/src/backend/app.py
@@ -1,0 +1,34 @@
+"""Entry point for running the simplified GLPI Dashboard API.
+
+This module defines a standalone FastAPI application exposing only the
+endpoints implemented in this exercise. It is intentionally minimal
+compared to the fully fledged worker API present in the original
+repository. The purpose of this file is to allow local execution and
+testing of the new ``/api/tickets/summary-per-level`` endpoint without
+pulling in the entire service stack.
+
+Clients expecting to call the real worker API should use the
+``backend/api/worker_api.py`` entrypoint instead.
+"""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+
+from backend.routes.tickets import router as tickets_router
+
+
+def create_app() -> FastAPI:
+    app = FastAPI(title="GLPI Dashboard Ticket Summary API")
+    # Mount ticket summary routes without any prefix. The route itself
+    # includes ``/api/tickets/summary-per-level``.
+    app.include_router(tickets_router)
+    return app
+
+
+app = create_app()
+
+if __name__ == "__main__":  # pragma: no cover
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/src/backend/app.py
+++ b/src/backend/app.py
@@ -29,6 +29,7 @@ def create_app() -> FastAPI:
 app = create_app()
 
 if __name__ == "__main__":  # pragma: no cover
+    import os
     import uvicorn
 
-    uvicorn.run(app, host="0.0.0.0", port=8000)
+    uvicorn.run(app, host=os.getenv("HOST", "0.0.0.0"), port=int(os.getenv("PORT", "8000")))


### PR DESCRIPTION
## Summary
- provide a lightweight FastAPI application for the ticket summary route

## Testing
- `ruff check src/backend/app.py`
- `ruff format src/backend/app.py`
- `pytest tests/test_worker_api.py -k test_rest_endpoints` *(fails: ModuleNotFoundError: No module named 'redis')*

------
https://chatgpt.com/codex/tasks/task_e_688d1c3cee6c832089fc389acce3a385

## Resumo por Sourcery

Adiciona um ponto de entrada (entrypoint) mínimo para a aplicação FastAPI da API de resumo de tickets.

Novas Funcionalidades:
- Introduz uma aplicação FastAPI standalone em src/backend/app.py para hospedar o endpoint /api/tickets/summary-per-level
- Fornece uma função de fábrica `create_app()` e instancia a aplicação para execução local
- Adiciona um bloco `__main__` para executar a aplicação com uvicorn na porta 8000

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a minimal FastAPI application entrypoint for the ticket summary API.

New Features:
- Introduce a standalone FastAPI app in src/backend/app.py to host the /api/tickets/summary-per-level endpoint
- Provide a create_app() factory function and instantiate the app for local execution
- Add a __main__ block to run the app with uvicorn on port 8000

</details>