### PR TITLE
Update metrics hook to aggregated endpoint

### DIFF
--- a/src/frontend/react_app/src/features/tickets/api.ts
+++ b/src/frontend/react_app/src/features/tickets/api.ts
@@ -7,7 +7,12 @@ export function useTicketMetrics() {
     '/v1/metrics/aggregated',
     {
       transformResponse: (data: unknown): MetricsOverview => {
-        if (typeof data === 'object' && data !== null) {
+        if (
+          typeof data === 'object' &&
+          data !== null &&
+          'metric1' in data &&
+          'metric2' in data
+        ) {
           return data as MetricsOverview;
         } else {
           throw new Error('Invalid response structure for MetricsOverview');

--- a/src/frontend/react_app/src/features/tickets/api.ts
+++ b/src/frontend/react_app/src/features/tickets/api.ts
@@ -1,17 +1,16 @@
 import { useApiQuery } from '../../hooks/useApiQuery'
-import type { TicketMetrics } from '../../types/dashboard'
+import type { MetricsOverview } from '../../types/metricsOverview'
 
 export function useTicketMetrics() {
-  return useApiQuery<TicketMetrics>(
+  return useApiQuery<MetricsOverview>(
     ['ticket-metrics'],
-    '/v1/metrics/summary',
+    '/v1/metrics/aggregated',
     {
-      transformResponse: (data: unknown): TicketMetrics => {
-        // Validate and transform the response to ensure it matches TicketMetrics
-        if (typeof data === 'object' && data !== null && 'metric1' in data && 'metric2' in data) {
-          return data as TicketMetrics;
+      transformResponse: (data: unknown): MetricsOverview => {
+        if (typeof data === 'object' && data !== null) {
+          return data as MetricsOverview;
         } else {
-          throw new Error('Invalid response structure for TicketMetrics');
+          throw new Error('Invalid response structure for MetricsOverview');
         }
       }
     }


### PR DESCRIPTION
## Summary
- switch ticket metrics hook to `/v1/metrics/aggregated`
- adapt hook return type to new `MetricsOverview` interface

## Testing
- `make test` *(fails: TypeError in sqlalchemy during backend tests)*

------
https://chatgpt.com/codex/tasks/task_e_688d52629a7c83208bf1a650a5b7ce20

## Resumo por Sourcery

Utilizar o endpoint de métricas agregadas e atualizar o hook de métricas de tickets para a nova interface MetricsOverview

Aprimoramentos:
- Mudar o hook de métricas de tickets para o endpoint '/v1/metrics/aggregated'
- Adaptar o tipo de retorno e a validação da resposta para a interface MetricsOverview

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Use the aggregated metrics endpoint and update the ticket metrics hook to the new MetricsOverview interface

Enhancements:
- Switch ticket metrics hook to '/v1/metrics/aggregated' endpoint
- Adapt return type and response validation to the MetricsOverview interface

</details>