### PR TITLE
Update metrics endpoints and clean up references

### DIFF
--- a/src/backend/app.py
+++ b/src/backend/app.py
@@ -4,8 +4,8 @@ This module defines a standalone FastAPI application exposing only the
 endpoints implemented in this exercise. It is intentionally minimal
 compared to the fully fledged worker API present in the original
 repository. The purpose of this file is to allow local execution and
-testing of the new ``/api/tickets/summary-per-level`` endpoint without
-pulling in the entire service stack.
+testing of the ``/v1/metrics/levels`` endpoint without pulling in the
+entire service stack.
 
 Clients expecting to call the real worker API should use the
 ``backend/api/worker_api.py`` entrypoint instead.
@@ -21,7 +21,7 @@ from backend.routes.tickets import router as tickets_router
 def create_app() -> FastAPI:
     app = FastAPI(title="GLPI Dashboard Ticket Summary API")
     # Mount ticket summary routes without any prefix. The route itself
-    # includes ``/api/tickets/summary-per-level``.
+    # exposes ``/v1/metrics/levels``.
     app.include_router(tickets_router)
     return app
 
@@ -30,6 +30,9 @@ app = create_app()
 
 if __name__ == "__main__":  # pragma: no cover
     import os
+
     import uvicorn
 
-    uvicorn.run(app, host=os.getenv("HOST", "0.0.0.0"), port=int(os.getenv("PORT", "8000")))
+    uvicorn.run(
+        app, host=os.getenv("HOST", "0.0.0.0"), port=int(os.getenv("PORT", "8000"))
+    )

--- a/src/backend/routes/tickets.py
+++ b/src/backend/routes/tickets.py
@@ -1,24 +1,28 @@
 """Ticket-related API routes.
 
 This router exposes endpoints for summarising ticket information. The
-primary endpoint implemented here aggregates ticket counts by status
-for each configured support level (N1–N4). See
-``backend.services.glpi.get_ticket_summary_by_group`` for details on
-how the data is gathered.
+primary endpoint implemented here aggregates ticket counts by status for
+each configured support level (N1–N4) and exposes them at
+``/v1/metrics/levels``. See
+``backend.services.glpi.get_ticket_summary_by_group`` for details on how
+the data is gathered.
 """
 
 from __future__ import annotations
 
+import logging
+
 from fastapi import APIRouter, HTTPException
 
-from backend.services.glpi import get_ticket_summary_by_group
 from backend.models.ts_models import TicketsSummaryPerLevel
+from backend.services.glpi import get_ticket_summary_by_group
 
+logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
-@router.get("/api/tickets/summary-per-level", response_model=TicketsSummaryPerLevel)
-def tickets_summary_per_level() -> TicketsSummaryPerLevel:
+@router.get("/v1/metrics/levels", response_model=TicketsSummaryPerLevel)
+def metrics_levels() -> TicketsSummaryPerLevel:
     """Return a summary of tickets grouped by status per service level.
 
     The returned object has a top-level key for each level (e.g. ``"N1"``),

--- a/tests/test_glpi_service.py
+++ b/tests/test_glpi_service.py
@@ -94,6 +94,6 @@ def test_api_route_summary(monkeypatch: pytest.MonkeyPatch) -> None:
     )
     app = create_app()
     client = TestClient(app)
-    response = client.get("/api/tickets/summary-per-level")
+    response = client.get("/v1/metrics/levels")
     assert response.status_code == 200
     assert response.json() == fake_summary


### PR DESCRIPTION
## Summary
- call new `/v1/metrics/aggregated` and `/v1/metrics/levels` endpoints in the demo Dash app
- update backend sample app and route to expose `/v1/metrics/levels`
- refresh unit test to use new route
- remove obsolete references to `summary-per-level`

## Testing
- `pre-commit run --files src/frontend/app.py src/backend/app.py src/backend/routes/tickets.py tests/test_glpi_service.py`
- `pytest -q` *(fails: environment missing test dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688d59378eec8320bbc74ae86283099e