### PR TITLE
Refactor dashboard API calls

### DIFF
--- a/dashboard_app.py
+++ b/dashboard_app.py
@@ -1,84 +1,55 @@
-"""Dash app using live GLPI data."""
+"""Dash app using the worker API for ticket metrics."""
 
-import asyncio
 import logging
 import os
+from typing import Any
 
 import dash_bootstrap_components as dbc
 import pandas as pd
+import requests
 from dash import Dash
 from flask import Flask
-from flask_caching import Cache
 from frontend.callbacks.callbacks import register_callbacks
 from frontend.layout.layout import build_layout
 
-from backend.core.settings import (
-    DASH_PORT,
-    GLPI_APP_TOKEN,
-    GLPI_BASE_URL,
-    GLPI_PASSWORD,
-    GLPI_USER_TOKEN,
-    GLPI_USERNAME,
-    USE_MOCK_DATA,
-)
-from backend.domain.exceptions import GLPIAPIError
-from backend.infrastructure.glpi.glpi_session import GLPISession
+from backend.core.settings import DASH_PORT, USE_MOCK_DATA
 from backend.infrastructure.glpi.normalization import process_raw
-from backend.schemas.auth import Credentials
 from shared.utils.logging import init_logging
 
 __all__ = ["create_app", "main"]
 
-flask_app = Flask(__name__)
-cache_type = os.getenv("CACHE_TYPE", "redis").lower()
-cache_config: dict[str, object]
-if cache_type == "simple":
-    cache_config = {"CACHE_TYPE": "SimpleCache"}
-else:
-    cache_config = {
-        "CACHE_TYPE": "RedisCache",
-        "CACHE_REDIS_HOST": os.getenv("REDIS_HOST", "redis"),
-        "CACHE_REDIS_PORT": int(os.getenv("REDIS_PORT", 6379)),
-        "CACHE_REDIS_DB": int(os.getenv("REDIS_DB", 0)),
-        "CACHE_REDIS_URL": (
-            f"redis://{os.getenv('REDIS_HOST', 'redis')}:"
-            f"{os.getenv('REDIS_PORT', 6379)}/{os.getenv('REDIS_DB', 0)}"
-        ),
-    }
-cache = Cache(flask_app, config=cache_config)
-if cache_type != "simple":
-    try:  # pragma: no cover - optional
-        cache.cache.get("test_key")
-    except Exception as exc:  # pragma: no cover - Redis missing
-        logging.warning("Redis unavailable, falling back to SimpleCache: %s", exc)
-        cache = Cache(flask_app, config={"CACHE_TYPE": "SimpleCache"})
-
+WORKER_BASE_URL = os.getenv("NEXT_PUBLIC_API_BASE_URL", "http://localhost:8000")
 log_level_name = os.getenv("LOG_LEVEL", "INFO")
 log_level = getattr(logging, log_level_name.upper(), logging.INFO)
 init_logging(log_level)
 
 
-@cache.memoize(timeout=300)
-def _fetch_api_data(
-    ticket_range: str = "0-99", **filters: str
-) -> list[dict[str, object]]:
-    """Fetch ticket data directly from the GLPI API."""
+def _fetch_api_data(ticket_range: str = "0-99", **filters: str) -> list[dict[str, Any]]:
+    """Fetch ticket data from the worker API."""
 
-    creds = Credentials(
-        app_token=GLPI_APP_TOKEN,
-        user_token=GLPI_USER_TOKEN,
-        username=GLPI_USERNAME,
-        password=GLPI_PASSWORD,
-    )
-
-    async def _run() -> list[dict[str, object]]:
-        async with GLPISession(GLPI_BASE_URL, creds) as client:
-            return await client.get_all("Ticket", range=ticket_range, **filters)
-
-    return asyncio.run(_run())
+    url = f"{WORKER_BASE_URL}/v1/tickets"
+    try:
+        resp = requests.get(url, timeout=30)
+        resp.raise_for_status()
+        return resp.json()
+    except requests.RequestException as exc:
+        logging.error("Failed to fetch tickets from %s: %s", url, exc)
+        raise
 
 
-@cache.memoize(timeout=300)
+def _fetch_aggregated_metrics() -> dict[str, Any]:
+    """Return aggregated metrics from the worker API."""
+
+    url = f"{WORKER_BASE_URL}/v1/metrics/aggregated"
+    try:
+        resp = requests.get(url, timeout=30)
+        resp.raise_for_status()
+        return resp.json()
+    except requests.RequestException as exc:
+        logging.error("Failed to fetch metrics from %s: %s", url, exc)
+        return {}
+
+
 def _transform_df(ticket_range: str = "0-99", **filters: str) -> pd.DataFrame:
     """Transform raw ticket data into a normalized DataFrame."""
 
@@ -86,15 +57,8 @@ def _transform_df(ticket_range: str = "0-99", **filters: str) -> pd.DataFrame:
     return process_raw(data)
 
 
-def clear_cache(ticket_range: str = "0-99", **filters: str) -> None:
-    """Manually invalidate cached data for a given ticket range and filters."""
-
-    cache.delete_memoized(_fetch_api_data, ticket_range, **filters)
-    cache.delete_memoized(_transform_df, ticket_range, **filters)
-
-
 def load_data(ticket_range: str = "0-99", **filters: str) -> pd.DataFrame | None:
-    """Load ticket data from GLPI or a local mock file."""
+    """Load ticket data from the worker or a local mock file."""
     if USE_MOCK_DATA:
         logging.info("Loading ticket data from mock file")
         try:
@@ -103,18 +67,19 @@ def load_data(ticket_range: str = "0-99", **filters: str) -> pd.DataFrame | None
             logging.error("failed to load mock data: %s", exc)
             return None
 
-    logging.info("Fetching ticket data from GLPI API")
+    logging.info("Fetching ticket data from worker API")
     try:
+        metrics = _fetch_aggregated_metrics()
+        logging.info("Aggregated metrics: %s", metrics)
         return _transform_df(ticket_range, **filters)
-    except GLPIAPIError as exc:
-        logging.error("Error contacting GLPI API: %s", exc)
+    except Exception as exc:
+        logging.error("Error contacting worker API: %s", exc)
         return None
 
 
 def create_app(df: pd.DataFrame | None) -> Dash:
     """Create Dash application."""
     server = Flask(__name__)
-    cache.init_app(server)
 
     # @server.route("/ping")
     # def ping() -> tuple[str, int]:


### PR DESCRIPTION
## Summary
- consume ticket and metrics data from the worker API
- drop redundant caching logic

## Testing
- `pre-commit run --files dashboard_app.py`
- `pytest -k "dashboard_app"` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_688d5ee66e988320bc5bb39fb19e18f7