### PR TITLE
feat: fetch ticket metrics from worker API

### DIFF
--- a/dashboard_app.py
+++ b/dashboard_app.py
@@ -13,7 +13,6 @@ from frontend.callbacks.callbacks import register_callbacks
 from frontend.layout.layout import build_layout
 
 from backend.core.settings import DASH_PORT, USE_MOCK_DATA
-from backend.infrastructure.glpi.normalization import process_raw
 from shared.utils.logging import init_logging
 
 __all__ = ["create_app", "main"]
@@ -22,19 +21,6 @@ WORKER_BASE_URL = os.getenv("NEXT_PUBLIC_API_BASE_URL", "http://localhost:8000")
 log_level_name = os.getenv("LOG_LEVEL", "INFO")
 log_level = getattr(logging, log_level_name.upper(), logging.INFO)
 init_logging(log_level)
-
-
-def _fetch_api_data(ticket_range: str = "0-99", **filters: str) -> list[dict[str, Any]]:
-    """Fetch ticket data from the worker API."""
-
-    url = f"{WORKER_BASE_URL}/v1/tickets"
-    try:
-        resp = requests.get(url, timeout=30)
-        resp.raise_for_status()
-        return resp.json()
-    except requests.RequestException as exc:
-        logging.error("Failed to fetch tickets from %s: %s", url, exc)
-        raise
 
 
 def _fetch_aggregated_metrics() -> dict[str, Any]:
@@ -50,31 +36,26 @@ def _fetch_aggregated_metrics() -> dict[str, Any]:
         return {}
 
 
-def _transform_df(ticket_range: str = "0-99", **filters: str) -> pd.DataFrame:
-    """Transform raw ticket data into a normalized DataFrame."""
-
-    data = _fetch_api_data(ticket_range, **filters)
-    return process_raw(data)
-
-
-def load_data(ticket_range: str = "0-99", **filters: str) -> pd.DataFrame | None:
+def load_data(ticket_range: str = "0-99", **filters: str) -> list[dict[str, Any]]:
     """Load ticket data from the worker or a local mock file."""
+
     if USE_MOCK_DATA:
         logging.info("Loading ticket data from mock file")
         try:
-            return process_raw(pd.read_json("tests/resources/mock_tickets.json"))
+            return pd.read_json("tests/resources/mock_tickets.json").to_dict("records")
         except Exception as exc:  # pragma: no cover - file errors
             logging.error("failed to load mock data: %s", exc)
-            return None
+            raise
 
-    logging.info("Fetching ticket data from worker API")
+    url = f"{WORKER_BASE_URL}/v1/tickets"
+    logging.info("Fetching ticket data from %s", url)
     try:
-        metrics = _fetch_aggregated_metrics()
-        logging.info("Aggregated metrics: %s", metrics)
-        return _transform_df(ticket_range, **filters)
-    except Exception as exc:
+        resp = requests.get(url, timeout=30)
+        resp.raise_for_status()
+        return resp.json()
+    except requests.RequestException as exc:
         logging.error("Error contacting worker API: %s", exc)
-        return None
+        raise
 
 
 def create_app(df: pd.DataFrame | None) -> Dash:
@@ -100,7 +81,11 @@ def profile_startup() -> None:
 
     profiler = cProfile.Profile()
     profiler.enable()
-    df = load_data()
+    try:
+        data = load_data()
+    except Exception:
+        data = []
+    df = pd.DataFrame(data) if data else None
     create_app(df)
     profiler.disable()
     Stats(profiler).sort_stats("cumulative").print_stats(10)
@@ -108,7 +93,12 @@ def profile_startup() -> None:
 
 def main() -> None:
     """Run the Dash server."""
-    df = load_data()
+    try:
+        data = load_data()
+    except Exception as exc:
+        logging.error("Failed to load initial data: %s", exc)
+        data = []
+    df = pd.DataFrame(data) if data else None
     app = create_app(df)
     app.run(
         host="0.0.0.0", port=DASH_PORT, debug=False, use_reloader=False, threaded=True

--- a/dashboard_app.py
+++ b/dashboard_app.py
@@ -42,7 +42,8 @@ def load_data(ticket_range: str = "0-99", **filters: str) -> list[dict[str, Any]
     if USE_MOCK_DATA:
         logging.info("Loading ticket data from mock file")
         try:
-            return pd.read_json("tests/resources/mock_tickets.json").to_dict("records")
+            with open("tests/resources/mock_tickets.json", "r", encoding="utf-8") as f:
+                return json.load(f)
         except Exception as exc:  # pragma: no cover - file errors
             logging.error("failed to load mock data: %s", exc)
             raise

--- a/dashboard_app.py
+++ b/dashboard_app.py
@@ -84,7 +84,8 @@ def profile_startup() -> None:
     profiler.enable()
     try:
         data = load_data()
-    except Exception:
+    except Exception as exc:
+        logging.error("Failed to load data for profiling: %s", exc)
         data = []
     df = pd.DataFrame(data) if data else None
     create_app(df)

--- a/src/frontend/layout/layout.py
+++ b/src/frontend/layout/layout.py
@@ -53,7 +53,7 @@ def build_layout(df: pd.DataFrame | None) -> html.Div | dbc.Alert:
     """Return dashboard layout or an error message."""
     if df is None:
         return dbc.Alert(
-            "Erro na conexão com o GLPI. Verifique suas credenciais.",
+            "Erro na conexão com a API. Verifique o serviço.",
             color="danger",
         )
     return render_dashboard(df)


### PR DESCRIPTION
## Summary
- use worker API to load ticket data
- parse API JSON responses into DataFrames in callbacks
- clean up unused GLPI credential logic and update error messages

## Testing
- `pre-commit run --files dashboard_app.py src/frontend/callbacks/callbacks.py src/frontend/layout/layout.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'libcst')*


------
https://chatgpt.com/codex/tasks/task_e_688d72e85f7c8320a927d2d543f10a24

## Resumo por Sourcery

Substituir a integração GLPI por chamadas diretas à API do worker para dados de tickets, refatorar o carregamento de dados e os callbacks para analisar JSON em DataFrames, e atualizar o tratamento de erros e as mensagens para o usuário.

Novas Funcionalidades:
- Obter métricas de tickets diretamente do endpoint da API do worker
- Converter JSON bruto da API em DataFrames pandas dentro dos callbacks do Dash

Melhorias:
- Remover lógica de credenciais GLPI e normalização não utilizada
- Refatorar load_data para retornar registros JSON brutos e tratar erros com valores padrão
- Empacotar dados da API em DataFrames na inicialização e em callbacks para consistência

Documentação:
- Atualizar mensagens de erro para o usuário de específicas do GLPI para referências genéricas da API

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Replace GLPI integration with direct worker API calls for ticket data, refactor data loading and callbacks to parse JSON into DataFrames, and update error handling and user-facing messages.

New Features:
- Fetch ticket metrics directly from the worker API endpoint
- Convert raw API JSON into pandas DataFrames within Dash callbacks

Enhancements:
- Remove unused GLPI credential and normalization logic
- Refactor load_data to return raw JSON records and handle errors with defaults
- Wrap API data in DataFrames at startup and in callbacks for consistency

Documentation:
- Update user-facing error messages from GLPI-specific to generic API references

</details>