### PR TITLE
fix: remove stray div from heatmap header

### DIFF
--- a/src/frontend/react_app/src/components/ChamadosHeatmap.tsx
+++ b/src/frontend/react_app/src/components/ChamadosHeatmap.tsx
@@ -36,8 +36,7 @@ function ChamadosHeatmapComponent() {
       <div className="flex flex-row items-center justify-between px-2 pb-3 border-b border-border/60 min-h-[48px]">
         <div className="levels-title">Chamados no Ano</div>
         <div className="levels-subtitle">Heatmap Diário</div>
-      <div/>
-    </div>
+      </div>
       <div className="overflow-x-auto pb-2 mb-4 mt-2">
         <ReactCalendarHeatmap
           startDate={startDate}


### PR DESCRIPTION
## Summary
- remove stray div from ChamadosHeatmap header

## Testing
- `npm test` *(fails: SyntaxError: Cannot use 'import.meta' outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_688d72e1500083209e5bf94c3cc32d3c

## Resumo por Sourcery

Correções de Bugs:
- Remove <div> auto-fechada supérflua do cabeçalho do mapa de calor

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Remove extraneous self-closing <div> from heatmap header

</details>