### PR TITLE
Add json import to dashboard app

### DIFF
--- a/dashboard_app.py
+++ b/dashboard_app.py
@@ -1,5 +1,6 @@
 """Dash app using the worker API for ticket metrics."""
 
+import json
 import logging
 import os
 from typing import Any


### PR DESCRIPTION
## Summary
- fix dashboard app imports by adding missing json module

## Testing
- `pre-commit run --files dashboard_app.py`
- `pytest tests/test_dash_offline.py` *(fails: ModuleNotFoundError: No module named 'opentelemetry.instrumentation...')*

------
https://chatgpt.com/codex/tasks/task_e_688d866022cc83208a6b54bc522c8ad9

## Sumário por Sourcery

Correções de Bugs:
- Adiciona importação de json para dashboard_app para resolver NameError

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Add json import to dashboard_app to resolve NameError

</details>