### PR TITLE
feat: add group field to ticket DTO

### DIFF
--- a/src/backend/schemas/ticket_models.py
+++ b/src/backend/schemas/ticket_models.py
@@ -101,8 +101,9 @@ class CleanTicketDTO(BaseModel):
     created_at: Optional[datetime] = Field(default=None, alias="date_creation")
     assigned_to: str = "Unassigned"
     requester: Optional[str] = None
+    group: str | None = None
 
-    model_config = ConfigDict(populate_by_name=True)
+    model_config = ConfigDict(populate_by_name=True, extra="allow")
 
     @model_validator(mode="before")
     @classmethod

--- a/src/backend/schemas/ticket_models.py
+++ b/src/backend/schemas/ticket_models.py
@@ -101,7 +101,7 @@ class CleanTicketDTO(BaseModel):
     created_at: Optional[datetime] = Field(default=None, alias="date_creation")
     assigned_to: str = "Unassigned"
     requester: Optional[str] = None
-    group: str | None = None
+    group: Optional[str] = None
 
     model_config = ConfigDict(populate_by_name=True, extra="allow")
 

--- a/src/frontend/react_app/src/types/api.ts
+++ b/src/frontend/react_app/src/types/api.ts
@@ -6,52 +6,19 @@
 */
 
 /**
- * Status
- */
-export type TicketStatus = 0 | 1 | 2 | 3 | 4 | 5 | 6;
-/**
- * Urgency
- */
-export type Urgency = 0 | 1 | 2 | 3 | 4 | 5 | 6;
-/**
- * Impact
- */
-export type Impact = 0 | 1 | 2 | 3 | 4 | 5 | 6;
-/**
- * Ticket type
- */
-export type TicketType = 0 | 1 | 2;
-
-/**
- * Subset of ticket fields exposed to the frontend.
+ * Normalized ticket used internally by the application.
  */
 export interface CleanTicketDTO {
-  /**
-   * Ticket identifier
-   */
   id: number;
+  name?: string | null;
+  status: string;
   /**
-   * Short summary
+   * Priority as a human-readable label
    */
-  name?: string;
-  /**
-   * Detailed description
-   */
-  content?: string | null;
-  status?: TicketStatus;
-  /**
-   * Priority
-   */
-  priority?: string;
-  urgency?: Urgency;
-  impact?: Impact;
-  type?: TicketType;
-  /**
-   * Creation timestamp
-   */
+  priority?: string | null;
   date_creation?: string | null;
-  /**
-   * Requester
-   */
+  assigned_to?: string;
   requester?: string | null;
+  group?: string | null;
+  [k: string]: unknown;
 }

--- a/tests/test_worker_api.py
+++ b/tests/test_worker_api.py
@@ -73,6 +73,7 @@ class FakeClient(GlpiApiClient):
                 "priority": 3,
                 "date_creation": "2024-06-01T00:00:00",
                 "assigned_to": "",
+                "group": "N1",
                 "requester": "Alice",
                 "users_id_requester": 10,
             },
@@ -83,6 +84,7 @@ class FakeClient(GlpiApiClient):
                 "priority": 2,
                 "date_creation": "2024-06-02T00:00:00",
                 "assigned_to": "",
+                "group": "N2",
                 "requester": "Bob",
                 "users_id_requester": 11,
             },
@@ -104,6 +106,7 @@ def test_rest_endpoints(test_app: TestClient):
     assert isinstance(tickets, list)
     assert tickets and "id" in tickets[0]
     assert tickets[0]["requester"] == "Alice"
+    assert tickets[0]["group"] == "N1"
 
     resp = test_app.get("/v1/metrics/summary")
     assert resp.status_code == 200
@@ -164,6 +167,7 @@ def test_chamados_por_data_cache(dummy_cache: DummyCache):
                 "status": 5,
                 "priority": 2,
                 "date_creation": "2024-06-03",
+                "group": "N1",
                 "requester": "Alice",
                 "users_id_requester": 10,
             },
@@ -173,6 +177,7 @@ def test_chamados_por_data_cache(dummy_cache: DummyCache):
                 "status": 6,
                 "priority": 3,
                 "date_creation": "2024-06-04",
+                "group": "N2",
                 "requester": "Bob",
                 "users_id_requester": 11,
             },
@@ -200,6 +205,7 @@ def test_chamados_por_dia_cache(dummy_cache: DummyCache):
                 "status": 5,
                 "priority": 2,
                 "date_creation": "2024-06-03",
+                "group": "N1",
                 "requester": "Alice",
                 "users_id_requester": 10,
             },
@@ -209,6 +215,7 @@ def test_chamados_por_dia_cache(dummy_cache: DummyCache):
                 "status": 6,
                 "priority": 3,
                 "date_creation": "2024-06-04",
+                "group": "N2",
                 "requester": "Bob",
                 "users_id_requester": 11,
             },
@@ -442,6 +449,7 @@ def test_metrics_aggregated_cache(dummy_cache: DummyCache):
                 "status": 5,
                 "priority": 2,
                 "date_creation": "2024-07-01",
+                "group": "N3",
                 "requester": "Carol",
                 "users_id_requester": 12,
             }


### PR DESCRIPTION
## Summary
- include ticket `group` field in CleanTicketDTO and allow extra fields
- regenerate TypeScript API types
- cover `group` serialization in worker API tests

## Testing
- `pytest tests/test_worker_api.py::test_rest_endpoints -q`


------
https://chatgpt.com/codex/tasks/task_e_688d86afef6483209c15f28446ab2f3f