### PR TITLE
chore: rename API base env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,16 +187,16 @@ The dashboard reads data produced by the worker and stored in PostgreSQL. More d
 [AGENTS.md](AGENTS.md). Structural file moves are logged in [docs/REFACTOR_LOG.md](docs/REFACTOR_LOG.md). A walkthrough of the `langgraph_workflow.py` module is
 available in [docs/langgraph_workflow.md](docs/langgraph_workflow.md).
 Instructions for running the React front-end—including npm scripts and required environment variables—are available in
-[docs/frontend_architecture.md](docs/frontend_architecture.md). That document also covers how the front-end communicates with the worker API via `NEXT_PUBLIC_API_BASE_URL` and how to run the Jest and Playwright test suites.
+[docs/frontend_architecture.md](docs/frontend_architecture.md). That document also covers how the front-end communicates with the worker API via `VITE_API_BASE_URL` and how to run the Jest and Playwright test suites.
 Create the environment file with `cp src/frontend/react_app/.env.example src/frontend/react_app/.env` before running the dashboard. Docker Compose automatically loads `.env` when present. Execute all npm commands from inside the `src/frontend/react_app` directory, e.g. `cd src/frontend/react_app && npm run dev`, or launch Docker.
 
 When running via Docker, the front-end container reaches the backend using the
 service name `backend`. The `.env` file already sets
-`NEXT_PUBLIC_API_BASE_URL=http://backend:8000` so requests between containers
+`VITE_API_BASE_URL=http://backend:8000` so requests between containers
 resolve correctly. Browsers on the host can still hit the API on
 `http://localhost:8000` thanks to the published port. If you see
 `net::ERR_NAME_NOT_RESOLVED` errors in the browser console, edit
-`src/frontend/react_app/.env` and set `NEXT_PUBLIC_API_BASE_URL` to
+`src/frontend/react_app/.env` and set `VITE_API_BASE_URL` to
 `http://localhost:8000` or add `backend` to your `/etc/hosts` file.
 
 ### Multi-agent pipeline (A1–A9)
@@ -514,7 +514,7 @@ this behaviour. Responses include the header `X-Warning: using mock data` when
 the fallback is active.
 
 Make sure the service is running with `python worker.py` and that your
-front-end points to it via `NEXT_PUBLIC_API_BASE_URL` in
+front-end points to it via `VITE_API_BASE_URL` in
 `src/frontend/react_app/.env`.
 
 Docker Compose now mounts `src/frontend/react_app/.env.example` directly in the

--- a/dashboard_app.py
+++ b/dashboard_app.py
@@ -18,7 +18,7 @@ from shared.utils.logging import init_logging
 
 __all__ = ["create_app", "main"]
 
-WORKER_BASE_URL = os.getenv("NEXT_PUBLIC_API_BASE_URL", "http://localhost:8000")
+WORKER_BASE_URL = os.getenv("VITE_API_BASE_URL", "http://localhost:8000")
 log_level_name = os.getenv("LOG_LEVEL", "INFO")
 log_level = getattr(logging, log_level_name.upper(), logging.INFO)
 init_logging(log_level)

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -20,7 +20,7 @@ services:
     ports:
       - "5174:5174"  # Porta customizada do Vite
     environment:
-      NEXT_PUBLIC_API_BASE_URL: http://localhost:8000
+      VITE_API_BASE_URL: http://localhost:8000
     volumes:
       # Mounts local source code for live-reloading, and uses a named volume
       # to persist node_modules, preventing it from being overwritten by the host.

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -33,7 +33,7 @@ services:
     ports:
       - "80:80"
     environment:
-      NEXT_PUBLIC_API_BASE_URL: http://ppiratini.intra.rs.gov.br/glpi
+      VITE_API_BASE_URL: http://ppiratini.intra.rs.gov.br/glpi
 
   db:
     image: postgres:15-alpine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
       args:
         # A URL da API que o navegador usará para se conectar ao backend.
         # Em um ambiente de desenvolvimento local, é o localhost com a porta exposta do backend.
-        NEXT_PUBLIC_API_BASE_URL: "http://localhost:8000"
+        VITE_API_BASE_URL: "http://localhost:8000"
     depends_on:
       - backend
     healthcheck:

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -1,4 +1,4 @@
-- `NEXT_PUBLIC_API_BASE_URL`: must point to `http://localhost:8000` when running under Docker Compose.
+- `VITE_API_BASE_URL`: must point to `http://localhost:8000` when running under Docker Compose.
   You can also create `.env.local` with this setting for local scripts outside Docker.
 - `DISALLOWED_PROXIES`: comma-separated list of proxy hosts ignored by `scripts/validate_credentials.py`.
 

--- a/docs/developer_usage.md
+++ b/docs/developer_usage.md
@@ -217,7 +217,7 @@ Se precisar passar opções criadas inline, serializá-las ou extraia-as para um
 constante para evitar re-renderizações extras.
 
 Internamente a função usa o `fetch` nativo e monta a URL com
-`NEXT_PUBLIC_API_BASE_URL`.
+`VITE_API_BASE_URL`.
 
 ### Exemplos de novos hooks
 

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -94,8 +94,6 @@ The React code can read this value using `import.meta.env.VITE_API_BASE_URL` to 
 
 > **Note**: this variable was renamed from `NEXT_PUBLIC_API_BASE_URL` to `VITE_API_BASE_URL` to match Vite conventions.
 
-Vite only exposes variables prefixed with `VITE_` by default. The project configures `envPrefix` in `vite.config.ts` so that `NEXT_PUBLIC_*` variables are also loaded.
-
 Imports reference `@/` as a shortcut to the `src/` folder. Both Vite and TypeScript resolve this alias through `resolve.alias` in `vite.config.ts` and the `paths` option in `tsconfig.app.json`.
 
 ### API Integration

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -79,20 +79,20 @@ npx prettier --write "src/**/*.{ts,tsx}"  # format code
 Create a `.env` file in the `src/frontend/react_app` directory to configure the URL of the worker API. This value must be provided in **development**, **testing** and **production** environments:
 
 ```bash
-NEXT_PUBLIC_API_BASE_URL=http://127.0.0.1:8000
+VITE_API_BASE_URL=http://127.0.0.1:8000
 ```
 
 If this variable is missing the application will fail to start. The API client
-verifies that `NEXT_PUBLIC_API_BASE_URL` is defined and throws an error
+verifies that `VITE_API_BASE_URL` is defined and throws an error
 otherwise. `npm run dev`, `npm test`, `npm run build` and
  `npm run preview` automatically execute `npm run check-env` to validate the
  configuration. This script imports the shared logic from `scripts/check-env.js`
  at the project root, so you can also run `npm run check-env` manually before
  launching the app or building for production.
 
-The React code can read this value using `import.meta.env.NEXT_PUBLIC_API_BASE_URL` to send requests to the worker.
+The React code can read this value using `import.meta.env.VITE_API_BASE_URL` to send requests to the worker.
 
-> **Note**: this variable was renamed from `VITE_API_URL` to `NEXT_PUBLIC_API_BASE_URL` to match Next.js conventions. This change ensures compatibility with Next.js, which uses the `NEXT_PUBLIC_` prefix for environment variables exposed to the browser.
+> **Note**: this variable was renamed from `NEXT_PUBLIC_API_BASE_URL` to `VITE_API_BASE_URL` to match Vite conventions.
 
 Vite only exposes variables prefixed with `VITE_` by default. The project configures `envPrefix` in `vite.config.ts` so that `NEXT_PUBLIC_*` variables are also loaded.
 
@@ -100,17 +100,17 @@ Imports reference `@/` as a shortcut to the `src/` folder. Both Vite and TypeScr
 
 ### API Integration
 
-Start the worker with `python worker.py` (it listens on port `8000` by default) and point the front-end to it using the `NEXT_PUBLIC_API_BASE_URL` variable. The `/v1/tickets` endpoint now returns the `priority` label and the `requester` name. Example fetching ticket metrics:
+Start the worker with `python worker.py` (it listens on port `8000` by default) and point the front-end to it using the `VITE_API_BASE_URL` variable. The `/v1/tickets` endpoint now returns the `priority` label and the `requester` name. Example fetching ticket metrics:
 
 ```ts
-const resp = await fetch(`${import.meta.env.NEXT_PUBLIC_API_BASE_URL}/v1/metrics/summary`);
+const resp = await fetch(`${import.meta.env.VITE_API_BASE_URL}/v1/metrics/summary`);
 const data = await resp.json();
 ```
 
 The worker also streams progress using `/v1/tickets/stream`:
 
 ```ts
-const url = `${import.meta.env.NEXT_PUBLIC_API_BASE_URL}/v1/tickets/stream`;
+const url = `${import.meta.env.VITE_API_BASE_URL}/v1/tickets/stream`;
 const es = new EventSource(url);
 es.onmessage = (ev) => console.log('chunk', ev.data);
 ```

--- a/docs/frontend_charts.md
+++ b/docs/frontend_charts.md
@@ -11,7 +11,7 @@ Two REST routes provide the aggregated data used by the charts and leverage the 
 
 Both endpoints perform the aggregation server-side so the front-end only consumes summarized values.
 
-Make sure `python worker.py` is running and set `NEXT_PUBLIC_API_BASE_URL` in
+Make sure `python worker.py` is running and set `VITE_API_BASE_URL` in
 `src/frontend/react_app/.env` to point to the worker (default `http://127.0.0.1:8000`). All
 requests in the examples below use this variable.
 
@@ -42,7 +42,7 @@ export function useChamadosPorData() {
   return { dados: data, loading: isLoading, erro: error }
 }
 
-// `useApiQuery` resolves the full URL using `NEXT_PUBLIC_API_BASE_URL`.
+// `useApiQuery` resolves the full URL using `VITE_API_BASE_URL`.
 ```
 
 ### `useChamadosPorDia`

--- a/scripts/lint-configs.sh
+++ b/scripts/lint-configs.sh
@@ -9,7 +9,7 @@ grep -q "node:20.19.0" src/frontend/react_app/Dockerfile || {
 
 echo "🔍 Checking API_BASE_URL…"
 grep -q "backend:8000" .env || {
-  echo "ERROR: NEXT_PUBLIC_API_BASE_URL must be http://backend:8000"
+  echo "ERROR: VITE_API_BASE_URL must be http://backend:8000"
   exit 1
 }
 

--- a/src/frontend/react_app/.env.example
+++ b/src/frontend/react_app/.env.example
@@ -1,4 +1,4 @@
-# Example environment for the Next.js frontend
+# Example environment for the Vite frontend
 # Points to the worker API running locally
-NEXT_PUBLIC_API_BASE_URL=http://localhost:8000
+VITE_API_BASE_URL=http://localhost:8000
 # NEXT_PUBLIC_FARO_URL=http://localhost:1234/collect

--- a/src/frontend/react_app/Dockerfile
+++ b/src/frontend/react_app/Dockerfile
@@ -5,8 +5,8 @@ WORKDIR /app
 ENV NPM_CONFIG_CACHE=/root/.npm
 
 # Argumento de build para a URL da API, que será injetado no build estático.
-ARG NEXT_PUBLIC_API_BASE_URL
-ENV NEXT_PUBLIC_API_BASE_URL=$NEXT_PUBLIC_API_BASE_URL
+ARG VITE_API_BASE_URL
+ENV VITE_API_BASE_URL=$VITE_API_BASE_URL
 
 # Copia os arquivos de dependência e instala
 COPY src/frontend/react_app/package.json src/frontend/react_app/package-lock.json* ./

--- a/src/frontend/react_app/README.md
+++ b/src/frontend/react_app/README.md
@@ -4,7 +4,7 @@ This folder contains the React front-end of the **GLPI Dashboard CAU**. The appl
 
 ## Setup
 
-1. Copy `.env.example` to `.env` and set `NEXT_PUBLIC_API_BASE_URL` to the worker address.
+1. Copy `.env.example` to `.env` and set `VITE_API_BASE_URL` to the worker address.
 
 2. (Optional) If you use the Grafana observability stack, set `NEXT_PUBLIC_FARO_URL` to your Faro collector (for example `http://localhost:1234/collect`). Leave this line commented if the collector isn't running to avoid browser errors.
 

--- a/src/frontend/react_app/jest.integration.setup.ts
+++ b/src/frontend/react_app/jest.integration.setup.ts
@@ -14,6 +14,6 @@ export default async function globalSetup() {
   // StartedTestContainer is returned above
 
   const mappedPort = container.getMappedPort(8000)
-  process.env.NEXT_PUBLIC_API_BASE_URL = `http://localhost:${mappedPort}`
+  process.env.VITE_API_BASE_URL = `http://localhost:${mappedPort}`
   fs.writeFileSync(path.join(__dirname, 'container-id'), container.getId())
 }

--- a/src/frontend/react_app/scripts/check-env.js
+++ b/src/frontend/react_app/scripts/check-env.js
@@ -10,7 +10,7 @@ dotenv.config({ path: path.join(__dirname, '..', '.env') })
 // 2. Função de assert
 function assertEnv(keys) {
   const defaults = {
-    NEXT_PUBLIC_API_BASE_URL: 'http://localhost:8000',
+    VITE_API_BASE_URL: 'http://localhost:8000',
   };
 
   keys.forEach(key => {
@@ -32,11 +32,11 @@ function assertEnv(keys) {
 }
 
 // 3. Checa as variáveis
-assertEnv(['NEXT_PUBLIC_API_BASE_URL']);
+assertEnv(['VITE_API_BASE_URL']);
 
 // 4. Log de sucesso
 console.log(
-  `NEXT_PUBLIC_API_BASE_URL resolved to: ${process.env.NEXT_PUBLIC_API_BASE_URL}`
+  `VITE_API_BASE_URL resolved to: ${process.env.VITE_API_BASE_URL}`
 );
 if (process.env.NEXT_PUBLIC_FARO_URL) {
   console.log(

--- a/src/frontend/react_app/src/hooks/__tests__/useApiQuery.test.tsx
+++ b/src/frontend/react_app/src/hooks/__tests__/useApiQuery.test.tsx
@@ -4,11 +4,11 @@ import { useApiQuery } from '../useApiQuery'
 
 const MOCK_API_URL = 'http://test-api.com'
 beforeAll(() => {
-  process.env.NEXT_PUBLIC_API_BASE_URL = MOCK_API_URL
+  process.env.VITE_API_BASE_URL = MOCK_API_URL
 })
 
 afterAll(() => {
-  delete process.env.NEXT_PUBLIC_API_BASE_URL
+  delete process.env.VITE_API_BASE_URL
 })
 beforeEach(() => {
   global.fetch = jest.fn() as unknown as typeof fetch
@@ -36,14 +36,14 @@ describe('useApiQuery', () => {
   })
 
   it('handles missing base URL', async () => {
-    delete process.env.NEXT_PUBLIC_API_BASE_URL
+    delete process.env.VITE_API_BASE_URL
     ;(global.fetch as jest.Mock).mockResolvedValue({ ok: true, json: async () => ({}) })
     const { result } = renderHook(() => useApiQuery(['t'], '/test'), { wrapper })
     await waitFor(() => expect(result.current.isLoading).toBe(false))
     expect((result.current.error as Error).message).toBe(
-      'URL base da API não configurada. Verifique NEXT_PUBLIC_API_BASE_URL.',
+      'URL base da API não configurada. Verifique VITE_API_BASE_URL.',
     )
-    process.env.NEXT_PUBLIC_API_BASE_URL = MOCK_API_URL
+    process.env.VITE_API_BASE_URL = MOCK_API_URL
   })
 
   it('updates state on error', async () => {

--- a/src/frontend/react_app/src/hooks/useApiQuery.ts
+++ b/src/frontend/react_app/src/hooks/useApiQuery.ts
@@ -34,14 +34,14 @@ export function useApiQuery<T, E = Error>(
       : undefined;
 
   const baseUrl =
-    metaEnv?.NEXT_PUBLIC_API_BASE_URL ??
-    process.env.NEXT_PUBLIC_API_BASE_URL ??
+    metaEnv?.VITE_API_BASE_URL ??
+    process.env.VITE_API_BASE_URL ??
     'http://localhost:8000';
 
   const fetchFromApi = async (): Promise<T> => {
     if (!baseUrl) {
       throw new Error(
-        'URL base da API não configurada. Verifique NEXT_PUBLIC_API_BASE_URL.',
+        'URL base da API não configurada. Verifique VITE_API_BASE_URL.',
       );
     }
     const response = await fetch(`${baseUrl}${endpoint}`);

--- a/src/frontend/react_app/tests/components/GlpiTicketsTable.test.tsx
+++ b/src/frontend/react_app/tests/components/GlpiTicketsTable.test.tsx
@@ -7,7 +7,7 @@ const wrapper = ({ children }: { children: React.ReactNode }) => (
 )
 
 beforeEach(() => {
-  const mockImportMetaEnv: ImportMetaEnv = { NEXT_PUBLIC_API_BASE_URL: 'http://localhost' };
+  const mockImportMetaEnv: ImportMetaEnv = { VITE_API_BASE_URL: 'http://localhost' };
   Object.defineProperty(import.meta, 'env', { value: mockImportMetaEnv, writable: true });
 })
 

--- a/src/frontend/react_app/tests/hooks/useApiQuery.test.tsx
+++ b/src/frontend/react_app/tests/hooks/useApiQuery.test.tsx
@@ -6,7 +6,7 @@ const fetchMock = jest.fn()
 global.fetch = fetchMock as unknown as typeof fetch
 
 const MOCK_API_URL = 'http://test-api.com'
-process.env.NEXT_PUBLIC_API_BASE_URL = MOCK_API_URL
+process.env.VITE_API_BASE_URL = MOCK_API_URL
 
 let queryClient: QueryClient
 const wrapper = ({ children }: { children: React.ReactNode }) => (
@@ -65,7 +65,7 @@ describe('useApiQuery', () => {
 
 
   it('deve tratar erro de URL base não configurada', async () => {
-    delete process.env.NEXT_PUBLIC_API_BASE_URL
+    delete process.env.VITE_API_BASE_URL
 
     const { result } = renderHook(() => useApiQuery(['tickets'], '/v1/tickets'), {
       wrapper,
@@ -74,9 +74,9 @@ describe('useApiQuery', () => {
     await waitFor(() => expect(result.current.isLoading).toBe(false))
 
     expect((result.current.error as Error).message).toBe(
-      'URL base da API não configurada. Verifique NEXT_PUBLIC_API_BASE_URL.',
+      'URL base da API não configurada. Verifique VITE_API_BASE_URL.',
     )
 
-    process.env.NEXT_PUBLIC_API_BASE_URL = MOCK_API_URL
+    process.env.VITE_API_BASE_URL = MOCK_API_URL
   })
 });

--- a/src/frontend/react_app/tests/integration/health.test.ts
+++ b/src/frontend/react_app/tests/integration/health.test.ts
@@ -1,11 +1,11 @@
 test('health endpoint', async () => {
-  const base = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8000';
+  const base = process.env.VITE_API_BASE_URL || 'http://localhost:8000';
   const res = await fetch(`${base}/v1/health`);
   expect(res.status).toBe(200);
 });
 
 test('health endpoint HEAD', async () => {
-  const base = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8000';
+  const base = process.env.VITE_API_BASE_URL || 'http://localhost:8000';
   let res = await fetch(`${base}/v1/health`, { method: 'HEAD' });
 
   // Caso res.status seja undefined, faz um GET como fallback


### PR DESCRIPTION
## Summary
- rename `NEXT_PUBLIC_API_BASE_URL` to `VITE_API_BASE_URL`
- update React hook, Docker/Compose configs, scripts and docs

## Testing
- `npm test` *(fails: Cannot use 'import.meta' outside a module)*
- `pytest` *(fails: 53 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_688d9634fb6483208bd046c3e92d8e9c

## Resumo por Sourcery

Migra a variável de ambiente base da API de `NEXT_PUBLIC_API_BASE_URL` para `VITE_API_BASE_URL` em todo o projeto para alinhar com as convenções do Vite.

Melhorias:
- Atualiza o React hook, o script de asserção de ambiente e o `dashboard_app` para usar `VITE_API_BASE_URL` em vez de `NEXT_PUBLIC_API_BASE_URL`

Compilação:
- Ajusta as configurações de `ARG`/`ENV` do Dockerfile e do docker-compose para usar `VITE_API_BASE_URL`

Documentação:
- Revisa a documentação e os arquivos README para referenciar `VITE_API_BASE_URL`

Testes:
- Atualiza os testes de unidade/integração, a configuração do Jest e os scripts de lint para usar `VITE_API_BASE_URL` em vez de `NEXT_PUBLIC_API_BASE_URL`

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Migrate the API base environment variable from NEXT_PUBLIC_API_BASE_URL to VITE_API_BASE_URL across the project to align with Vite conventions

Enhancements:
- Update React hook, env assertion script, and dashboard_app to use VITE_API_BASE_URL instead of NEXT_PUBLIC_API_BASE_URL

Build:
- Adjust Dockerfile ARG/ENV and docker-compose configurations to use VITE_API_BASE_URL

Documentation:
- Revise documentation and README files to reference VITE_API_BASE_URL

Tests:
- Update unit/integration tests, Jest setup, and lint scripts to use VITE_API_BASE_URL instead of NEXT_PUBLIC_API_BASE_URL

</details>