### PR TITLE
feat: forward filters to ticket loader

### DIFF
--- a/dashboard_app.py
+++ b/dashboard_app.py
@@ -59,7 +59,8 @@ def load_data(ticket_range: str = "0-99", **filters: str) -> list[dict[str, Any]
             raise
 
     url = f"{WORKER_BASE_URL}/v1/tickets"
-    params = {"range": ticket_range, **filters}
+    filtered_filters = {k: v for k, v in filters.items() if v is not None}
+    params = {"range": ticket_range, **filtered_filters}
     logging.info("Fetching ticket data from %s with params %s", url, params)
     try:
         resp = requests.get(url, params=params, timeout=30)

--- a/dashboard_app.py
+++ b/dashboard_app.py
@@ -38,7 +38,16 @@ def _fetch_aggregated_metrics() -> dict[str, Any]:
 
 
 def load_data(ticket_range: str = "0-99", **filters: str) -> list[dict[str, Any]]:
-    """Load ticket data from the worker or a local mock file."""
+    """Load ticket data from the worker or a local mock file.
+
+    Parameters
+    ----------
+    ticket_range:
+        Inclusive range of ticket IDs to fetch in the format ``"start-end"``.
+    **filters:
+        Additional filter parameters forwarded to the worker API, such as
+        ``status`` or ``technician``.
+    """
 
     if USE_MOCK_DATA:
         logging.info("Loading ticket data from mock file")
@@ -50,9 +59,10 @@ def load_data(ticket_range: str = "0-99", **filters: str) -> list[dict[str, Any]
             raise
 
     url = f"{WORKER_BASE_URL}/v1/tickets"
-    logging.info("Fetching ticket data from %s", url)
+    params = {"range": ticket_range, **filters}
+    logging.info("Fetching ticket data from %s with params %s", url, params)
     try:
-        resp = requests.get(url, timeout=30)
+        resp = requests.get(url, params=params, timeout=30)
         resp.raise_for_status()
         return resp.json()
     except requests.RequestException as exc:

--- a/src/frontend/callbacks/callbacks.py
+++ b/src/frontend/callbacks/callbacks.py
@@ -8,11 +8,6 @@ from dash import Dash, Input, Output, callback
 from frontend.components.components import _status_fig, compute_ticket_stats
 
 
-def _get_filtered(df: pd.DataFrame, status: str | None) -> pd.DataFrame:
-    """Return dataframe optionally filtered by status."""
-    return df[df["status"] == status.lower()] if status else df
-
-
 def register_callbacks(
     app: Dash,
     loader: Callable[..., List[Dict[str, Any]]],
@@ -59,20 +54,19 @@ def register_callbacks(
         store: Optional[Dict[str, Any]], status: Optional[str]
     ) -> tuple[List[Dict[str, Any]], Dict[str, Any]]:
         rng: str = store.get("ticket_range", ticket_range) if store else ticket_range
-        data = loader(rng, **filters)
+        data = loader(rng, status=status, **filters)
         df: pd.DataFrame = pd.DataFrame(data)
-        filtered: pd.DataFrame = _get_filtered(df, status)
         fig: Dict[str, Any] = {
             "data": [
                 {
                     "type": "scattergl",
                     "mode": "markers",
-                    "x": filtered["date_creation"],
-                    "y": filtered["id"],
+                    "x": df["date_creation"],
+                    "y": df["id"],
                 }
             ]
         }
-        return list(filtered.to_dict("records")), fig  # type: ignore
+        return list(df.to_dict("records")), fig  # type: ignore
 
     @callback(
         Output("notification-container", "children"),

--- a/src/frontend/callbacks/callbacks.py
+++ b/src/frontend/callbacks/callbacks.py
@@ -54,7 +54,7 @@ def register_callbacks(
         store: Optional[Dict[str, Any]], status: Optional[str]
     ) -> tuple[List[Dict[str, Any]], Dict[str, Any]]:
         rng: str = store.get("ticket_range", ticket_range) if store else ticket_range
-        data = loader(rng, status=status, **filters)
+        data = loader(rng, **({**filters, "status": status} if status else filters))
         df: pd.DataFrame = pd.DataFrame(data)
         fig: Dict[str, Any] = {
             "data": [


### PR DESCRIPTION
## Summary
- send ticket_range and arbitrary filters as query params to worker API
- forward status selections from Dash callbacks to the loader

## Testing
- `pre-commit run --files dashboard_app.py src/frontend/callbacks/callbacks.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'libcst')*

------
https://chatgpt.com/codex/tasks/task_e_688d9757d3e083208547fb037b8e2853

## Resumo por Sourcery

Encaminha `ticket_range` e parâmetros de filtro arbitrários de callbacks do Dash para o carregador de tickets do backend como parâmetros de consulta, e remove a filtragem local no frontend para depender da filtragem no lado do servidor.

Novas Funcionalidades:
- Envia `ticket_range` e quaisquer filtros adicionais (ex: status) como parâmetros de consulta HTTP para a API do worker.
- Encaminha as seleções de status de callbacks do Dash para a chamada do carregador de tickets.

Melhorias:
- Expande a docstring e o log de `load_data` para documentar e exibir os parâmetros de consulta encaminhados.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Forward ticket_range and arbitrary filter parameters from Dash callbacks to the backend ticket loader as query parameters, and remove local filtering in the frontend to rely on server-side filtering.

New Features:
- Send ticket_range and any additional filters (e.g., status) as HTTP query parameters to the worker API.
- Forward status selections from Dash callbacks into the ticket loader call.

Enhancements:
- Expand load_data docstring and logging to document and display the forwarded query parameters.

</details>