### PR TITLE
feat: expose ticket group

### DIFF
--- a/src/backend/schemas/ticket_models.py
+++ b/src/backend/schemas/ticket_models.py
@@ -101,7 +101,7 @@ class CleanTicketDTO(BaseModel):
     created_at: Optional[datetime] = Field(default=None, alias="date_creation")
     assigned_to: str = "Unassigned"
     requester: Optional[str] = None
-    group: Optional[str] = None
+    group: str | None = None
 
     model_config = ConfigDict(populate_by_name=True, extra="allow")
 

--- a/src/frontend/react_app/src/hooks/useTickets.ts
+++ b/src/frontend/react_app/src/hooks/useTickets.ts
@@ -14,6 +14,7 @@ function toTicket(dto: CleanTicketDTO): Ticket {
     priority: dto.priority != null ? String(dto.priority) : undefined,
     name: dto.name ?? "",
     requester: dto.requester ?? undefined,
+    group: dto.group ?? undefined,
     // Prefer `undefined` over `null` when the API omits the field
     date_creation:
       dto.date_creation != null ? new Date(dto.date_creation) : undefined,

--- a/src/frontend/react_app/src/types/api.ts
+++ b/src/frontend/react_app/src/types/api.ts
@@ -1,8 +1,8 @@
 /* tslint:disable */
 /* eslint-disable */
 /**
-/* This file was automatically generated from pydantic models by running pydantic2ts.
-/* Do not modify it by hand - just update the pydantic models and then re-run the script
+/* This file was automatically generated from Pydantic models by running pydantic2ts.
+/* Do not modify it by hand - just update the Pydantic models and then re-run the script
 */
 
 /**

--- a/src/frontend/react_app/src/types/ticket.ts
+++ b/src/frontend/react_app/src/types/ticket.ts
@@ -5,6 +5,7 @@ export interface Ticket {
   name: string
   status?: string
   requester?: string
+  group?: string
   priority?: string
   urgency?: Urgency
   impact?: Impact

--- a/src/frontend/react_app/tests/hooks/useTickets.test.tsx
+++ b/src/frontend/react_app/tests/hooks/useTickets.test.tsx
@@ -11,7 +11,7 @@ const wrapper = ({ children }: { children: React.ReactNode }) => (
 test('fetches tickets from API', async () => {
   global.fetch = jest.fn().mockResolvedValue({
     status: 200,
-    json: () => Promise.resolve([{ id: 1, name: 't1' }]),
+    json: () => Promise.resolve([{ id: 1, name: 't1', group: 'N1' }]),
   }) as jest.Mock
 
   const { result } = renderHook(() => useTickets(DEFAULT_FILTERS), { wrapper })
@@ -20,6 +20,7 @@ test('fetches tickets from API', async () => {
   expect(result.current.isSuccess).toBe(true)
   expect(result.current.tickets).toHaveLength(1)
   expect(result.current.tickets?.[0].name).toBe('t1')
+  expect(result.current.tickets?.[0].group).toBe('N1')
 })
 
 test('handles API error', async () => {

--- a/tests/test_clean_ticket_dto.py
+++ b/tests/test_clean_ticket_dto.py
@@ -14,6 +14,7 @@ def test_clean_ticket_dto_valid_creation():
         "date_creation": "2024-01-01T12:00:00",
         "assigned_to": "Alice",
         "requester": "Alice",
+        "group": "N1",
         "users_id_requester": 7,
     }
 
@@ -25,6 +26,7 @@ def test_clean_ticket_dto_valid_creation():
     assert ticket.priority == "Low"
     assert ticket.assigned_to == "Alice"
     assert ticket.requester == "Alice"
+    assert ticket.group == "N1"
 
 
 @pytest.mark.unit
@@ -83,6 +85,7 @@ def test_clean_ticket_dto_missing_optional_fields():
     assert ticket.priority is None
     assert ticket.created_at is None
     assert ticket.requester is None
+    assert ticket.group is None
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
- add group field to CleanTicketDTO and propagate to frontend types
- cover group in hook and DTO tests

## Testing
- `npm run generate-types` *(fails: No module named 'opentelemetry')*
- `pytest tests/test_clean_ticket_dto.py tests/test_data_pipeline.py tests/test_worker_api.py -k test_rest_endpoints` *(fails: ModuleNotFoundError: No module named 'opentelemetry')*
- `npm test tests/hooks/useTickets.test.tsx` *(fails: SyntaxError: Cannot use 'import.meta' outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_688d9757ae608320ad86e5090f8d89ef