### PR TITLE
refactor: use select for metrics

### DIFF
--- a/src/frontend/react_app/src/features/tickets/__tests__/api.test.tsx
+++ b/src/frontend/react_app/src/features/tickets/__tests__/api.test.tsx
@@ -1,0 +1,40 @@
+import { renderHook } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { useTicketMetrics } from '../api'
+import { useApiQuery } from '../../../hooks/useApiQuery'
+
+jest.mock('../../../hooks/useApiQuery')
+
+const createWrapper = () => {
+  const queryClient = new QueryClient()
+  return {
+    wrapper: ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+  }
+}
+
+test('validates response structure with select', () => {
+  const valid = { status: { open: 1 }, per_user: { alice: 2 } }
+  let opts: any
+  ;(useApiQuery as jest.Mock).mockImplementation(
+    (_key: unknown, _endpoint: string, options: any) => {
+      opts = options
+      return { data: valid, isLoading: false, isError: false, error: null }
+    }
+  )
+  const { wrapper } = createWrapper()
+  const { result } = renderHook(() => useTicketMetrics(), { wrapper })
+  expect(result.current.data).toEqual(valid)
+  const select = opts.select as (data: unknown) => unknown
+  expect(select(valid)).toEqual(valid)
+  expect(() => select({ status: { open: 'x' }, per_user: {} })).toThrow(
+    'Invalid response structure for MetricsOverview'
+  )
+  expect(() => select({ status: {}, per_user: 'y' })).toThrow(
+    'Invalid response structure for MetricsOverview'
+  )
+  expect(() => select({})).toThrow(
+    'Invalid response structure for MetricsOverview'
+  )
+})

--- a/src/frontend/react_app/src/features/tickets/api.ts
+++ b/src/frontend/react_app/src/features/tickets/api.ts
@@ -6,18 +6,23 @@ export function useTicketMetrics() {
     ['ticket-metrics'],
     '/v1/metrics/aggregated',
     {
-      transformResponse: (data: unknown): MetricsOverview => {
+      select: (data: any): MetricsOverview => {
         if (
+          data &&
           typeof data === 'object' &&
-          data !== null &&
-          'metric1' in data &&
-          'metric2' in data
+          'status' in data &&
+          typeof data.status === 'object' &&
+          data.status !== null &&
+          Object.values(data.status).every((v) => typeof v === 'number') &&
+          'per_user' in data &&
+          typeof data.per_user === 'object' &&
+          data.per_user !== null &&
+          Object.values(data.per_user).every((v) => typeof v === 'number')
         ) {
           return data as MetricsOverview;
-        } else {
-          throw new Error('Invalid response structure for MetricsOverview');
         }
-      }
+        throw new Error('Invalid response structure for MetricsOverview');
+      },
     }
   );
 }

--- a/src/frontend/react_app/src/types/metricsOverview.ts
+++ b/src/frontend/react_app/src/types/metricsOverview.ts
@@ -1,8 +1,4 @@
-export interface LevelMetrics {
-  open: number
-  closed: number
-}
-
 export interface MetricsOverview {
-  [level: string]: LevelMetrics
+  status: Record<string, number>
+  per_user: Record<string, number>
 }


### PR DESCRIPTION
## Summary
- validate ticket metrics with react-query `select`
- align `MetricsOverview` type with backend structure
- cover ticket metrics hook with tests

## Testing
- `npx jest src/features/tickets/__tests__/api.test.tsx` *(fails: SyntaxError: Cannot use 'import.meta' outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_688d97594fb083208a8320cc96712c15