### PR TITLE
docs: update metrics levels endpoint references

### DIFF
--- a/src/frontend/app.py
+++ b/src/frontend/app.py
@@ -1,8 +1,8 @@
 """Dash application for displaying GLPI ticket status summaries.
 
 This script defines a minimal Dash app that retrieves ticket metrics
-from a FastAPI backend using the ``/v1/metrics/aggregated`` and
-``/v1/metrics/levels`` endpoints. The data is presented as a series of
+from a FastAPI backend using the ``/v1/metrics/aggregated`` endpoint and
+the worker API's ``/metrics/levels`` endpoint. The data is presented as a series of
 cards. It is designed to be self-contained for demonstration purposes.
 In a full project this code would integrate into the existing Dash
 application infrastructure.
@@ -24,12 +24,15 @@ logger = logging.getLogger(__name__)
 def fetch_levels(base_url: str) -> Dict[str, Dict[str, int]]:
     """Fetch ticket counts grouped by support level."""
 
-    endpoint = f"{base_url}/v1/metrics/levels"
+    endpoint = f"{base_url}/metrics/levels"
     try:
         response = requests.get(endpoint, timeout=30)
         response.raise_for_status()
         return response.json()
-    except (requests.exceptions.RequestException, ValueError):  # pragma: no cover - network errors
+    except (
+        requests.exceptions.RequestException,
+        ValueError,
+    ):  # pragma: no cover - network errors
         logger.exception("Failed to fetch level metrics from %s", endpoint)
         return {}
 
@@ -42,7 +45,10 @@ def fetch_aggregated(base_url: str) -> Dict[str, int]:
         response = requests.get(endpoint, timeout=30)
         response.raise_for_status()
         return response.json()
-    except (requests.exceptions.RequestException, ValueError):  # pragma: no cover - network errors
+    except (
+        requests.exceptions.RequestException,
+        ValueError,
+    ):  # pragma: no cover - network errors
         logger.exception("Failed to fetch aggregated metrics from %s", endpoint)
         return {}
 
@@ -73,9 +79,10 @@ def build_app(base_url: str = "http://localhost:8000") -> Dash:
     """Create and configure the Dash application."""
 
     level_data = fetch_levels(base_url)
-    # TODO: Fetching aggregated metrics is included to keep this example aligned with the
-    # production frontend. The result is not currently used or displayed.
-    # Remove this call if aggregated metrics are not needed in the future, or implement their use here.
+    # TODO: Fetch aggregated metrics to keep this example aligned with
+    # the production frontend. The result is not currently used or displayed.
+    # Remove this call if aggregated metrics are not needed in the future,
+    # or implement their use here.
     _ = fetch_aggregated(base_url)
 
     app = Dash(__name__, external_stylesheets=[dbc.themes.BOOTSTRAP])

--- a/src/frontend/react_app/src/hooks/useMetricsLevels.ts
+++ b/src/frontend/react_app/src/hooks/useMetricsLevels.ts
@@ -14,7 +14,7 @@ interface ApiLevelMetrics {
 export function useMetricsLevels() {
   const query = useApiQuery<Record<string, ApiLevelMetrics>>(
     ['metrics-levels'],
-    '/v1/metrics/levels',
+    '/metrics/levels',
     { refetchInterval: 60000 },
   )
 


### PR DESCRIPTION
## Summary
- fix examples to reference worker API metrics levels endpoint
- update React hook for metrics levels to new endpoint

## Testing
- `pytest` *(fails: No module named 'dash_bootstrap_components')*
- `npm test` *(fails: SyntaxError: Cannot use 'import.meta' outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_688d7c5d2d748320b8eebb5dedce67ab