### PR TITLE
Add per-level metrics endpoint

### DIFF
--- a/tests/test_metrics_api.py
+++ b/tests/test_metrics_api.py
@@ -169,3 +169,30 @@ def test_levels_error(monkeypatch, test_client):
     monkeypatch.setattr(metrics_module, "_fetch_dataframe", fail)
     resp = client.get("/v1/metrics/levels")
     assert resp.status_code == 500
+
+
+def test_level_specific_endpoint(test_client, monkeypatch):
+    client, api_client, cache, metrics_module = test_client
+    monkeypatch.setattr(
+        pd.Timestamp,
+        "utcnow",
+        lambda: pd.Timestamp("2024-06-15", tz="UTC"),
+    )
+
+    resp = client.get("/v1/metrics/levels/N1")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["open_tickets"] == {"N1": 1}
+    assert data["tickets_closed_this_month"] == {"N1": 1}
+    assert data["status_distribution"] == {"new": 1, "closed": 1}
+
+    # call again should hit cache
+    resp = client.get("/v1/metrics/levels/N1")
+    assert resp.status_code == 200
+    assert api_client.calls == 1
+
+
+def test_level_invalid(test_client):
+    client, *_ = test_client
+    resp = client.get("/v1/metrics/levels/N5")
+    assert resp.status_code == 400


### PR DESCRIPTION
## Summary
- support caching metrics per support level
- expose `/metrics/levels/{level}` endpoint and related computation
- test per-level metrics endpoint behavior

## Testing
- `pytest tests/test_metrics_api.py::test_level_specific_endpoint -q -o addopts=""` *(fails: KeyboardInterrupt after ~23s)*

------
https://chatgpt.com/codex/tasks/task_e_688da32054fc8320971a357157a1e47f

## Resumo por Sourcery

Introduzir métricas de tickets por nível implementando `compute_level_metrics`, atualizando a chave de cache agregada, expondo um endpoint de métricas dedicado e cobrindo a nova funcionalidade com testes

Novas Funcionalidades:
- Adicionar a função `compute_level_metrics` para calcular e armazenar em cache métricas para um único nível de suporte
- Expor o endpoint `GET /metrics/levels/{level}` com validação para níveis de suporte conhecidos

Melhorias:
- Renomear a chave de cache para métricas de nível agregado para `metrics:levels:all`

Testes:
- Adicionar testes para verificar o comportamento do endpoint de métricas por nível, o cache e o tratamento de erros para níveis inválidos

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce per-level ticket metrics by implementing compute_level_metrics, updating the aggregate cache key, exposing a dedicated metrics endpoint, and covering the new functionality with tests

New Features:
- Add compute_level_metrics function to calculate and cache metrics for a single support level
- Expose GET /metrics/levels/{level} endpoint with validation for known support levels

Enhancements:
- Rename cache key for aggregate level metrics to metrics:levels:all

Tests:
- Add tests to verify per-level metrics endpoint behavior, caching, and error handling for invalid levels

</details>