### PR TITLE
feat: expose GLPI group constants and map level labels

### DIFF
--- a/app/api/metrics.py
+++ b/app/api/metrics.py
@@ -52,9 +52,7 @@ async def _fetch_dataframe(client: Optional[GlpiApiClient]) -> pd.DataFrame:
 
     data = [t.model_dump() for t in tickets]
     df = process_raw(data)
-    original = df["group"].astype(str)
-    numeric = pd.to_numeric(original, errors="coerce")
-    df["group"] = numeric.map(GROUP_LABELS_BY_ID).fillna(original).fillna("UNKNOWN")
+    df["group"] = map_group_ids_to_labels(df["group"])
     return df
 
 

--- a/src/backend/application/aggregated_metrics.py
+++ b/src/backend/application/aggregated_metrics.py
@@ -57,12 +57,7 @@ def status_by_group(df: pd.DataFrame) -> Dict[str, Dict[str, int]]:
         return {}
 
     filtered_df = df[["group", "status"]].copy()
-    filtered_df["group"] = (
-        pd.to_numeric(filtered_df["group"], errors="coerce")
-        .map(GROUP_LABELS_BY_ID)
-        .fillna(filtered_df["group"].astype(str))
-        .fillna("UNKNOWN")
-    )
+    filtered_df["group"] = map_group_ids_to_labels(filtered_df["group"])
     # ``status`` may be a ``Categorical`` column. Converting to ``object``
     # ensures ``fillna`` does not fail when the placeholder value is not part
     # of the categories.

--- a/src/backend/application/aggregated_metrics.py
+++ b/src/backend/application/aggregated_metrics.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, Optional
 import pandas as pd
 
 from backend.adapters.normalization import aggregate_by_user
+from backend.constants import GROUP_LABELS_BY_ID
 from shared.utils.redis_client import RedisClient, redis_client
 
 
@@ -56,6 +57,12 @@ def status_by_group(df: pd.DataFrame) -> Dict[str, Dict[str, int]]:
         return {}
 
     filtered_df = df[["group", "status"]].copy()
+    filtered_df["group"] = (
+        pd.to_numeric(filtered_df["group"], errors="coerce")
+        .map(GROUP_LABELS_BY_ID)
+        .fillna(filtered_df["group"].astype(str))
+        .fillna("UNKNOWN")
+    )
     # ``status`` may be a ``Categorical`` column. Converting to ``object``
     # ensures ``fillna`` does not fail when the placeholder value is not part
     # of the categories.

--- a/src/backend/constants.py
+++ b/src/backend/constants.py
@@ -1,0 +1,18 @@
+"""Shared constants for backend modules."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+# Mapping of service level names to GLPI group IDs
+GROUP_IDS: Dict[str, int] = {
+    "N1": 89,
+    "N2": 90,
+    "N3": 91,
+    "N4": 92,
+}
+
+# Reverse mapping of GLPI group ID to service level label
+GROUP_LABELS_BY_ID: Dict[int, str] = {gid: level for level, gid in GROUP_IDS.items()}
+
+__all__ = ["GROUP_IDS", "GROUP_LABELS_BY_ID"]

--- a/src/backend/services/glpi.py
+++ b/src/backend/services/glpi.py
@@ -31,6 +31,8 @@ from typing import Any, Dict
 
 import requests
 
+from backend.constants import GROUP_IDS
+
 logger = logging.getLogger(__name__)
 
 # Load configuration from environment once at import time. This avoids
@@ -39,17 +41,6 @@ logger = logging.getLogger(__name__)
 GLPI_BASE_URL: str = os.getenv("GLPI_BASE_URL", "").rstrip("/")
 GLPI_APP_TOKEN: str = os.getenv("GLPI_APP_TOKEN", "")
 GLPI_SESSION_TOKEN: str = os.getenv("GLPI_SESSION_TOKEN", "")
-
-# Mapping of human friendly service level names to GLPI group IDs. These
-# group IDs correspond to the different levels of support (N1–N4). If
-# the project grows to support additional levels the dictionary can be
-# extended without modifying the service logic.
-GROUP_IDS: Dict[str, int] = {
-    "N1": 89,
-    "N2": 90,
-    "N3": 91,
-    "N4": 92,
-}
 
 
 def _build_headers() -> Dict[str, str]:


### PR DESCRIPTION
## Summary
- centralize GLPI group constants in `backend.constants`
- translate numeric group IDs to N1–N4 labels with fallback
- reuse shared constants across services and metrics worker

## Testing
- `pytest` *(fails: 53 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_688daddb31588320a03de0f2d1a2e701

## Resumo por Sourcery

Centralizar e expor constantes de ID de grupo GLPI em todos os módulos de backend, e traduzir IDs de grupo numéricos para rótulos N1–N4 amigáveis ao usuário com suporte de fallback em rotinas de métricas e agregação.

Novas Funcionalidades:
- Adicionar constantes compartilhadas GROUP_IDS e GROUP_LABELS_BY_ID para mapeamentos de grupo GLPI
- Mapear IDs de grupo GLPI numéricos para rótulos N1–N4 com fallback no processamento de métricas

Melhorias:
- Centralizar constantes de grupo GLPI em backend.constants e remover definições duplicadas
- Substituir conjunto de níveis conhecidos codificados (hardcoded) por valores dinâmicos de constantes compartilhadas

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Centralize and expose GLPI group ID constants across backend modules, and translate numeric group IDs to human-friendly N1–N4 labels with fallback support in metrics and aggregation routines.

New Features:
- Add shared GROUP_IDS and GROUP_LABELS_BY_ID constants for GLPI group mappings
- Map numeric GLPI group IDs to N1–N4 labels with fallback in metrics processing

Enhancements:
- Centralize GLPI group constants in backend.constants and remove duplicate definitions
- Replace hardcoded known levels set with dynamic values from shared constants

</details>