### PR TITLE
feat(metrics): handle closed status

### DIFF
--- a/src/backend/application/aggregated_metrics.py
+++ b/src/backend/application/aggregated_metrics.py
@@ -39,7 +39,7 @@ def compute_aggregated(df: pd.DataFrame) -> Dict[str, Any]:
 
 
 def status_by_group(df: pd.DataFrame) -> Dict[str, Dict[str, int]]:
-    """Return counts of ``new``, ``pending`` and ``solved`` tickets per group.
+    """Return counts of ``new``, ``pending`` and ``closed`` tickets per group.
 
     Parameters
     ----------
@@ -62,7 +62,10 @@ def status_by_group(df: pd.DataFrame) -> Dict[str, Dict[str, int]]:
     filtered_df["status"] = (
         filtered_df["status"].astype("object").fillna("").astype(str).str.lower()
     )
-    filtered_df = filtered_df[filtered_df["status"].isin(["new", "pending", "solved"])]
+    filtered_df["status"] = filtered_df["status"].replace({"solved": "closed"})
+    filtered_df = filtered_df[
+        filtered_df["status"].isin(["new", "pending", "solved", "closed"])
+    ]
 
     grouped = (
         filtered_df.groupby(["group", "status"], observed=True)
@@ -70,11 +73,11 @@ def status_by_group(df: pd.DataFrame) -> Dict[str, Dict[str, int]]:
         .unstack(fill_value=0)
     )
 
-    for col in ["new", "pending", "solved"]:
+    for col in ["new", "pending", "closed"]:
         if col not in grouped.columns:
             grouped[col] = 0
 
-    grouped = grouped[["new", "pending", "solved"]]
+    grouped = grouped[["new", "pending", "closed"]]
     grouped = grouped.astype(int)
     return grouped.to_dict(orient="index")
 

--- a/src/backend/application/aggregated_metrics.py
+++ b/src/backend/application/aggregated_metrics.py
@@ -64,7 +64,7 @@ def status_by_group(df: pd.DataFrame) -> Dict[str, Dict[str, int]]:
     )
     filtered_df["status"] = filtered_df["status"].replace({"solved": "closed"})
     filtered_df = filtered_df[
-        filtered_df["status"].isin(["new", "pending", "solved", "closed"])
+        filtered_df["status"].isin(["new", "pending", "closed"])
     ]
 
     grouped = (

--- a/tests/test_aggregated_metrics.py
+++ b/tests/test_aggregated_metrics.py
@@ -75,13 +75,14 @@ def test_status_by_group_counts():
             {"group": "N1", "status": "pending"},
             {"group": "N1", "status": "pending"},
             {"group": "N2", "status": "solved"},
+            {"group": "N2", "status": "closed"},
         ]
     )
 
     result = status_by_group(df)
     assert result == {
-        "N1": {"new": 1, "pending": 2, "solved": 0},
-        "N2": {"new": 0, "pending": 0, "solved": 1},
+        "N1": {"new": 1, "pending": 2, "closed": 0},
+        "N2": {"new": 0, "pending": 0, "closed": 2},
     }
 
 
@@ -97,6 +98,6 @@ def test_status_by_group_with_categorical():
     df["status"] = df["status"].astype("category")
     result = status_by_group(df)
     assert result == {
-        "N1": {"new": 1, "pending": 0, "solved": 0},
-        "N2": {"new": 0, "pending": 1, "solved": 0},
+        "N1": {"new": 1, "pending": 0, "closed": 0},
+        "N2": {"new": 0, "pending": 1, "closed": 0},
     }


### PR DESCRIPTION
## Summary
- handle tickets marked closed alongside solved
- adjust metrics tests for closed status mapping

## Testing
- `pytest tests/test_aggregated_metrics.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688dadaedc48832084ff0aa74bfff338

## Resumo por Sourcery

Adicionar suporte para o status de ticket 'closed' em métricas agregadas, remapeando 'solved' para 'closed' e atualizando as contagens de status

Novas Funcionalidades:
- Normalizar os status 'solved' para 'closed' em status_by_group
- Incluir tickets 'closed' na agregação status_by_group

Testes:
- Atualizar testes para esperar contagens de 'closed' e cobrir cenários de status 'closed'

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for 'closed' ticket status in aggregated metrics by remapping 'solved' to 'closed' and updating status counts

New Features:
- Normalize 'solved' statuses to 'closed' in status_by_group
- Include 'closed' tickets in the status_by_group aggregation

Tests:
- Update tests to expect 'closed' counts and cover closed status scenarios

</details>