### PR TITLE
docs: clarify worker endpoints and add tests

### DIFF
--- a/docs/developer_usage.md
+++ b/docs/developer_usage.md
@@ -76,7 +76,8 @@ Endpoints relevantes:
 
 - `/v1/tickets` – lista completa de chamados
  - A resposta inclui os campos `priority` e `requester` em formato textual.
-- `/v1/metrics/summary` – contagem de abertos/fechados
+- `/v1/tickets/stream` – stream de progresso (SSE) seguido do JSON final
+- `/v1/metrics/summary` – contagem rápida de `total`, `abertos` e `fechados`
 - `/v1/graphql/` – versão GraphQL
 - `/v1/cache/stats` – estatísticas de cache
 

--- a/docs/developer_usage.md
+++ b/docs/developer_usage.md
@@ -76,7 +76,8 @@ Endpoints relevantes:
 
 - `/v1/tickets` – lista completa de chamados
  - A resposta inclui os campos `priority` e `requester` em formato textual.
-- `/v1/tickets/stream` – stream de progresso (SSE) seguido do JSON final
+- `/v1/tickets/stream` – fluxo `text/event-stream` emitindo eventos `progress` e o
+  evento final `tickets` com a lista em JSON
 - `/v1/metrics/summary` – contagem rápida de `total`, `abertos` e `fechados`
 - `/v1/graphql/` – versão GraphQL
 - `/v1/cache/stats` – estatísticas de cache

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -121,13 +121,14 @@ The worker also streams progress using `/v1/tickets/stream`:
 ```ts
 const url = `${import.meta.env.VITE_API_BASE_URL}/v1/tickets/stream`;
 const es = new EventSource(url);
-es.onmessage = (ev) => console.log('chunk', ev.data);
+es.addEventListener('progress', (ev) => console.log('chunk', ev.data));
+es.addEventListener('tickets', (ev) => console.log(JSON.parse(ev.data)));
 ```
 
-Each message is plain text. Progress lines like ``fetching...`` and
-``processing...`` precede the final JSON payload containing all tickets. A
-frontend can append these lines to a log or display a spinner until the last
-event is received.
+Each message follows the SSE format (`event:`/`data:`). Progress notifications
+with the `progress` event precede the final `tickets` event containing the JSON
+array of tickets. A frontend can append these lines to a log or display a
+spinner until the final event is received.
 
 For aggregated statistics the worker offers `/v1/metrics/aggregated`. This endpoint
 returns cached counts grouped by status and technician, enabling dashboards to

--- a/docs/frontend_architecture.md
+++ b/docs/frontend_architecture.md
@@ -113,6 +113,9 @@ const resp = await fetch(`${import.meta.env.VITE_API_BASE_URL}/v1/metrics/summar
 const data = await resp.json();
 ```
 
+Use this endpoint to populate KPI cards such as total chamados or items
+abertos/fechados without downloading the full ticket list.
+
 The worker also streams progress using `/v1/tickets/stream`:
 
 ```ts
@@ -120,6 +123,11 @@ const url = `${import.meta.env.VITE_API_BASE_URL}/v1/tickets/stream`;
 const es = new EventSource(url);
 es.onmessage = (ev) => console.log('chunk', ev.data);
 ```
+
+Each message is plain text. Progress lines like ``fetching...`` and
+``processing...`` precede the final JSON payload containing all tickets. A
+frontend can append these lines to a log or display a spinner until the last
+event is received.
 
 For aggregated statistics the worker offers `/v1/metrics/aggregated`. This endpoint
 returns cached counts grouped by status and technician, enabling dashboards to

--- a/src/backend/api/worker_api.py
+++ b/src/backend/api/worker_api.py
@@ -182,6 +182,12 @@ def create_app(client: Optional[GlpiApiClient] = None, cache=None) -> FastAPI:
 
     @router.get("/tickets/stream")
     async def tickets_stream(response: Response) -> StreamingResponse:  # noqa: F401
+        """Stream progress lines followed by the final ticket list.
+
+        Front-end clients can attach an ``EventSource`` to this endpoint to
+        display loading progress in real time. The stream emits plain-text
+        status updates and ends with a JSON array of tickets.
+        """
         return StreamingResponse(
             stream_tickets(client, cache=cache, response=response),
             media_type="text/plain",
@@ -190,6 +196,11 @@ def create_app(client: Optional[GlpiApiClient] = None, cache=None) -> FastAPI:
 
     @router.get("/metrics/summary")
     async def metrics_summary(response: Response) -> dict:  # noqa: F401
+        """Return total, opened and closed ticket counts.
+
+        Use this lightweight endpoint to populate KPI cards without fetching
+        the full ticket dataset.
+        """
         df = await load_tickets(client=client, cache=cache, response=response)
         return calculate_dataframe_metrics(df)
 

--- a/src/backend/schemas/metrics.py
+++ b/src/backend/schemas/metrics.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class MetricsSummary(BaseModel):
+    """Ticket counts used for lightweight KPI cards."""
+
+    total: int
+    opened: int
+    closed: int

--- a/tests/integration/test_worker_api_endpoints.py
+++ b/tests/integration/test_worker_api_endpoints.py
@@ -1,0 +1,90 @@
+import pytest
+from fastapi.testclient import TestClient
+
+import backend.application.aggregated_metrics as aggregated_metrics
+from backend.application.glpi_api_client import GlpiApiClient
+from backend.schemas.ticket_models import CleanTicketDTO
+from src.backend.api import worker_api as worker_module
+from src.backend.api.worker_api import create_app, get_glpi_client
+
+
+class DummyCache:
+    def __init__(self):
+        self.data = {}
+
+    async def get(self, key):
+        return self.data.get(key)
+
+    async def set(self, key, value, ttl_seconds=None):
+        self.data[key] = value
+
+    def get_cache_metrics(self) -> dict[str, float]:
+        return {"hits": 0, "misses": 0, "total": 0, "hit_rate": 0.0}
+
+
+class FakeClient(GlpiApiClient):
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    async def fetch_tickets(self, *args, **kwargs):
+        raw = [
+            {
+                "id": 1,
+                "name": "A",
+                "status": 5,
+                "priority": 3,
+                "date_creation": "2024-06-01T00:00:00",
+                "assigned_to": "",
+                "group": "N1",
+                "requester": "Alice",
+                "users_id_requester": 10,
+            },
+            {
+                "id": 2,
+                "name": "B",
+                "status": 6,
+                "priority": 2,
+                "date_creation": "2024-06-02T00:00:00",
+                "assigned_to": "",
+                "group": "N2",
+                "requester": "Bob",
+                "users_id_requester": 11,
+            },
+        ]
+        return [CleanTicketDTO.model_validate(r) for r in raw]
+
+
+@pytest.fixture
+def test_client(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(
+        aggregated_metrics,
+        "map_group_ids_to_labels",
+        lambda series: series,
+        raising=False,
+    )
+
+    async def fake_stream(_client, cache=None, response=None):
+        yield b"fetching...\n"
+        yield b"done\n"
+
+    monkeypatch.setattr(worker_module, "stream_tickets", fake_stream)
+    cache = DummyCache()
+    app = create_app(client=FakeClient(), cache=cache)
+    app.dependency_overrides[get_glpi_client] = FakeClient
+    return TestClient(app)
+
+
+def test_metrics_summary_endpoint(test_client: TestClient):
+    resp = test_client.get("/v1/metrics/summary")
+    assert resp.status_code == 200
+    assert resp.json() == {"total": 2, "opened": 0, "closed": 2}
+
+
+def test_tickets_stream_endpoint(test_client: TestClient):
+    resp = test_client.get("/v1/tickets/stream")
+    assert resp.status_code == 200
+    lines = resp.text.splitlines()
+    assert lines == ["fetching...", "done"]


### PR DESCRIPTION
## Summary
- document `/v1/tickets/stream` and `/v1/metrics/summary` for frontend usage
- explain worker metrics and ticket-stream endpoints in backend API
- add integration tests covering worker endpoints

## Testing
- `pytest tests/integration/test_worker_api_endpoints.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688db1565b088320a55800ec643d9b29

## Resumo por Sourcery

Esclarece e documenta os endpoints da API do worker para resumo de métricas e streaming de tickets, adiciona docstrings detalhados e introduz testes de integração para ambos os endpoints

Melhorias:
- Adiciona docstrings aos endpoints FastAPI `/v1/metrics/summary` e `/v1/tickets/stream` para explicar a semântica de streaming e os payloads

Documentação:
- Esclarece o uso de `/v1/metrics/summary` e `/v1/tickets/stream` com exemplos na documentação de frontend e do desenvolvedor

Testes:
- Adiciona testes de integração para os endpoints `/v1/metrics/summary` e `/v1/tickets/stream` usando um FakeClient e DummyCache

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clarify and document worker API endpoints for metrics summary and ticket streaming, add detailed docstrings, and introduce integration tests for both endpoints

Enhancements:
- Add docstrings to FastAPI `/v1/metrics/summary` and `/v1/tickets/stream` endpoints to explain streaming semantics and payloads

Documentation:
- Clarify usage of `/v1/metrics/summary` and `/v1/tickets/stream` with examples in frontend and developer documentation

Tests:
- Add integration tests for `/v1/metrics/summary` and `/v1/tickets/stream` endpoints using a FakeClient and DummyCache

</details>