### PR TITLE
Include date_resolved normalization

### DIFF
--- a/src/backend/infrastructure/glpi/__init__.py
+++ b/src/backend/infrastructure/glpi/__init__.py
@@ -2,7 +2,7 @@
 
 import contextlib
 
-with contextlib.suppress(Exception):
+with contextlib.suppress(ImportError):
     from .glpi_client import (
         GLPIClientAuthError,
         GLPIClientError,

--- a/src/backend/infrastructure/glpi/__init__.py
+++ b/src/backend/infrastructure/glpi/__init__.py
@@ -1,16 +1,19 @@
 """Public interface for GLPI infrastructure helpers."""
 
-from .glpi_client import (
-    GLPIClientAuthError,
-    GLPIClientError,
-    GLPIClientNotFound,
-    GLPIClientRateLimit,
-    GLPIClientServerError,
-    GLPISessionManager,
-    SearchCriteriaBuilder,
-    get_secret,
-)
-from .glpi_session import GLPISession
+import contextlib
+
+with contextlib.suppress(Exception):
+    from .glpi_client import (
+        GLPIClientAuthError,
+        GLPIClientError,
+        GLPIClientNotFound,
+        GLPIClientRateLimit,
+        GLPIClientServerError,
+        GLPISessionManager,
+        SearchCriteriaBuilder,
+        get_secret,
+    )
+    from .glpi_session import GLPISession
 
 __all__ = [
     "GLPISessionManager",

--- a/src/backend/infrastructure/glpi/normalization.py
+++ b/src/backend/infrastructure/glpi/normalization.py
@@ -22,6 +22,7 @@ REQUIRED_FIELDS = [
     "requester",
     "date_creation",
     "priority",
+    "date_resolved",
 ]
 
 # Map alternate/underscore-prefixed field names returned by the GLPI API to the
@@ -37,6 +38,7 @@ FIELD_ALIASES = {
     "date": "date_creation",
     "_status": "status",
     "_priority": "priority",
+    "solvedate": "date_resolved",
 }
 
 
@@ -98,6 +100,10 @@ def process_raw(data: TicketData) -> pd.DataFrame:
     df["date_creation"] = pd.to_datetime(
         df.get("date_creation", pd.Series([pd.NaT] * len(df), index=idx))
     )
+    df["date_resolved"] = pd.to_datetime(
+        df.get("date_resolved", pd.Series([pd.NaT] * len(df), index=idx)),
+        utc=True,
+    )
     assigned_to = _normalize_assigned_field(df, "assigned_to", idx)
     df["assigned_to"] = (
         assigned_to.replace({"<NA>": "", "nan": "", "None": ""})  # type: ignore
@@ -120,6 +126,7 @@ def process_raw(data: TicketData) -> pd.DataFrame:
             "requester",
             "group",
             "date_creation",
+            "date_resolved",
         ]
     ].copy()
 

--- a/src/backend/infrastructure/glpi/normalization.py
+++ b/src/backend/infrastructure/glpi/normalization.py
@@ -98,7 +98,8 @@ def process_raw(data: TicketData) -> pd.DataFrame:
         .astype(str)  # type: ignore
     ).astype("category")  # type: ignore
     df["date_creation"] = pd.to_datetime(
-        df.get("date_creation", pd.Series([pd.NaT] * len(df), index=idx))
+        df.get("date_creation", pd.Series([pd.NaT] * len(df), index=idx)),
+        utc=True,
     )
     df["date_resolved"] = pd.to_datetime(
         df.get("date_resolved", pd.Series([pd.NaT] * len(df), index=idx)),

--- a/tests/test_data_pipeline.py
+++ b/tests/test_data_pipeline.py
@@ -15,7 +15,7 @@ def test_process_raw_sanitization():
     ]
     df = process_raw(raw)
 
-    assert df.shape == (3, 8)
+    assert df.shape == (3, 9)
     assert df.columns.tolist() == [
         "id",
         "name",
@@ -25,6 +25,7 @@ def test_process_raw_sanitization():
         "requester",
         "group",
         "date_creation",
+        "date_resolved",
     ]
 
     assert df["id"].tolist() == [1, 0, 0]
@@ -35,6 +36,7 @@ def test_process_raw_sanitization():
     assert df["group"].tolist() == ["", "", ""]
     assert df["priority"].isna().all()
     assert df["date_creation"].isna().all()
+    assert df["date_resolved"].isna().all()
 
 
 def test_process_raw_aliases():
@@ -48,6 +50,7 @@ def test_process_raw_aliases():
             "_users_id_requester": 9,
             "groups_name": "N1",
             "creation_date": "2024-05-01",
+            "solvedate": "2024-05-02",
         }
     ]
     df = process_raw(raw)
@@ -61,6 +64,7 @@ def test_process_raw_aliases():
         "requester",
         "group",
         "date_creation",
+        "date_resolved",
     }
     assert required_columns.issubset(df.columns)
     assert "priority" in df.columns
@@ -72,6 +76,8 @@ def test_process_raw_aliases():
     assert df.iloc[0]["group"] == "N1"
     assert df.iloc[0]["id"] == 1
     assert df.iloc[0]["date_creation"].strftime("%Y-%m-%d") == "2024-05-01"
+    assert df.iloc[0]["date_resolved"].strftime("%Y-%m-%d") == "2024-05-02"
+    assert str(df.dtypes["date_resolved"]) == "datetime64[ns, UTC]"
 
 
 def test_process_raw_to_dataframe_dtypes():
@@ -111,6 +117,9 @@ def test_process_raw_memory_usage_reduced():
     baseline_df = pd.DataFrame(raw)
     baseline_df["name"] = ""
     baseline_df["date_creation"] = pd.NaT
+    baseline_df["priority"] = pd.NA
+    baseline_df["requester"] = ""
+    baseline_df["date_resolved"] = pd.NaT
     baseline = baseline_df.memory_usage(deep=True).sum()
 
     optimized = process_raw(raw).memory_usage(deep=True).sum()


### PR DESCRIPTION
## Summary
- normalize GLPI tickets with `date_resolved` in UTC
- map `solvedate` to `date_resolved` and add to required fields
- relax GLPI infrastructure imports to avoid optional dependency errors
- extend data pipeline tests for new column

## Testing
- `pre-commit run --files src/backend/infrastructure/glpi/normalization.py tests/test_data_pipeline.py src/backend/infrastructure/glpi/__init__.py`
- `pytest tests/test_data_pipeline.py`


------
https://chatgpt.com/codex/tasks/task_e_688db75d3f0483208ae43173e4036d3d

## Resumo por Sourcery

Inclui `date_resolved` no pipeline de normalização de tickets GLPI, mapeando o campo `solvedate`, analisando-o em UTC, relaxando importações de dependências opcionais e atualizando os testes para cobrir a nova coluna

Novas Funcionalidades:
- Normaliza e inclui `date_resolved` na saída do ticket GLPI

Melhorias:
- Mapeia o campo `solvedate` da API GLPI para `date_resolved` e o analisa em UTC
- Suprime erros de importação no módulo de infraestrutura GLPI para evitar problemas de dependência opcional

Testes:
- Estende os testes do pipeline de dados para esperar a nova coluna `date_resolved`, seu `dtype` UTC, formato do DataFrame (`shape`) e uso de memória

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Include date_resolved in the GLPI ticket normalization pipeline by mapping the solvedate field, parsing it in UTC, relaxing optional dependency imports, and updating tests to cover the new column

New Features:
- Normalize and include date_resolved in the GLPI ticket output

Enhancements:
- Map the GLPI API field solvedate to date_resolved and parse it in UTC
- Suppress import errors in the GLPI infrastructure module to avoid optional dependency issues

Tests:
- Extend data pipeline tests to expect the new date_resolved column, its UTC dtype, DataFrame shape, and memory usage

</details>