### PR TITLE
test: cover glpi timeout and levels endpoint

### DIFF
--- a/app/api/metrics.py
+++ b/app/api/metrics.py
@@ -8,6 +8,7 @@ to keep the responses fast even when the dataset is large.
 from __future__ import annotations
 
 import logging
+from enum import Enum
 from typing import Any, Awaitable, Callable, Dict, Optional
 
 import pandas as pd
@@ -18,7 +19,7 @@ from backend.application.glpi_api_client import (
     GlpiApiClient,
     create_glpi_api_client,
 )
-from backend.constants import GROUP_IDS, GROUP_LABELS_BY_ID
+from backend.constants import GROUP_LABELS_BY_ID
 from backend.infrastructure.glpi.normalization import process_raw
 from shared.utils.redis_client import RedisClient, redis_client
 
@@ -54,6 +55,12 @@ async def _fetch_dataframe(client: Optional[GlpiApiClient]) -> pd.DataFrame:
     df = process_raw(data)
     df["group"] = map_group_ids_to_labels(df["group"])
     return df
+
+
+def map_group_ids_to_labels(series: pd.Series) -> pd.Series:
+    """Map numerical group IDs to their human-readable labels."""
+
+    return series.map(GROUP_LABELS_BY_ID).fillna(series)
 
 
 async def get_or_set_cache(
@@ -209,7 +216,7 @@ async def compute_level_metrics(
         if "group" not in df.columns:
             raise HTTPException(
                 status_code=500,
-                detail="Data error: 'group' column missing from ticket data"
+                detail="Data error: 'group' column missing from ticket data",
             )
         df = df[df["group"] == level]
 
@@ -247,21 +254,24 @@ async def compute_level_metrics(
     return result
 
 
-KNOWN_LEVELS = set(GROUP_IDS.keys())
+class SupportLevel(str, Enum):
+    """Known support levels exposed by the API."""
+
+    N1 = "N1"
+    N2 = "N2"
+    N3 = "N3"
+    N4 = "N4"
 
 
 @router.get("/metrics/levels/{level}", response_model=MetricsOverview)
-async def metrics_level(level: str) -> MetricsOverview:
+async def metrics_level(level: SupportLevel) -> MetricsOverview:
     """Return ticket metrics for a specific support level."""
 
-    level_norm = level.upper()
-    if level_norm not in KNOWN_LEVELS:
-        raise HTTPException(status_code=400, detail="Unknown level")
-
+    level_value = level.value
     try:
-        return await compute_level_metrics(level_norm)
+        return await compute_level_metrics(level_value)
     except Exception as exc:  # pragma: no cover - defensive
-        logger.exception("Error computing metrics for level %s", level_norm)
+        logger.exception("Error computing metrics for level %s", level_value)
         raise HTTPException(
             status_code=500, detail="Failed to compute metrics"
         ) from exc

--- a/app/api/metrics.py
+++ b/app/api/metrics.py
@@ -77,7 +77,7 @@ async def _fetch_dataframe(client: Optional[GlpiApiClient]) -> pd.DataFrame:
 def map_group_ids_to_labels(series: pd.Series) -> pd.Series:
     """Map numerical group IDs to their human-readable labels."""
 
-    return series.map(GROUP_LABELS_BY_ID).fillna(series)
+    return pd.to_numeric(series, errors="coerce").map(GROUP_LABELS_BY_ID).fillna(series)
 
 
 async def get_or_set_cache(

--- a/tests/test_metrics_api.py
+++ b/tests/test_metrics_api.py
@@ -182,10 +182,10 @@ async def test_level_specific_endpoint(test_client, monkeypatch):
 
     resp = client.get("/v1/metrics/levels/N1")
     assert resp.status_code == 200
-    data = resp.json()
-    assert data["open_tickets"] == {"N1": 1}
-    assert data["tickets_closed_this_month"] == {"N1": 1}
-    assert data["status_distribution"] == {"new": 1, "closed": 1}
+    model = metrics_module.MetricsOverview.model_validate(resp.json())
+    assert model.open_tickets == {"N1": 1}
+    assert model.tickets_closed_this_month == {"N1": 1}
+    assert model.status_distribution == {"new": 1, "closed": 1}
 
     # call again should hit cache
     resp = client.get("/v1/metrics/levels/N1")
@@ -196,4 +196,4 @@ async def test_level_specific_endpoint(test_client, monkeypatch):
 def test_level_invalid(test_client):
     client, *_ = test_client
     resp = client.get("/v1/metrics/levels/N5")
-    assert resp.status_code == 400
+    assert resp.status_code == 422


### PR DESCRIPTION
## Summary
- handle support level enum in metrics endpoint
- test GLPI timeout fallback in service layer
- verify /metrics/levels/{level} responses and validation

## Testing
- `pytest tests/test_glpi_service.py tests/test_metrics_api.py -q`


------
https://chatgpt.com/codex/tasks/task_e_688dba9a5c84832083ed0bf7a11cab73

## Resumo por Sourcery

Aprimorar a API de métricas introduzindo um `enum` para níveis de suporte e mapeamento de rótulos, adicionar um fallback para tratamento de timeout no serviço GLPI e atualizar os testes para cobrir essas melhorias e impor a validação do modelo de resposta.

Novas Funcionalidades:
- Adicionar o `enum SupportLevel` para validar e gerenciar níveis de suporte no endpoint de métricas
- Implementar `map_group_ids_to_labels` para traduzir IDs de grupo em rótulos legíveis por humanos

Correções de Bugs:
- Adicionar fallback para retornar contagens de tickets vazias quando as requisições da API GLPI atingem o tempo limite

Melhorias:
- Refatorar o endpoint de nível de métricas para usar validação baseada em `enum` e otimizar o tratamento de erros
- Atualizar testes para usar validação de modelo Pydantic para respostas de métricas

Testes:
- Adicionar teste para o fallback de timeout do GLPI na camada de serviço
- Ajustar teste de endpoint de nível inválido para esperar o código de status 422

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhance metrics API by introducing an enum for support levels and label mapping, add timeout handling fallback in GLPI service, and update tests to cover these improvements and enforce response model validation

New Features:
- Add SupportLevel enum to validate and handle support levels in the metrics endpoint
- Implement map_group_ids_to_labels to translate group IDs into human-readable labels

Bug Fixes:
- Add fallback to return empty ticket counts when GLPI API requests timeout

Enhancements:
- Refactor metrics level endpoint to use enum-based validation and streamline error handling
- Update tests to use Pydantic model validation for metrics responses

Tests:
- Add test for GLPI timeout fallback in service layer
- Adjust invalid level endpoint test to expect 422 status code

</details>