### PR TITLE
feat: add group status summary helper

### DIFF
--- a/tests/test_glpi_api_client.py
+++ b/tests/test_glpi_api_client.py
@@ -1,3 +1,4 @@
+from typing import Dict
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -5,6 +6,8 @@ import pytest
 from backend.application.glpi_api_client import (
     GlpiApiClient,
 )
+from backend.constants import GROUP_IDS
+from backend.schemas.ticket_models import TEXT_STATUS_MAP
 
 
 @pytest.mark.asyncio
@@ -12,6 +15,10 @@ async def test_populate_forced_fields(monkeypatch):
     session = MagicMock()
     monkeypatch.setattr(
         "backend.application.glpi_api_client.MappingService",
+        lambda *a, **k: MagicMock(),
+    )
+    monkeypatch.setattr(
+        "backend.application.glpi_api_client.TicketTranslator",
         lambda *a, **k: MagicMock(),
     )
     session.list_search_options = AsyncMock(
@@ -48,6 +55,10 @@ async def test_resolve_ticket_fields(monkeypatch):
     monkeypatch.setattr(
         "backend.application.glpi_api_client.MappingService", lambda *a, **k: mapper
     )
+    monkeypatch.setattr(
+        "backend.application.glpi_api_client.TicketTranslator",
+        lambda *a, **k: MagicMock(),
+    )
 
     client = GlpiApiClient(session=session)
     client._forced_fields = []
@@ -82,7 +93,8 @@ async def test_get_all_paginated_maps_fields(monkeypatch):
         lambda *a, **k: MagicMock(initialize=AsyncMock()),
     )
     monkeypatch.setattr(
-        "backend.application.glpi_api_client.TicketTranslator", MagicMock
+        "backend.application.glpi_api_client.TicketTranslator",
+        lambda *a, **k: MagicMock(),
     )
 
     client = GlpiApiClient(session=session)
@@ -96,3 +108,80 @@ async def test_get_all_paginated_maps_fields(monkeypatch):
         {"id": 2, "name": "b"},
         {"id": 3, "name": "c"},
     ]
+
+
+@pytest.mark.asyncio
+async def test_get_ticket_summary_by_group(monkeypatch):
+    session = MagicMock()
+    monkeypatch.setattr(
+        "backend.application.glpi_api_client.MappingService",
+        lambda *a, **k: MagicMock(),
+    )
+    monkeypatch.setattr(
+        "backend.application.glpi_api_client.TicketTranslator",
+        lambda *a, **k: MagicMock(),
+    )
+
+    fake_data: Dict[str, list[dict]] = {
+        "89": [
+            {"status": {"name": "New"}},
+            {"status": {"name": "New"}},
+            {"status": {"name": "Processing (assigned)"}},
+        ],
+        "90": [
+            {"status": {"name": "Solved"}},
+            {"status": {"name": "Solved"}},
+            {"status": {"name": "New"}},
+        ],
+        "91": [],
+        "92": [
+            {"status": {"name": "Pending"}},
+        ],
+    }
+
+    async def fake_get_all_paginated(itemtype, *, criteria=None, **_):
+        group_id = criteria[0]["value"]
+        return fake_data[group_id]
+
+    client = GlpiApiClient(session=session)
+    monkeypatch.setattr(
+        client,
+        "get_all_paginated",
+        AsyncMock(side_effect=fake_get_all_paginated),
+    )
+
+    summary = await client.get_ticket_summary_by_group()
+
+    assert summary["N1"]["new"] == 2
+    assert summary["N1"]["processing (assigned)"] == 1
+    assert summary["N2"]["solved"] == 2
+    assert summary["N2"]["new"] == 1
+    assert summary["N3"] == {status: 0 for status in TEXT_STATUS_MAP.keys()}
+    assert summary["N4"]["pending"] == 1
+
+
+@pytest.mark.asyncio
+async def test_get_ticket_summary_by_group_network_error(monkeypatch):
+    session = MagicMock()
+    monkeypatch.setattr(
+        "backend.application.glpi_api_client.MappingService",
+        lambda *a, **k: MagicMock(),
+    )
+    monkeypatch.setattr(
+        "backend.application.glpi_api_client.TicketTranslator",
+        lambda *a, **k: MagicMock(),
+    )
+
+    client = GlpiApiClient(session=session)
+    monkeypatch.setattr(
+        client,
+        "get_all_paginated",
+        AsyncMock(side_effect=Exception("boom")),
+    )
+
+    summary = await client.get_ticket_summary_by_group()
+
+    expected = {
+        level: {status: 0 for status in TEXT_STATUS_MAP.keys()} for level in GROUP_IDS
+    }
+    assert summary == expected


### PR DESCRIPTION
## Summary
- aggregate ticket status counts for predefined GLPI groups
- cover happy-path and network-error scenarios in tests

## Testing
- `pytest tests/test_glpi_api_client.py -q --override-ini=addopts="" -p no:cov`


------
https://chatgpt.com/codex/tasks/task_e_688dc893acbc8320bcc790297ee80ff8

## Resumo por Sourcery

Adiciona um novo método auxiliar em `GlpiApiClient` para buscar e contar status de tickets por grupo de suporte predefinido, lidando com cenários de sucesso e erro, e adiciona testes unitários correspondentes para fluxos normais e com erro de rede. Também refatora o método auxiliar de contagem de status existente para um log mais limpo e simplificar o tratamento de tipos.

Novos Recursos:
- Adiciona `GlpiApiClient.get_ticket_summary_by_group` para agregar contagens de status de tickets por grupo de suporte

Melhorias:
- Simplifica o registro de erros (logging) e remove anotações de tipo redundantes em `get_status_counts_by_levels`

Testes:
- Adiciona testes unitários para `get_ticket_summary_by_group` cobrindo cenários de sucesso (`happy path`) e erro de rede
- Cria `stub` para `TicketTranslator` em testes existentes do cliente API para consistência

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a new helper method in GlpiApiClient to fetch and count ticket statuses per predefined support group, handling both successful and error scenarios, and add corresponding unit tests for normal and network-error flows. Also refactor existing status count helper for cleaner logging and simplify type handling.

New Features:
- Add GlpiApiClient.get_ticket_summary_by_group to aggregate ticket status counts by support group

Enhancements:
- Simplify error logging and remove redundant type annotations in get_status_counts_by_levels

Tests:
- Add unit tests for get_ticket_summary_by_group covering happy path and network-error scenarios
- Stub TicketTranslator in existing API client tests for consistency

</details>