### PR TITLE
Handle metrics cache misses

### DIFF
--- a/src/backend/application/aggregated_metrics.py
+++ b/src/backend/application/aggregated_metrics.py
@@ -12,7 +12,25 @@ from shared.utils.redis_client import RedisClient, redis_client
 
 
 def map_group_ids_to_labels(series: pd.Series) -> pd.Series:
-    """Map numeric group IDs to human-readable labels if available."""
+    """
+    Map numeric group IDs in a pandas Series to human-readable labels using GROUP_LABELS_BY_ID.
+
+    Parameters
+    ----------
+    series : pd.Series
+        Series containing group IDs (typically numeric).
+
+    Returns
+    -------
+    pd.Series
+        Series with group IDs replaced by their corresponding human-readable labels
+        from GROUP_LABELS_BY_ID. If a group ID is not found in the mapping,
+        the original value is retained.
+
+    Notes
+    -----
+    The mapping source is the GROUP_LABELS_BY_ID constant imported from backend.constants.
+    """
     return series.map(GROUP_LABELS_BY_ID).fillna(series)
 
 

--- a/src/backend/application/aggregated_metrics.py
+++ b/src/backend/application/aggregated_metrics.py
@@ -11,6 +11,11 @@ from backend.constants import GROUP_LABELS_BY_ID
 from shared.utils.redis_client import RedisClient, redis_client
 
 
+def map_group_ids_to_labels(series: pd.Series) -> pd.Series:
+    """Map numeric group IDs to human-readable labels if available."""
+    return series.map(GROUP_LABELS_BY_ID).fillna(series)
+
+
 def tickets_by_date(df: pd.DataFrame) -> pd.DataFrame:
     """Return ticket counts grouped by ``date_creation``."""
     if "date_creation" not in df.columns:
@@ -65,9 +70,7 @@ def status_by_group(df: pd.DataFrame) -> Dict[str, Dict[str, int]]:
         filtered_df["status"].astype("object").fillna("").astype(str).str.lower()
     )
     filtered_df["status"] = filtered_df["status"].replace({"solved": "closed"})
-    filtered_df = filtered_df[
-        filtered_df["status"].isin(["new", "pending", "closed"])
-    ]
+    filtered_df = filtered_df[filtered_df["status"].isin(["new", "pending", "closed"])]
 
     grouped = (
         filtered_df.groupby(["group", "status"], observed=True)


### PR DESCRIPTION
## Summary
- recompute aggregated and per-level metrics when cache is cold
- map group IDs to labels for metrics calculations
- expand worker API tests to cover cache-miss paths and context-managed clients

## Testing
- `pytest tests/test_worker_api.py::test_metrics_aggregated_cache_miss tests/test_worker_api.py::test_metrics_levels_cache_miss tests/test_worker_api.py::test_chamados_por_data_cache tests/test_worker_api.py::test_chamados_por_dia_cache`

------
https://chatgpt.com/codex/tasks/task_e_688dc897e11483208a46e427e7d71fd4

## Resumo por Sourcery

Habilita os endpoints de métricas a lidar com falhas de cache (cache misses) recalculando e armazenando em cache seus resultados, introduz o mapeamento de IDs de grupo numéricos para rótulos para cálculos de métricas e expande os testes da API do worker para cobrir cenários de cache-miss e clientes gerenciados por contexto.

Novas Funcionalidades:
- Recalcula e armazena em cache métricas agregadas em falhas de cache no endpoint /v1/metrics/aggregated
- Recalcula e armazena em cache métricas por nível em falhas de cache no endpoint /v1/metrics/levels
- Adiciona função para mapear IDs de grupo numéricos para rótulos legíveis por humanos para geração de métricas

Testes:
- Adiciona testes para caminhos de falha de cache de métricas agregadas e por nível
- Refatora os testes de cache `chamados_por_data` e `chamados_por_dia` para usar `TestClient` como um gerenciador de contexto e relaxar as asserções de estatísticas de cache

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable metrics endpoints to handle cache misses by recomputing and caching their results, introduce mapping of numeric group IDs to labels for metrics calculations, and expand worker API tests to cover cache-miss scenarios and context-managed clients.

New Features:
- Recompute and cache aggregated metrics on cache misses in /v1/metrics/aggregated endpoint
- Recompute and cache per-level metrics on cache misses in /v1/metrics/levels endpoint
- Add function to map numeric group IDs to human-readable labels for metrics generation

Tests:
- Add tests for aggregated and per-level metrics cache-miss paths
- Refactor chamados_por_data and chamados_por_dia cache tests to use TestClient as a context manager and relax cache stats assertions

</details>