### PR TITLE
Ensure API metrics include all support levels

### DIFF
--- a/tests/test_metrics_api.py
+++ b/tests/test_metrics_api.py
@@ -155,8 +155,10 @@ def test_levels_endpoint(test_client):
     resp = client.get("/v1/metrics/levels")
     assert resp.status_code == 200
     assert resp.json() == {
-        "N1": {"new": 1, "closed": 1},
-        "N2": {"pending": 1, "closed": 1},
+        "N1": {"closed": 1, "new": 1, "pending": 0},
+        "N2": {"closed": 1, "new": 0, "pending": 1},
+        "N3": {"closed": 0, "new": 0, "pending": 0},
+        "N4": {"closed": 0, "new": 0, "pending": 0},
     }
 
 


### PR DESCRIPTION
## Summary
- guarantee N1–N4 levels are always returned in `/metrics/levels`
- test that metrics endpoint returns missing levels with zeroed status counts

## Testing
- `pytest tests/test_metrics_api.py::test_levels_endpoint -c /tmp/pytest.ini` *(hangs >150s, interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_688dcdd431408320b82b3027cd242739

## Resumo por Sourcery

Garantir que o endpoint de níveis de métricas sempre inclua os níveis de suporte N1 a N4, inicializando quaisquer status ausentes com zero e atualizando os testes de acordo.

Correções de Bugs:
- Garantir que o endpoint de níveis de métricas retorne entradas para todos os níveis de suporte N1–N4 quando dados estiverem ausentes

Testes:
- Atualizar o teste do endpoint de níveis para esperar contagens zero para status ausentes e adicionar os níveis N3 e N4

Tarefas:
- Remover função `map_group_ids_to_labels` não utilizada

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure that the metrics levels endpoint always includes support levels N1 through N4 by initializing any missing statuses to zero and update tests accordingly

Bug Fixes:
- Ensure metrics levels endpoint returns entries for all support levels N1–N4 when data is missing

Tests:
- Update levels endpoint test to expect zero counts for missing statuses and add levels N3 and N4

Chores:
- Remove unused map_group_ids_to_labels function

</details>