### PR TITLE
Fetch level metrics via GLPI API with fallback

### DIFF
--- a/app/api/metrics.py
+++ b/app/api/metrics.py
@@ -178,7 +178,7 @@ async def compute_levels(
     try:
         result: Dict[str, Dict[str, int]] = await get_status_totals_by_levels(GROUP_IDS)
     except Exception:
-        logger.exception("failed to fetch status totals; falling back to DataFrame")
+        logger.exception("Failed to fetch status totals from GLPI API; falling back to DataFrame aggregation")
         df = await _fetch_dataframe(client)
         df["status"] = df["status"].astype(str).str.lower()
         grouped = (

--- a/app/api/metrics.py
+++ b/app/api/metrics.py
@@ -177,7 +177,8 @@ async def compute_levels(
         return cached
     try:
         result: Dict[str, Dict[str, int]] = await get_status_totals_by_levels(GROUP_IDS)
-    except Exception:
+    except (HTTPException, ConnectionError, socket.timeout) as exc:
+        # Catch expected network/API errors; let programming errors propagate
         logger.exception("Failed to fetch status totals from GLPI API; falling back to DataFrame aggregation")
         df = await _fetch_dataframe(client)
         df["status"] = df["status"].astype(str).str.lower()


### PR DESCRIPTION
## Summary
- use `get_status_totals_by_levels` to gather status totals per level
- cache level metrics under `metrics:levels:all`
- fall back to DataFrame aggregation if GLPI API call fails

## Testing
- `pytest` *(fails: No module named 'fastapi', 'pandas', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689059e3e4748320984e4efa0c4b317c

## Resumo por Sourcery

Use a API do GLPI para calcular totais de status por nível de suporte, com um fallback para agregação de DataFrame quando a chamada da API falhar e armazenar os resultados em cache.

Melhorias:
- Obtenha métricas de nível via `get_status_totals_by_levels` em vez de agrupamento local de DataFrame
- Adicione um bloco `try/except` para registrar erros e retornar à agregação de DataFrame em falhas de API
- Itere sobre as chaves `GROUP_IDS` para garantir que todos os níveis de suporte sejam incluídos dinamicamente

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Use the GLPI API to compute status totals by support level with a fallback to DataFrame aggregation when the API call fails and cache the results.

Enhancements:
- Fetch level metrics via get_status_totals_by_levels instead of local DataFrame grouping
- Add a try/except block to log errors and fall back to DataFrame aggregation on API failures
- Loop over GROUP_IDS keys to ensure all support levels are included dynamically

</details>