### PR TITLE
refactor: replace status metrics calc

### DIFF
--- a/tests/test_worker_api.py
+++ b/tests/test_worker_api.py
@@ -53,6 +53,17 @@ def dummy_cache() -> DummyCache:
     return DummyCache()
 
 
+@pytest.fixture(autouse=True)
+def patch_status_totals(monkeypatch):
+    async def fake_totals(levels):
+        return {level: {"new": 0, "pending": 0, "closed": 1} for level in levels}
+
+    monkeypatch.setattr(
+        "backend.application.glpi_api_client.get_status_totals_by_levels",
+        fake_totals,
+    )
+
+
 class FakeClient(GlpiApiClient):
     def __init__(self) -> None:
         """Fake client that conforms to the GlpiApiClient interface for tests."""
@@ -140,7 +151,7 @@ def test_metrics_levels_cache_miss(dummy_cache: DummyCache):
     data = resp.json()
     assert data["N1"]["closed"] == 1
     assert data["N2"]["closed"] == 1
-    assert dummy_cache.data["metrics_levels"] == data
+    assert dummy_cache.data["metrics:levels:all"] == data
 
 
 def test_chamados_por_data(dummy_cache: DummyCache):


### PR DESCRIPTION
## Summary
- replace status_by_group with get_status_totals_by_levels
- cache status metrics under metrics:levels:all
- update worker API and tests to use new metrics key

## Testing
- `pre-commit run --files src/backend/application/ticket_loader.py src/backend/application/metrics_worker.py src/backend/api/worker_api.py tests/test_worker_api.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_68905d2aea0c8320b4923679381e7acc

## Resumo pelo Sourcery

Refatorar o cálculo de métricas de status para usar `get_status_totals_by_levels` e padronizar o cache sob a nova chave `metrics:levels:all`, atualizando o endpoint da API, as rotinas do worker, o carregador de tickets e os testes, respectivamente.

Melhorias:
- Substituir a agregação `status_by_group` por `get_status_totals_by_levels` na API, no worker de métricas e no carregador de tickets
- Padronizar a chave de cache para métricas baseadas em nível para `metrics:levels:all` em todos os componentes

Testes:
- Adicionar fixture pytest para simular `get_status_totals_by_levels`
- Atualizar as asserções de teste para verificar dados sob a nova chave de cache `metrics:levels:all`

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor status metrics calculation to use get_status_totals_by_levels and standardize caching under the new key metrics:levels:all, updating the API endpoint, worker routines, ticket loader, and tests accordingly.

Enhancements:
- Replace status_by_group aggregation with get_status_totals_by_levels in the API, metrics worker, and ticket loader
- Standardize cache key for level-based metrics to metrics:levels:all across all components

Tests:
- Add pytest fixture to mock get_status_totals_by_levels
- Update test assertions to check data under the new cache key metrics:levels:all

</details>