### PR TITLE
feat(api): count statuses via client

### DIFF
--- a/app/api/metrics.py
+++ b/app/api/metrics.py
@@ -186,7 +186,7 @@ async def compute_levels(
         normalized: Dict[str, int] = {}
         for status, total in status_counts.items():
             key = str(status).lower()
-            if key in {"processing", "assigned", "planned"}:
+            if key in {"processing (assigned)", "processing (planned)"}:
                 key = "progress"
             elif key in {"solved", "closed"}:
                 key = "resolved"


### PR DESCRIPTION
## Summary
- compute level metrics via `count_status_by_group`
- expose `GlpiApiClient.count_status_by_group`

## Testing
- `python -m pytest` *(fails: 54 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_689060495a0c83208dabdbad128b0434

## Resumo por Sourcery

Use o método `count_status_by_group` baseado no cliente para calcular métricas de nível e simplificar a normalização de status

Novas Funcionalidades:
- Expor `GlpiApiClient.count_status_by_group` para buscar contagens de status por grupo

Melhorias:
- Refatorar `compute_levels` para usar o novo método do cliente em vez de agregação de DataFrame
- Normalizar chaves de status brutas em categorias 'progress' e 'resolved'
- Levantar um erro quando o cliente GLPI não estiver disponível

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Use the client-based count_status_by_group method to compute level metrics and simplify status normalization

New Features:
- Expose GlpiApiClient.count_status_by_group for fetching status counts per group

Enhancements:
- Refactor compute_levels to use the new client method instead of DataFrame aggregation
- Normalize raw status keys into 'progress' and 'resolved' categories
- Raise an error when the GLPI client is not available

</details>