### PR TITLE
refactor: align level metrics interface

### DIFF
--- a/src/frontend/react_app/src/hooks/useMetricsLevels.ts
+++ b/src/frontend/react_app/src/hooks/useMetricsLevels.ts
@@ -6,9 +6,9 @@ interface ApiLevelMetrics {
   new?: number
   pending?: number
   progress?: number
-  solved?: number
   resolved?: number
-  closed?: number
+  // Support legacy field names (e.g. "solved" or "closed") via index signature
+  [status: string]: number | undefined
 }
 
 export function useMetricsLevels() {
@@ -47,7 +47,7 @@ export function useMetricsLevels() {
           progress: metrics.progress ?? 0,
           pending: metrics.pending ?? 0,
           resolved:
-            metrics.resolved ?? metrics.solved ?? metrics.closed ?? 0,
+            metrics.resolved ?? metrics['solved'] ?? metrics['closed'] ?? 0,
         },
       }));
   }, [query.data])


### PR DESCRIPTION
## Summary
- align Level Metrics hook with backend field names
- support legacy metrics keys via index signature fallback

## Testing
- `pre-commit run --files src/frontend/react_app/src/hooks/useMetricsLevels.ts`
- `npm test tests/integration/health.test.ts` *(fails: Cannot use 'import.meta' outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_6890668e2e248320b41aad284846ca1d

## Resumo por Sourcery

Alinhar o hook de níveis de métricas com campos de backend atualizados e dar suporte a chaves de métricas legadas

Melhorias:
- Remover propriedades depreciadas explícitas de ApiLevelMetrics e adicionar um fallback de assinatura de índice para campos legados
- Atualizar a lógica de contagem de resolvidos para usar acesso dinâmico de propriedade para chaves legadas "solved" e "closed"

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align the metrics levels hook with updated backend fields and support legacy metric keys

Enhancements:
- Remove explicit deprecated properties from ApiLevelMetrics and add an index signature fallback for legacy fields
- Update resolved count logic to use dynamic property access for legacy "solved" and "closed" keys

</details>