### PR TITLE
feat: normalize ticket status labels

### DIFF
--- a/app/api/metrics.py
+++ b/app/api/metrics.py
@@ -19,7 +19,7 @@ from backend.application.glpi_api_client import (
     GlpiApiClient,
     create_glpi_api_client,
 )
-from backend.constants import GROUP_IDS, GROUP_LABELS_BY_ID
+from backend.constants import GROUP_IDS, GROUP_LABELS_BY_ID, STATUS_ALIAS
 from backend.infrastructure.glpi.normalization import process_raw
 from shared.utils.redis_client import RedisClient, redis_client
 
@@ -185,11 +185,7 @@ async def compute_levels(
     for level, status_counts in raw_counts.items():
         normalized: Dict[str, int] = {}
         for status, total in status_counts.items():
-            key = str(status).lower()
-            if key in {"processing (assigned)", "processing (planned)"}:
-                key = "progress"
-            elif key in {"solved", "closed"}:
-                key = "resolved"
+            key = STATUS_ALIAS.get(str(status).lower(), str(status).lower())
             normalized[key] = normalized.get(key, 0) + int(total)
         result[level] = normalized
 

--- a/src/backend/constants.py
+++ b/src/backend/constants.py
@@ -15,4 +15,12 @@ GROUP_IDS: Dict[str, int] = {
 # Reverse mapping of GLPI group ID to service level label
 GROUP_LABELS_BY_ID: Dict[int, str] = {gid: level for level, gid in GROUP_IDS.items()}
 
-__all__ = ["GROUP_IDS", "GROUP_LABELS_BY_ID"]
+# Mapping of verbose GLPI status labels to canonical dashboard labels
+STATUS_ALIAS: Dict[str, str] = {
+    "processing (assigned)": "progress",
+    "processing (planned)": "progress",
+    "solved": "resolved",
+    "closed": "resolved",
+}
+
+__all__ = ["GROUP_IDS", "GROUP_LABELS_BY_ID", "STATUS_ALIAS"]


### PR DESCRIPTION
## Summary
- map verbose GLPI status labels to canonical values
- normalize status counts before building metrics
- reuse alias mapping when computing per-level stats

## Testing
- `pytest` *(fails: 54 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6890668b00ec83209d06608c9c6754a3

## Resumo por Sourcery

Normalizar os rótulos de status de tickets do GLPI em toda a aplicação, introduzindo um mapeamento de alias compartilhado e aplicando-o tanto no cliente API quanto no cálculo de métricas.

Melhorias:
- Adicionar a constante `STATUS_ALIAS` para mapear rótulos de status verbosos do GLPI para rótulos canônicos de painel
- Refatorar `count_status_by_group` em `GlpiApiClient` para usar `STATUS_ALIAS` em vez de mapeamentos de status codificados
- Atualizar `metrics.compute_levels` para normalizar contagens de status brutas com o mapeamento `STATUS_ALIAS` compartilhado
- Remover lógica duplicada de normalização de status e centralizá-la em constantes

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Normalize GLPI ticket status labels across the application by introducing a shared alias mapping and applying it in both the API client and metrics computation.

Enhancements:
- Add STATUS_ALIAS constant to map verbose GLPI status labels to canonical dashboard labels
- Refactor count_status_by_group in GlpiApiClient to use STATUS_ALIAS instead of hardcoded status maps
- Update metrics.compute_levels to normalize raw status counts with the shared STATUS_ALIAS mapping
- Remove duplicated status normalization logic and centralize it in constants

</details>