### PR TITLE
feat(cache): add in-memory fallback for metrics

### DIFF
--- a/app/api/metrics.py
+++ b/app/api/metrics.py
@@ -20,6 +20,7 @@ from backend.application.glpi_api_client import (
     create_glpi_api_client,
 )
 from backend.constants import GROUP_IDS, GROUP_LABELS_BY_ID, STATUS_ALIAS
+from backend.core.settings import REDIS_TTL_SECONDS
 from backend.infrastructure.glpi.normalization import process_raw
 from shared.utils.redis_client import RedisClient, redis_client
 
@@ -99,7 +100,7 @@ async def get_or_set_cache(
 async def compute_aggregated(
     client: Optional[GlpiApiClient] = None,
     cache: Optional[RedisClient] = None,
-    ttl_seconds: int = 300,
+    ttl_seconds: int = REDIS_TTL_SECONDS,
 ) -> MetricsOverview:
     """Compute metrics and cache the result."""
     cache = cache or redis_client
@@ -142,6 +143,9 @@ async def compute_aggregated(
     result = await get_or_set_cache(
         cache, cache_key, MetricsOverview, compute_metrics, ttl_seconds
     )
+    remaining_ttl = await cache.get_ttl(cache_key)
+    logger.debug("TTL restante para %s: %s", cache_key, remaining_ttl)
+
     # Ensure the result is a MetricsOverview instance
     if not isinstance(result, MetricsOverview):
         raise RuntimeError("Cached value is not a MetricsOverview instance")


### PR DESCRIPTION
## Summary
- add in-memory cache fallback when Redis is unavailable
- expose TTL checks and logs on aggregated metrics

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_68906d1da1408320889e7f613abe81c6

## Resumo por Sourcery

Adicionar um fallback de cache em memória ao RedisClient para lidar com operações `get`/`set`/`delete`/`ttl` quando o Redis estiver indisponível, e aprimorar a API de métricas para usar a constante TTL compartilhada e registrar o TTL restante para métricas agregadas.

Novos Recursos:
- Implementar fallback de cache em memória com expiração por chave no RedisClient
- Expor recuperação de TTL e registrar o TTL restante para métricas agregadas

Melhorias:
- Usar a constante `REDIS_TTL_SECONDS` como TTL padrão em `compute_aggregated`

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add an in-memory cache fallback to the RedisClient to handle get/set/delete/ttl operations when Redis is unavailable, and enhance the metrics API to use the shared TTL constant and log remaining TTL for aggregated metrics.

New Features:
- Implement in-memory cache fallback with per-key expiration in RedisClient
- Expose TTL retrieval and log remaining TTL for aggregated metrics

Enhancements:
- Use REDIS_TTL_SECONDS constant as default TTL in compute_aggregated

</details>